### PR TITLE
feat: add Active switch for presence-based sleep/wake

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Each GeekMagic device creates the following entities for control and monitoring:
 | `number.geekmagic_cycle_interval` | Number | View cycle interval (0 = manual only) |
 | `select.geekmagic_mode` | Select | Device mode (Custom Views, Clock, Weather, System Info) |
 | `select.geekmagic_current_view` | Select | Currently displayed view (when in Custom mode) |
+| `switch.geekmagic_active` | Switch | Enable/disable the display (sleep/wake) |
 | `switch.geekmagic_view_cycling` | Switch | Enable/disable automatic view cycling |
 
 ### Sensors
@@ -273,6 +274,38 @@ Each GeekMagic device creates the following entities for control and monitoring:
 | `button.geekmagic_refresh` | Button | Force immediate display refresh |
 | `button.geekmagic_next_screen` | Button | Switch to next view in rotation |
 | `button.geekmagic_previous_screen` | Button | Switch to previous view in rotation |
+
+### Presence-Based Sleep/Wake
+
+The **Active** switch (`switch.geekmagic_active`) lets you pause the display when no one is in the room. When turned off, the screen dims to zero and all rendering stops (saving CPU cycles and flash memory writes). When turned on, brightness is restored and the display refreshes immediately.
+
+Wire it to any HA presence sensor, motion sensor, or media player via an automation:
+
+```yaml
+automation:
+  - alias: "GeekMagic: sleep when room is empty"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.office_presence
+        to: "off"
+        for: "00:05:00"   # optional: wait 5 min before sleeping
+    action:
+      - action: switch.turn_off
+        target:
+          entity_id: switch.geekmagic_smalltv_active
+
+  - alias: "GeekMagic: wake when room is occupied"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.office_presence
+        to: "on"
+    action:
+      - action: switch.turn_on
+        target:
+          entity_id: switch.geekmagic_smalltv_active
+```
+
+Any HA entity works as a trigger — presence sensors, media players, motion sensors, person trackers, etc.
 
 ---
 

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -225,6 +225,10 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         self._display_mode: str = "custom"
         self._builtin_theme: int = 0  # Device theme when in builtin mode (0-2)
 
+        # Sleep/wake state — when paused, the render/upload cycle is skipped entirely
+        self._paused: bool = False
+        self._pre_pause_brightness: int | None = None
+
         # Backoff state for handling offline devices
         # When device is unreachable, increase update interval exponentially
         # to reduce log spam and resource usage
@@ -873,6 +877,9 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             Dictionary with update status
         """
         try:
+            if self._paused:
+                return {"success": True, "paused": True}
+
             # If device was offline, do a lightweight connectivity check first
             # to avoid expensive rendering operations
             if self._device_offline:
@@ -1190,6 +1197,11 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         self._device_brightness = value
 
     @property
+    def is_active(self) -> bool:
+        """Return True when the display is active (not paused/sleeping)."""
+        return not self._paused
+
+    @property
     def space_info(self) -> SpaceInfo | None:
         """Get device storage info."""
         return self._space_info
@@ -1234,6 +1246,35 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             brightness: Brightness level 0-100
         """
         await self.device.set_brightness(brightness)
