### PR TITLE
fix: remove incompatible device_class from storage_used sensor

### DIFF
--- a/custom_components/geekmagic/entities/sensor.py
+++ b/custom_components/geekmagic/entities/sensor.py
@@ -84,7 +84,6 @@ class GeekMagicStorageUsedSensor(GeekMagicEntity, SensorEntity):
     _attr_name = "Storage Used"
     _attr_icon = "mdi:harddisk"
     _attr_native_unit_of_measurement = PERCENTAGE
-    _attr_device_class = SensorDeviceClass.DATA_SIZE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator: GeekMagicCoordinator) -> None:


### PR DESCRIPTION
The storage_used sensor reports percentage values, but the DATA_SIZE
device class only accepts data units (B, kB, MB, etc). Removing the
device_class fixes the Home Assistant warning about invalid units.

Fixes #28