### PR TITLE
fix: add hamburger menu button for mobile panel navigation

### DIFF
--- a/custom_components/geekmagic/frontend/dist/geekmagic-panel.js
+++ b/custom_components/geekmagic/frontend/dist/geekmagic-panel.js
@@ -765,6 +765,10 @@ let g = class extends I {
         </div>
       ` : d`
       <div class="header">
+        <ha-menu-button
+          .hass=${this.hass}
+          .narrow=${this.narrow}
+        ></ha-menu-button>
         <ha-icon icon="mdi:monitor-dashboard"></ha-icon>
         <span class="header-title">GeekMagic</span>
       </div>

--- a/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
+++ b/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
@@ -850,6 +850,10 @@ export class GeekMagicPanel extends LitElement {
 
     return html`
       <div class="header">
+        <ha-menu-button
+          .hass=${this.hass}
+          .narrow=${this.narrow}
+        ></ha-menu-button>
         <ha-icon icon="mdi:monitor-dashboard"></ha-icon>
         <span class="header-title">GeekMagic</span>
       </div>


### PR DESCRIPTION
Adds ha-menu-button to the panel header to allow mobile users to access
the Home Assistant sidebar. Previously, users on mobile were trapped in
the GeekMagic panel with no way to navigate back to the sidebar.

The menu button uses HA's standard pattern:
- Automatically shows only on narrow viewports or when sidebar is hidden
- Fires hass-toggle-menu event to open the sidebar drawer
- Shows notification badge when there are pending notifications

Fixes #22