### PR TITLE
feat: add configurable JPEG quality to allow reduced refresh times, add display rotation

### DIFF
--- a/custom_components/geekmagic/const.py
+++ b/custom_components/geekmagic/const.py
@@ -9,12 +9,15 @@ DISPLAY_HEIGHT = 240
 # Default settings
 DEFAULT_REFRESH_INTERVAL = 10  # seconds
 DEFAULT_JPEG_QUALITY = 92  # High quality for crisp display
+DEFAULT_DISPLAY_ROTATION = 0  # No rotation
 MAX_IMAGE_SIZE = 400 * 1024  # 400KB max size for device uploads
 
 # Config keys
 CONF_HOST = "host"
 CONF_NAME = "name"
 CONF_REFRESH_INTERVAL = "refresh_interval"
+CONF_JPEG_QUALITY = "jpeg_quality"
+CONF_DISPLAY_ROTATION = "display_rotation"
 CONF_LAYOUT = "layout"
 CONF_WIDGETS = "widgets"
 

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -18,12 +18,16 @@ from .const import (
     COLOR_GRAY,
     COLOR_LIME,
     COLOR_WHITE,
+    CONF_DISPLAY_ROTATION,
+    CONF_JPEG_QUALITY,
     CONF_LAYOUT,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
     CONF_SCREEN_THEME,
     CONF_SCREENS,
     CONF_WIDGETS,
+    DEFAULT_DISPLAY_ROTATION,
+    DEFAULT_JPEG_QUALITY,
     DEFAULT_REFRESH_INTERVAL,
     DEFAULT_SCREEN_CYCLE_INTERVAL,
     DOMAIN,
@@ -671,8 +675,10 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             welcome_layout.render(self.renderer, draw, widget_states)
 
         # Encode to both formats
-        jpeg_data = self.renderer.to_jpeg(img)
-        png_data = self.renderer.to_png(img)
+        jpeg_quality = self.options.get(CONF_JPEG_QUALITY, DEFAULT_JPEG_QUALITY)
+        rotation = self.options.get(CONF_DISPLAY_ROTATION, DEFAULT_DISPLAY_ROTATION)
+        jpeg_data = self.renderer.to_jpeg(img, quality=jpeg_quality, rotation=rotation)
+        png_data = self.renderer.to_png(img, rotation=rotation)
 
         return jpeg_data, png_data
 

--- a/custom_components/geekmagic/renderer.py
+++ b/custom_components/geekmagic/renderer.py
@@ -992,6 +992,7 @@ class Renderer:
         img: Image.Image,
         quality: int = DEFAULT_JPEG_QUALITY,
         max_size: int | None = None,
+        rotation: int = 0,
     ) -> bytes:
         """Convert image to JPEG bytes with optional size cap.
 
@@ -999,6 +1000,7 @@ class Renderer:
             img: PIL Image
             quality: JPEG quality (0-100)
             max_size: Maximum size in bytes (reduces quality if exceeded)
+            rotation: Rotation in degrees (0, 90, 180, 270)
 
         Returns:
             JPEG image bytes
@@ -1010,6 +1012,10 @@ class Renderer:
 
         # Finalize (downscale) before export
         final_img = self.finalize(img)
+
+        # Apply rotation if specified
+        if rotation:
+            final_img = final_img.rotate(-rotation, expand=False)
 
         # Try at requested quality first
         buffer = BytesIO()
@@ -1026,17 +1032,23 @@ class Renderer:
 
         return result
 
-    def to_png(self, img: Image.Image) -> bytes:
+    def to_png(self, img: Image.Image, rotation: int = 0) -> bytes:
         """Convert image to PNG bytes.
 
         Args:
             img: PIL Image
+            rotation: Rotation in degrees (0, 90, 180, 270)
 
         Returns:
             PNG image bytes
         """
         # Finalize (downscale) before export
         final_img = self.finalize(img)
+
+        # Apply rotation if specified
+        if rotation:
+            final_img = final_img.rotate(-rotation, expand=False)
+
         buffer = BytesIO()
         final_img.save(buffer, format="PNG")
         return buffer.getvalue()


### PR DESCRIPTION
Hello, Great project. :) Been tinkering with this and have some additions.

I've been messing about with this to display a camera feed from Frigate above my monitor and it seems you can reliably get a 1-2 second refresh by slightly reducing the image quality.

Cleanup / Tidying

- Moved the refresh time to config, with the new options.

Following changes allow a 1-2s refresh.

- Added hass configuration option for pillow image compression for users who want a lower file size for faster refresh rates.
- Derestricted and 1s stepping on the minimum refresh rate option to allow a 1s refresh
- Quality 72 seems to be the sweet spot, Seeing a 19kb to 10kb reduction and stable 1-2s refresh times.

Display Rotation

- I've also added a hass configuration option to allow users to set pillow image rotate in 90* increments so you could mount this above a monitor and have it rotated tilted down.

<img width="487" height="433" alt="image" src="https://github.com/user-attachments/assets/3c6724e2-e408-4a85-8b49-5a5bf0ba5c9c" />
