### PR TITLE
add device link to online status

### DIFF
--- a/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
+++ b/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
@@ -882,7 +882,7 @@ export class GeekMagicPanel extends LitElement {
                         <div class="device-header">
                           <span class="device-name">${device.name}</span>
                           <span class="device-status ${device.online ? "online" : "offline"}">
-                            ${device.online ? "Online" : "Offline"}
+                            <a href="http://${device.host}" target="_blank">${device.online ? "Online" : "Offline"}</a>
                           </span>
                         </div>
                         <div class="views-checkboxes">


### PR DESCRIPTION
As I have to open the device IP regularly as HA shows it offline, even though it is not, I added a link to the device on the view-config page.