+
+    async def async_set_active(self, active: bool) -> None:
+        """Pause or resume the render/upload cycle.
+
+        When paused: stores current brightness, dims screen to 0, and skips
+        all rendering and uploading until resumed. Intended for presence-based
+        automation (turn off when room is empty).
+
+        When resumed: restores brightness and triggers an immediate refresh.
+
+        Args:
+            active: True to resume, False to pause/sleep
+        """
+        if active:
+            self._paused = False
+            if self._pre_pause_brightness is not None:
+                await self.device.set_brightness(self._pre_pause_brightness)
+                self._device_brightness = self._pre_pause_brightness
+                self._pre_pause_brightness = None
+            _LOGGER.debug("Display activated, triggering refresh")
+            await self.async_request_refresh()
+        else:
+            if not self._paused:
+                self._pre_pause_brightness = self._device_brightness
+            await self.device.set_brightness(0)
+            self._device_brightness = 0
+            self._paused = True
+            _LOGGER.debug("Display paused (pre-pause brightness: %s)", self._pre_pause_brightness)
+            self.async_update_listeners()
 
     async def async_refresh_display(self) -> None:
         """Force an immediate display refresh.

--- a/custom_components/geekmagic/entities/switch.py
+++ b/custom_components/geekmagic/entities/switch.py
@@ -31,10 +31,40 @@ async def async_setup_entry(
     coordinator: GeekMagicCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     entities = [
+        GeekMagicActiveSwitch(coordinator),
         GeekMagicViewCyclingSwitch(coordinator),
     ]
 
     async_add_entities(entities)
+
+
+class GeekMagicActiveSwitch(GeekMagicEntity, SwitchEntity):
+    """Switch to pause/resume the render and upload cycle.
+
+    When off, all rendering and device uploads are skipped and the screen is
+    dimmed to zero. Intended for presence-based automations so the display
+    does not refresh (or stay lit) when no one is in the room.
+    """
+
+    _attr_name = "Active"
+    _attr_icon = "mdi:monitor"
+
+    def __init__(self, coordinator: GeekMagicCoordinator) -> None:
+        """Initialize active switch."""
+        super().__init__(coordinator, "active")
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the display is active (not paused)."""
+        return self.coordinator.is_active
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Resume the display."""
+        await self.coordinator.async_set_active(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Pause the display and dim the screen."""
+        await self.coordinator.async_set_active(False)
 
 
 class GeekMagicViewCyclingSwitch(GeekMagicEntity, SwitchEntity):

