### PR TITLE
fix: add exponential backoff for offline device handling (#36)

### DIFF
--- a/custom_components/geekmagic/const.py
+++ b/custom_components/geekmagic/const.py
@@ -18,7 +18,7 @@ DEFAULT_JPEG_QUALITY = 92  # High quality for crisp display
 # Backoff settings for offline device handling
 # When device is unreachable, increase update interval exponentially
 # to reduce log spam and resource usage
-MAX_BACKOFF_MULTIPLIER = 18  # Max ~3 minutes between retries (10s * 18 = 180s)
+MAX_BACKOFF_MULTIPLIER = 16  # Max 160s (~2.7 min) between retries (10s * 2^4)
 BACKOFF_LOG_INTERVAL = 30  # Log summary every 30 failures (~5 min at max backoff)
 DEFAULT_DISPLAY_ROTATION = 0  # No rotation
 MAX_IMAGE_SIZE = 400 * 1024  # 400KB max size for device uploads


### PR DESCRIPTION
When a GeekMagic device goes offline (e.g., powered off via smart plug),
the coordinator was generating excessive log entries with full stack traces
every 10 seconds.

This fix implements:
- Exponential backoff: retry interval increases from 10s → 20s → 40s → ...
  up to ~3 minutes max, reducing retry frequency significantly
- Smart logging: first failure logs at warning level, subsequent failures
  log at debug level only, with periodic summary every ~5 minutes
- Skip rendering when offline: only do lightweight connectivity check
  instead of expensive image rendering
- Automatic recovery: when device comes back online, backoff resets and
  normal updates resume immediately

Fixes #36

https://claude.ai/code/session_01U6unQkMvZV4VuintfuHGck