### PR TITLE
fix: use correct custom theme number for Pro devices

### DIFF
--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -559,7 +559,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             if self._display_mode == "builtin":
                 _LOGGER.debug("Switching from builtin to custom mode for screen change")
                 self._display_mode = "custom"
-                await self.device.set_theme(3)
+                await self.device.set_theme_custom()
 
             await self.async_request_refresh()
 
@@ -1248,15 +1248,15 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         """Force an immediate display refresh.
 
         If we were in builtin mode, this switches back to custom mode
-        and ensures the device theme is set to 3 (custom image mode).
+        and ensures the device is in custom image mode.
         """
-        # If switching from builtin to custom, ensure device is in theme 3
+        # If switching from builtin to custom, ensure device is in custom image mode
         if self._display_mode == "builtin":
             _LOGGER.debug("Switching from builtin to custom mode")
             self._display_mode = "custom"
 
-        # Ensure device is in custom image mode (theme=3)
-        await self.device.set_theme(3)
+        # Ensure device is in custom image mode
+        await self.device.set_theme_custom()
 
         self._update_preview = True  # Update preview on manual refresh
         await self.async_request_refresh()

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -169,12 +169,21 @@ class GeekMagicDevice:
         """Set device theme.
 
         Args:
-            theme: Theme number (3 = custom image)
+            theme: Theme number (3 = custom image on Ultra, 4 = custom image on Pro)
         """
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?theme={theme}") as response:
             response.raise_for_status()
         _LOGGER.debug("Set theme to %d", theme)
+
+    async def set_theme_custom(self) -> None:
+        """Set device to custom image mode with the correct theme number.
+
+        Ultra devices use theme 3, Pro devices use theme 4.
+        Uses the model detected at startup via detect_model().
+        """
+        theme = 4 if self.model == MODEL_PRO else 3
+        await self.set_theme(theme)
 
     async def set_image(self, filename: str) -> None:
         """Set the displayed image.
@@ -183,7 +192,7 @@ class GeekMagicDevice:
             filename: Image filename (without path)
         """
         # Ensure we're in custom image mode
-        await self.set_theme(3)
+        await self.set_theme_custom()
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?img=/image/{filename}") as response:
             response.raise_for_status()

--- a/custom_components/geekmagic/entities/base.py
+++ b/custom_components/geekmagic/entities/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ..const import DOMAIN
+from ..const import DOMAIN, MODEL_PRO, MODEL_ULTRA
 
 if TYPE_CHECKING:
     from ..coordinator import GeekMagicCoordinator
@@ -29,11 +29,21 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
         self._attr_unique_id = f"{coordinator.entry.entry_id}_{entity_suffix}"
 
     @property
+    def _device_model_name(self) -> str:
+        """Return human-readable device model name."""
+        model = self.coordinator.device.model
+        if model == MODEL_PRO:
+            return "SmallTV Pro"
+        if model == MODEL_ULTRA:
+            return "SmallTV Ultra"
+        return "SmallTV"
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
         return DeviceInfo(
             identifiers={(DOMAIN, self.coordinator.entry.entry_id)},
             name=self.coordinator.entry.title,
             manufacturer="GeekMagic",
-            model="SmallTV Pro",
+            model=self._device_model_name,
         )


### PR DESCRIPTION
Pro devices require theme 4 for custom image mode, while Ultra devices
use theme 3. Previously theme 3 was hardcoded everywhere, breaking
custom image display on Pro devices.

Add set_theme_custom() to GeekMagicDevice that uses the model already
detected at startup (via detect_model()) to pick the right theme.
Also make entity device_info report the actual detected model name
instead of hardcoding "SmallTV Pro".

Addresses the issue raised by @noisymime in #74.

https://claude.ai/code/session_01Ash9dsMr8uVkp3JehvsBLT