--- a/custom_components/geekmagic/strings.json
+++ b/custom_components/geekmagic/strings.json
@@ -51,6 +51,9 @@
       }
     },
     "switch": {
+      "active": {
+        "name": "Active"
+      },
       "view_cycling": {
         "name": "View Cycling"
       }

--- a/scripts/mock_hass.py
+++ b/scripts/mock_hass.py
@@ -43,7 +43,7 @@ class MockStates:
 
         # Auto-resolve icon if not explicitly set
         if "icon" not in attrs:
-            domain = entity_id.split(".")[0] if "." in entity_id else None
+            domain = entity_id.split(".", maxsplit=1)[0] if "." in entity_id else None
             device_class = attrs.get("device_class")
 
             # Try device class first, then domain

--- a/tests/entities/test_entities.py
+++ b/tests/entities/test_entities.py
@@ -329,3 +329,87 @@ class TestViewCyclingSwitchAttributes:
         switch = GeekMagicViewCyclingSwitch(mock_coordinator)
 
         assert switch._attr_unique_id == "test_entry_123_view_cycling"
+
+
+class TestActiveSwitchIsOn:
+    """Tests for ActiveSwitch is_on property."""
+
+    def test_is_on_true_when_not_paused(self, mock_coordinator):
+        """Test is_on returns True when coordinator is not paused (default)."""
+        from custom_components.geekmagic.entities.switch import GeekMagicActiveSwitch
+
+        mock_coordinator.is_active = True
+        switch = GeekMagicActiveSwitch(mock_coordinator)
+
+        assert switch.is_on is True
+
+    def test_is_on_false_when_paused(self, mock_coordinator):
+        """Test is_on returns False when coordinator is paused."""
+        from custom_components.geekmagic.entities.switch import GeekMagicActiveSwitch
+
+        mock_coordinator.is_active = False
+        switch = GeekMagicActiveSwitch(mock_coordinator)
+
+        assert switch.is_on is False
+
+
+class TestActiveSwitchTurnOff:
+    """Tests for ActiveSwitch async_turn_off."""
+
+    @pytest.mark.asyncio
+    async def test_turn_off_calls_set_active_false(self, mock_coordinator):
+        """Test async_turn_off calls coordinator.async_set_active(False)."""
+        from custom_components.geekmagic.entities.switch import GeekMagicActiveSwitch
+
+        mock_coordinator._paused = False
+        mock_coordinator.async_set_active = AsyncMock()
+
+        switch = GeekMagicActiveSwitch(mock_coordinator)
+        await switch.async_turn_off()
+
+        mock_coordinator.async_set_active.assert_called_once_with(False)
+
+
+class TestActiveSwitchTurnOn:
+    """Tests for ActiveSwitch async_turn_on."""
+
+    @pytest.mark.asyncio
+    async def test_turn_on_calls_set_active_true(self, mock_coordinator):
+        """Test async_turn_on calls coordinator.async_set_active(True)."""
+        from custom_components.geekmagic.entities.switch import GeekMagicActiveSwitch
+
+        mock_coordinator._paused = True
+        mock_coordinator.async_set_active = AsyncMock()
+
+        switch = GeekMagicActiveSwitch(mock_coordinator)
+        await switch.async_turn_on()
+
+        mock_coordinator.async_set_active.assert_called_once_with(True)
+
+
+class TestActiveSwitchAttributes:
+    """Tests for ActiveSwitch entity attributes."""
+
+    def test_switch_has_correct_name(self, mock_coordinator):
+        """Test active switch has name 'Active'."""
+        from custom_components.geekmagic.entities.switch import GeekMagicActiveSwitch
+
+        switch = GeekMagicActiveSwitch(mock_coordinator)
+
+        assert switch._attr_name == "Active"
+
+    def test_switch_has_correct_icon(self, mock_coordinator):
+        """Test active switch has monitor icon."""
+        from custom_components.geekmagic.entities.switch import GeekMagicActiveSwitch
+
+        switch = GeekMagicActiveSwitch(mock_coordinator)
+
+        assert switch._attr_icon == "mdi:monitor"
+
+    def test_switch_has_unique_id(self, mock_coordinator):
+        """Test active switch has unique ID."""
+        from custom_components.geekmagic.entities.switch import GeekMagicActiveSwitch
+
+        switch = GeekMagicActiveSwitch(mock_coordinator)
+
+        assert switch._attr_unique_id == "test_entry_123_active"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -778,3 +778,149 @@ class TestCoordinatorBackoff:
 
         # Verify expensive operations were NOT called
         backoff_device.upload_and_display.assert_not_called()
+
+
+class TestCoordinatorPause:
+    """Tests for the sleep/wake (pause) feature.
+
+    Verifies that setting _paused=True causes _async_update_data to skip
+    all rendering and uploading, and that async_set_active properly
+    manages the paused state and brightness.
+    """
+
+    @pytest.fixture
+    def pause_device(self):
+        """Create mock device for pause tests."""
+        device = MagicMock()
+        device.host = "192.168.1.100"
+        device.model = "unknown"
+        device.upload_and_display = AsyncMock()
+        device.set_brightness = AsyncMock()
+        device.get_brightness = AsyncMock(return_value=75)
+        device.get_state = AsyncMock(return_value=None)
+        device.get_space = AsyncMock(return_value=None)
+        return device
+
+    @pytest.fixture
+    def simple_options(self):
+        """Create simple single-screen options."""
+        return {
+            CONF_REFRESH_INTERVAL: 10,
+            CONF_SCREENS: [
+                {
+                    "name": "Test",
+                    CONF_LAYOUT: LAYOUT_GRID_2X2,
+                    CONF_WIDGETS: [{"type": "clock", "slot": 0}],
+                }
+            ],
+        }
+
+    def test_initial_paused_state_is_false(self, hass, pause_device, simple_options):
+        """Test that coordinator starts unpaused."""
+        coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
+
+        assert coordinator._paused is False
+        assert coordinator._pre_pause_brightness is None
+
+    @pytest.mark.asyncio
+    async def test_update_skips_render_when_paused(self, hass, pause_device, simple_options):
+        """Test that _async_update_data returns early without rendering when paused."""
+        coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
+        coordinator._paused = True
+
+        result = await coordinator._async_update_data()
+
+        assert result == {"success": True, "paused": True}
+        pause_device.upload_and_display.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_active_false_dims_screen_and_pauses(
+        self, hass, pause_device, simple_options
+    ):
+        """Test async_set_active(False) saves brightness, dims to 0, sets paused."""
+        coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
+        coordinator._device_brightness = 75
+
+        await coordinator.async_set_active(False)
+
+        assert coordinator._paused is True
+        assert coordinator._pre_pause_brightness == 75
+        assert coordinator._device_brightness == 0
+        pause_device.set_brightness.assert_called_once_with(0)
+
+    @pytest.mark.asyncio
+    async def test_set_active_true_restores_brightness_and_refreshes(
+        self, hass, pause_device, simple_options
+    ):
+        """Test async_set_active(True) restores brightness and triggers refresh."""
+        coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
+        coordinator._paused = True
+        coordinator._pre_pause_brightness = 75
+        coordinator._device_brightness = 0
+
+        with patch.object(
+            coordinator, "async_request_refresh", new_callable=AsyncMock
+        ) as mock_refresh:
+            await coordinator.async_set_active(True)
+
+        assert coordinator._paused is False
+        assert coordinator._pre_pause_brightness is None
+        assert coordinator._device_brightness == 75
+        pause_device.set_brightness.assert_called_once_with(75)
+        mock_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_active_false_handles_no_brightness(self, hass, pause_device, simple_options):
+        """Test async_set_active(False) works when brightness was never polled."""
+        coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
+        coordinator._device_brightness = None  # never polled
+
+        await coordinator.async_set_active(False)
+
+        assert coordinator._paused is True
+        assert coordinator._pre_pause_brightness is None
+        pause_device.set_brightness.assert_called_once_with(0)
+
+    @pytest.mark.asyncio
+    async def test_set_active_true_skips_brightness_when_none_stored(
+        self, hass, pause_device, simple_options
+    ):
+        """Test async_set_active(True) does not call set_brightness if none was stored."""
+        coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
+        coordinator._paused = True
+        coordinator._pre_pause_brightness = None
+
+        with patch.object(
+            coordinator, "async_request_refresh", new_callable=AsyncMock
+        ) as mock_refresh:
+            await coordinator.async_set_active(True)
+
+        assert coordinator._paused is False
+        pause_device.set_brightness.assert_not_called()
+        mock_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_active_false_twice_preserves_pre_pause_brightness(
+        self, hass, pause_device, simple_options
+    ):
+        """Test that calling sleep twice does not overwrite the stored brightness."""
+        coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
+        coordinator._device_brightness = 80
+
+        await coordinator.async_set_active(False)
+        assert coordinator._pre_pause_brightness == 80
+
+        # Second call while already paused should not overwrite the stored value
+        await coordinator.async_set_active(False)
+        assert coordinator._pre_pause_brightness == 80
+
+    @pytest.mark.asyncio
+    async def test_set_active_false_notifies_listeners(self, hass, pause_device, simple_options):
+        """Test that sleeping calls async_update_listeners for an immediate UI state update."""
+        coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
+        coordinator._device_brightness = 60
+
+        with patch.object(coordinator, "async_update_listeners") as mock_notify:
+            await coordinator.async_set_active(False)
+
+        mock_notify.assert_called_once()


### PR DESCRIPTION
Adds a `switch.geekmagic_active` entity that pauses the render/upload
cycle and dims the screen to zero when turned off. When turned back on,
brightness is restored and the display refreshes immediately.

Designed to be wired to any HA presence sensor, motion sensor, or media
player via an automation, so the device stops refreshing (and writing to
flash memory) when no one is in the room.

Closes #115

https://claude.ai/code/session_01DZAdbm1GKGB9iAShnFTm5u