### PR TITLE
docs: clarify that HTTPS and domain names are supported in config

### DIFF
--- a/custom_components/geekmagic/strings.json
+++ b/custom_components/geekmagic/strings.json
@@ -71,9 +71,9 @@
     "step": {
       "user": {
         "title": "Add GeekMagic Display",
-        "description": "Enter the IP address or URL of your GeekMagic device (e.g., 192.168.1.100 or http://192.168.1.100).",
+        "description": "Enter the IP address, hostname, or URL of your GeekMagic device. Examples: 192.168.1.100, geekmagic.local:8080. Prefix with https:// for secure connections.",
         "data": {
-          "host": "Host (IP address or URL)",
+          "host": "Host (IP, hostname, or URL)",
           "name": "Display name"
         }
       }


### PR DESCRIPTION
Update the config flow description and field label to show that the
integration accepts hostnames and HTTPS URLs, not just IP addresses.

Examples now include: IP address, .local hostname, and https:// URL.

Fixes #35

https://claude.ai/code/session_01PxhtX5Z1GSWZjRGQMsuynh