### PR TITLE
[FEAT] Refresh with correct theme on Pro devices. Partially fixes #8

### DIFF
--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -223,6 +223,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
 
         # Device state (updated on refresh)
         self._device_state: DeviceState | None = None
+        self._device_info: DeviceInfo | None = None
         self._space_info: SpaceInfo | None = None
         self._device_brightness: int | None = None
         self._last_brightness_poll: float = 0  # Timestamp of last brightness poll
@@ -1018,6 +1019,11 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         return self._device_state
 
     @property
+    def device_info(self) -> DeviceInfo | None:
+        """Get current device info."""
+        return self._device_info
+
+    @property
     def device_brightness(self) -> int | None:
         """Get device brightness from /brt.json endpoint."""
         return self._device_brightness
@@ -1084,11 +1090,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("Switching from builtin to custom mode")
             self._display_mode = "custom"
 
-        # Ensure device is in custom image mode (theme=3 for Ultra, =4 for Pro)
-        theme_num = 3 # Default to Ultra
-        if "Pro" in self.device._device_info.model:
-            theme_num = 4
-        await self.device.set_theme(theme_num)
+        await self.device.set_theme_custom()
 
         self._update_preview = True  # Update preview on manual refresh
         await self.async_request_refresh()

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -131,7 +131,7 @@ class GeekMagicDevice:
                 info.model,
                 info.version
             )
-            return state
+            return info
 
     async def get_space(self) -> SpaceInfo:
         """Get device storage information.
@@ -196,6 +196,18 @@ class GeekMagicDevice:
             response.raise_for_status()
         _LOGGER.debug("Set theme to %d", theme)
 
+    async def set_theme_custom(self) -> None:
+        """Set device theme to the correct custom theme number. This varies between difference devices
+        
+        Ultra = 3
+        Pro = 4
+        """
+        theme_num = 3 # Default to Ultra
+        _device_info = await self.get_info()
+        if "pro" in _device_info.model.lower():
+            theme_num = 4
+        await self.set_theme(theme_num)
+
     async def set_image(self, filename: str) -> None:
         """Set the displayed image.
 
@@ -203,7 +215,7 @@ class GeekMagicDevice:
             filename: Image filename (without path)
         """
         # Ensure we're in custom image mode
-        await self.set_theme(3)
+        await self.set_theme_custom()
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?img=/image/{filename}") as response:
             response.raise_for_status()

--- a/custom_components/geekmagic/entities/base.py
+++ b/custom_components/geekmagic/entities/base.py
@@ -35,6 +35,6 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
             identifiers={(DOMAIN, self.coordinator.entry.entry_id)},
             name=self.coordinator.entry.title,
             manufacturer="GeekMagic",
-            #model="SmallTV Pro",
-            model=self.coordinator._device_info.model
+            model="SmallTV Ultra/Pro",
+            #model=self.coordinator.device_info.model
         )


### PR DESCRIPTION
**Current issue:** The existing code is hardcoded to use 3 as the theme number for Pictures. This is the correct theme for Ultra devices however Pro devices appear to use 4 for the Picture theme. 

**Change:** This PR adds a check of the device model number from `/v.json` and sets the custom theme number based on that string. The model string 'GeekMagic SmallTV-PRO' is detected from that file and a check of this is made searching for the substring 'Pro'. If found it will set the theme to 4, but will otherwise default to 3. 

This is tested on a Pro device and appears to work as expected.

**Known Issues:** I do not have an Ultra device to test this on, so I cannot confirm that I haven't broken anything on them. I do not know what the model string for an Ultra is in `/v.json`, I have just assumed that it does not contain 'Pro'. 

