### PR TITLE
Fix media artwork fetches for Home Assistant proxy URLs

### DIFF
--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -1423,10 +1423,12 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             image_url = f"{base_url.rstrip('/')}/{entity_picture.lstrip('/')}"
 
             try:
-                async with (
-                    aiohttp.ClientSession() as session,
-                    session.get(image_url, timeout=aiohttp.ClientTimeout(total=10)) as response,
-                ):
+                # Use Home Assistant's managed session so media proxy requests
+                # carry the right auth/cookies.
+                session = async_get_clientsession(self.hass)
+                async with session.get(
+                    image_url, timeout=aiohttp.ClientTimeout(total=10)
+                ) as response:
                     if response.status == 200:
                         image_data = await response.read()
                         self._media_images[entity_id] = image_data

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -1336,11 +1336,13 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         if not image_url or not image_url.startswith("/"):
             return
 
-        # Use internal URL from HA config, but fall back to external_url if needed
-        base_url = self.hass.config.internal_url or getattr(self.hass.config, "external_url", None)
-        if not base_url:
-            _LOGGER.debug("No base URL available for entity picture fetch")
-            return
+        # Prefer configured HA URLs, but fall back to the local core endpoint on
+        # hosts where internal/external URLs are intentionally unset.
+        base_url = (
+            self.hass.config.internal_url
+            or getattr(self.hass.config, "external_url", None)
+            or "http://127.0.0.1:8123"
+        )
 
         # Ensure base_url doesn't have trailing slash and image_url has leading slash
         full_url = f"{base_url.rstrip('/')}/{image_url.lstrip('/')}"
@@ -1412,12 +1414,13 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                 self._media_images.pop(entity_id, None)
                 continue
 
-            # Use internal URL from HA config, but fall back to external_url if needed
-            base_url = self.hass.config.internal_url or getattr(
-                self.hass.config, "external_url", None
+            # Prefer configured HA URLs, but fall back to the local core endpoint on
+            # hosts where internal/external URLs are intentionally unset.
+            base_url = (
+                self.hass.config.internal_url
+                or getattr(self.hass.config, "external_url", None)
+                or "http://127.0.0.1:8123"
             )
-            if not base_url:
-                continue
 
             # Ensure base_url doesn't have trailing slash and entity_picture has leading slash
             image_url = f"{base_url.rstrip('/')}/{entity_picture.lstrip('/')}"


### PR DESCRIPTION
## Summary

Fix media widget album art fetches for Home Assistant proxy URLs.

## Problem

`_async_fetch_media_images()` builds a URL from `entity_picture` and then downloads it for the GeekMagic media widget.

There are two failure modes here:

1. The fetch uses a fresh `aiohttp.ClientSession()`, which can fail against authenticated Home Assistant media proxy URLs.
2. The code depends on `internal_url` / `external_url` being configured. On installations where both are intentionally unset, no base URL is available, so artwork is skipped entirely.

When either happens, the media widget falls back to text-only rendering.

## Fix

- Replace the ad-hoc `aiohttp.ClientSession()` with `async_get_clientsession(self.hass)`.
- Fall back to `http://127.0.0.1:8123` when Home Assistant has no configured internal or external URL.

This keeps the request inside Home Assistant's managed session and still allows local proxy fetches on hosts that do not set global HA URLs.

## Validation

Manually validated against a live Home Assistant instance:

- a GeekMagic `Now Playing` view was rendering without album art
- the media player artwork was exposed via Home Assistant's `entity_picture` proxy path
- after this change, the same view rendered album art correctly
