### PR TITLE
fix: parse color options from JSON lists to tuples

### DIFF
--- a/custom_components/geekmagic/widgets/helpers.py
+++ b/custom_components/geekmagic/widgets/helpers.py
@@ -685,6 +685,36 @@ def resolve_widget_color(
     return default_color
 
 
+def parse_color(
+    value: object,
+    default: tuple[int, int, int],
+) -> tuple[int, int, int]:
+    """Parse color value from config, converting lists to tuples.
+
+    Handles colors from JSON (which come as lists) and ensures they are
+    valid RGB tuples that PIL can use.
+
+    Args:
+        value: Color value (tuple, list, or None). Can be any type -
+               invalid types will return the default.
+        default: Default color to use if value is invalid
+
+    Returns:
+        Valid RGB color tuple
+    """
+    if value is None:
+        return default
+    if isinstance(value, tuple) and len(value) == 3:
+        return value  # type: ignore[return-value]
+    if isinstance(value, list) and len(value) == 3:
+        try:
+            # Type checker doesn't know list contains int-convertible values
+            return (int(value[0]), int(value[1]), int(value[2]))  # type: ignore[arg-type]
+        except (ValueError, TypeError):
+            return default
+    return default
+
+
 def estimate_max_chars(
     available_width: int,
     char_width: int = 8,

--- a/custom_components/geekmagic/widgets/status.py
+++ b/custom_components/geekmagic/widgets/status.py
@@ -19,7 +19,7 @@ from .components import (
     Spacer,
     Text,
 )
-from .helpers import ON_STATES, estimate_max_chars, truncate_text
+from .helpers import ON_STATES, estimate_max_chars, parse_color, truncate_text
 
 if TYPE_CHECKING:
     from ..render_context import RenderContext
@@ -148,8 +148,8 @@ class StatusWidget(Widget):
     def __init__(self, config: WidgetConfig) -> None:
         """Initialize the status widget."""
         super().__init__(config)
-        self.on_color = config.options.get("on_color", COLOR_LIME)
-        self.off_color = config.options.get("off_color", COLOR_RED)
+        self.on_color = parse_color(config.options.get("on_color"), COLOR_LIME)
+        self.off_color = parse_color(config.options.get("off_color"), COLOR_RED)
         self.on_text = config.options.get("on_text", "ON")
         self.off_text = config.options.get("off_text", "OFF")
         self.icon = config.options.get("icon")
@@ -272,8 +272,8 @@ class StatusListWidget(Widget):
         """Initialize the status list widget."""
         super().__init__(config)
         self.entities = config.options.get("entities", [])
-        self.on_color = config.options.get("on_color", COLOR_LIME)
-        self.off_color = config.options.get("off_color", COLOR_RED)
+        self.on_color = parse_color(config.options.get("on_color"), COLOR_LIME)
+        self.off_color = parse_color(config.options.get("off_color"), COLOR_RED)
         self.on_text = config.options.get("on_text")
         self.off_text = config.options.get("off_text")
         self.title = config.options.get("title")


### PR DESCRIPTION
Fixes #48 where the Status widget causes "TypeError: color must be int
or tuple" when users customize state colors via the frontend panel.

The issue was that colors configured via Home Assistant's color picker
are stored as JSON arrays (e.g., [102, 166, 30]) but PIL requires tuples.
When reading colors from config.options, the default values are tuples
(from const.py), but user-configured colors come as lists.

Changes:
- Add parse_color() helper that converts lists to tuples
- Use parse_color() in StatusWidget and StatusListWidget __init__
- Add comprehensive tests for color parsing and rendering