### PR TITLE
fix: add mobile responsive layout for views grid

### DIFF
--- a/custom_components/geekmagic/frontend/dist/geekmagic-panel.js
+++ b/custom_components/geekmagic/frontend/dist/geekmagic-panel.js
@@ -1707,6 +1707,12 @@ g.styles = me`
       gap: 16px;
     }
 
+    @media (max-width: 600px) {
+      .views-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
     ha-card {
       --ha-card-border-radius: 12px;
     }

--- a/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
+++ b/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
@@ -135,6 +135,12 @@ export class GeekMagicPanel extends LitElement {
       gap: 16px;
     }
 
+    @media (max-width: 600px) {
+      .views-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
     ha-card {
       --ha-card-border-radius: 12px;
     }


### PR DESCRIPTION
## Summary
Add responsive CSS media query to stack the views grid into a single column on mobile devices (screens ≤600px wide), improving usability on small screens.

## Changes
- Added `@media (max-width: 600px)` rule to `.views-grid` in both TypeScript source and compiled JavaScript
- On mobile, `grid-template-columns` changes from multi-column layout to `1fr` (single column)
- Ensures the panel remains usable and readable on phones and tablets

## Implementation Details
- Media query breakpoint set to 600px, a common mobile/tablet threshold
- Change applied to both `custom_components/geekmagic/frontend/src/geekmagic-panel.ts` (source) and the compiled dist file
- No functional changes to desktop layout or other styling

https://claude.ai/code/session_01HDm6uDZNvu5o9XZ3aqYrTb