### PR TITLE
refactor: extract screen_builder module from coordinator/preview/websocket

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,15 +33,15 @@ repos:
 
       - id: frontend-typecheck
         name: frontend typecheck
-        entry: bash -c 'cd custom_components/geekmagic/frontend && npm run typecheck'
-        language: system
+        entry: ./scripts/frontend-run.sh typecheck
+        language: script
         pass_filenames: false
         files: ^custom_components/geekmagic/frontend/src/.*\.ts$
 
       - id: frontend-test
         name: frontend test
-        entry: bash -c 'cd custom_components/geekmagic/frontend && npm test'
-        language: system
+        entry: ./scripts/frontend-run.sh test
+        language: script
         pass_filenames: false
         files: ^custom_components/geekmagic/frontend/src/.*\.ts$
 

--- a/custom_components/geekmagic/connection_backoff.py
+++ b/custom_components/geekmagic/connection_backoff.py
@@ -1,0 +1,133 @@
+"""Exponential backoff + smart logging for an unreliable connection.
+
+Wraps three things the coordinator used to manage by hand: a consecutive-
+failure counter, the exponential interval calculation, and the
+"first failure WARN, periodic WARN, otherwise DEBUG" log cadence.
+
+Used by the coordinator only today; kept as a separate module because the
+state machine + logging cadence is one cohesive concept that the update
+loop benefits from not having to spell out inline.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+
+
+class ConnectionBackoff:
+    """Tracks consecutive failures and produces the next update interval.
+
+    The state machine:
+      - On success: counter resets, interval returns to base.
+      - On failure: counter increments; interval = base * 2**counter,
+        capped at base * max_multiplier.
+      - Logging cadence is offloaded to `log_failure`: WARN on the first
+        failure and every Nth thereafter, DEBUG otherwise.
+    """
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        base_interval_seconds: int,
+        max_multiplier: int,
+        log_interval: int,
+    ) -> None:
+        self._logger = logger
+        self._base_interval = base_interval_seconds
+        self._max_multiplier = max_multiplier
+        self._log_interval = log_interval
+        self._failures = 0
+        self._offline = False
+
+    @property
+    def base_interval(self) -> int:
+        return self._base_interval
+
+    @base_interval.setter
+    def base_interval(self, value: int) -> None:
+        self._base_interval = value
+
+    @property
+    def failure_count(self) -> int:
+        return self._failures
+
+    @property
+    def is_offline(self) -> bool:
+        return self._offline
+
+    def record_failure(self) -> timedelta:
+        """Record a failure and return the next update interval to use."""
+        self._failures += 1
+        self._offline = True
+        multiplier = min(2 ** min(self._failures, 10), self._max_multiplier)
+        next_seconds = self._base_interval * multiplier
+        self._logger.debug(
+            "Applied backoff: interval=%ds (multiplier=%dx, failures=%d)",
+            next_seconds,
+            multiplier,
+            self._failures,
+        )
+        return timedelta(seconds=next_seconds)
+
+    def record_success(self) -> timedelta:
+        """Mark the connection as healthy and return the base update interval."""
+        self._failures = 0
+        self._offline = False
+        return timedelta(seconds=self._base_interval)
+
+    def log_failure(self, host: str, message: str, current_interval_seconds: int) -> None:
+        """Emit an appropriately verbose log line for the latest failure.
+
+        WARN on the first failure (full context), WARN at every Nth
+        subsequent failure (periodic summary), DEBUG otherwise to keep
+        long-running offline devices from spamming the log.
+        """
+        if self._failures == 1:
+            self._logger.warning(
+                "GeekMagic device %s is offline: %s. Will retry with exponential backoff.",
+                host,
+                message,
+            )
+        elif self._failures % self._log_interval == 0:
+            self._logger.warning(
+                "GeekMagic device %s still offline after %d attempts (retry interval: %ds)",
+                host,
+                self._failures,
+                current_interval_seconds,
+            )
+        else:
+            self._logger.debug(
+                "GeekMagic device %s offline (attempt %d): %s",
+                host,
+                self._failures,
+                message,
+            )
+
+    def log_connection_error(
+        self, host: str, err: BaseException, current_interval_seconds: int
+    ) -> None:
+        """Like log_failure but for unexpected exceptions during an update."""
+        if self._failures == 1:
+            self._logger.warning(
+                "GeekMagic device %s connection failed: %s. Will retry with exponential backoff.",
+                host,
+                err,
+            )
+        elif self._failures % self._log_interval == 0:
+            self._logger.warning(
+                "GeekMagic device %s still failing after %d attempts: %s (retry interval: %ds)",
+                host,
+                self._failures,
+                err,
+                current_interval_seconds,
+            )
+        else:
+            self._logger.debug(
+                "GeekMagic update failed (attempt %d): %s",
+                self._failures,
+                err,
+            )

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -7,9 +7,6 @@ import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    import asyncio
-
 from homeassistant.const import __version__ as ha_version
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -30,13 +27,11 @@ from .const import (
     DOMAIN,
     MAX_BACKOFF_MULTIPLIER,
     MODEL_PRO,
-    THEME_WATCHOS,
 )
 from .device import DeviceState, GeekMagicDevice, SpaceInfo
 from .history_fetcher import HistoryFetcher, extract_numeric_values
-from .layouts.fullscreen import FullscreenLayout
 from .layouts.hero import HeroLayout
-from .layouts.hero_simple import HeroSimpleLayout
+from .notification_manager import NotificationManager
 from .renderer import Renderer
 from .screen_builder import (
     CONF_ASSIGNED_VIEWS,
@@ -51,11 +46,9 @@ from .widgets.camera import CameraWidget
 from .widgets.candlestick import CandlestickWidget
 from .widgets.chart import ChartWidget
 from .widgets.clock import ClockWidget
-from .widgets.icon import IconWidget
 from .widgets.media import MediaWidget
 from .widgets.state import WidgetState
 from .widgets.text import TextWidget
-from .widgets.theme import get_theme
 from .widgets.weather import WeatherWidget
 
 if TYPE_CHECKING:
@@ -119,10 +112,8 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         self._last_brightness_poll: float = 0  # Timestamp of last brightness poll
         self._brightness_poll_interval: float = 600  # 10 minutes
 
-        # Notification state
-        self._notification_expiry: float = 0
-        self._notification_data: dict[str, Any] | None = None
-        self._notification_clear_handle: asyncio.TimerHandle | None = None
+        # Notification subsystem (trigger / expiry / layout override)
+        self._notifications = NotificationManager(hass, self.async_request_refresh)
 
         # Display mode tracking
         # "custom" = integration renders views, "builtin" = device shows built-in mode
@@ -348,9 +339,10 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             layout = self._layouts[self._current_screen]
 
             # Check for active notification
-            if time.time() < self._notification_expiry and self._notification_data:
+            override = self._notifications.build_layout()
+            if override is not None:
                 _LOGGER.debug("Rendering active notification")
-                layout = self._create_notification_layout(self._notification_data)
+                layout = override
 
             _LOGGER.debug(
                 "Rendering layout %s with %d widgets",
@@ -377,135 +369,8 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         return jpeg_data, png_data
 
     async def trigger_notification(self, data: dict[str, Any]) -> None:
-        """Trigger a notification on this device.
-
-        Args:
-            data: Notification data (message, title, icon, duration, etc.)
-        """
-        duration = data.get("duration", 10)
-        self._notification_data = data
-        self._notification_expiry = time.time() + duration
-
-        # Cancel any pending clear callback to prevent race conditions
-        if self._notification_clear_handle is not None:
-            self._notification_clear_handle.cancel()
-
-        # Schedule cleanup and store handle for potential cancellation
-        self._notification_clear_handle = self.hass.loop.call_later(
-            duration, self._clear_notification
-        )
-
-        # Force immediate refresh
-        await self.async_request_refresh()
-
-    def _clear_notification(self) -> None:
-        """Clear the active notification and refresh."""
-        self._notification_expiry = 0
-        self._notification_data = None
-        self._notification_clear_handle = None
-        # Use fire-and-forget for the refresh since this is a callback
-        self.hass.async_create_task(self.async_request_refresh())
-
-    def _create_notification_layout(self, data: dict[str, Any]) -> Layout:
-        """Create a layout for a notification.
-
-        Args:
-            data: Notification data
-
-        Returns:
-            Layout: HeroSimpleLayout (with message) or FullscreenLayout (image only)
-        """
-        message = data.get("message")
-
-        # Scenario 1: No message -> Fullscreen Layout (Image/Icon only)
-        if not message:
-            layout = FullscreenLayout()
-            # Apply theme if specified
-            theme_name = data.get("theme", THEME_WATCHOS)
-            layout.theme = get_theme(theme_name)
-
-            hero_widget = None
-            image_url = data.get("image")
-
-            if image_url:
-                hero_widget = CameraWidget(
-                    WidgetConfig(
-                        widget_type="camera",
-                        slot=0,
-                        entity_id=image_url,
-                        options={
-                            # contain ensures full image visible, cover fills screen
-                            "fit": "contain",
-                        },
-                    )
-                )
-
-            if not hero_widget:
-                # Default to Icon — IconWidget falls back to the active
-                # theme's accent color (matches whatever theme the user
-                # picked for the notification).
-                icon = data.get("icon", "mdi:bell-ring")
-                hero_widget = IconWidget(
-                    WidgetConfig(
-                        widget_type="icon",
-                        slot=0,
-                        options={
-                            "icon": icon,
-                            "size": "huge",  # This option is now supported by IconWidget
-                            "show_panel": False,  # Clean fullscreen look
-                        },
-                    )
-                )
-            layout.set_widget(0, hero_widget)
-            return layout
-
-        # Scenario 2: Message exists -> Hero Simple Layout
-        layout = HeroSimpleLayout()
-
-        # Apply theme if specified
-        theme_name = data.get("theme", THEME_WATCHOS)
-        layout.theme = get_theme(theme_name)
-
-        # Slot 0 (Hero): Icon or Image
-        hero_widget = None
-        image_url = data.get("image")
-        if image_url:
-            hero_widget = CameraWidget(
-                WidgetConfig(
-                    widget_type="camera", slot=0, entity_id=image_url, options={"fit": "contain"}
-                )
-            )
-
-        if not hero_widget:
-            # Default to Icon — falls back to the active theme's accent color.
-            icon = data.get("icon", "mdi:bell-ring")
-            hero_widget = IconWidget(
-                WidgetConfig(
-                    widget_type="icon",
-                    slot=0,
-                    options={
-                        "icon": icon,
-                        "size": "huge",  # Force huge icon
-                    },
-                )
-            )
-        layout.set_widget(0, hero_widget)
-
-        # Slot 1 (Footer): Message — defaults to theme.text_primary.
-        text_widget = TextWidget(
-            WidgetConfig(
-                widget_type="text",
-                slot=1,
-                options={
-                    "text": message,
-                    "size": "medium",
-                    "align": "center",
-                },
-            )
-        )
-        layout.set_widget(1, text_widget)
-
-        return layout
+        """Show a notification on this device. Delegates to NotificationManager."""
+        await self._notifications.trigger(data)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data and update display.
@@ -871,13 +736,12 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                             other_entity_ids.add(entity_id)
 
         # Also collect entities from notification
-        if self._notification_data:
-            image_source = self._notification_data.get("image")
-            if image_source:
-                if image_source.startswith("camera."):
-                    camera_entity_ids.add(image_source)
-                else:
-                    other_entity_ids.add(image_source)
+        image_source = self._notifications.image_source
+        if image_source:
+            if image_source.startswith("camera."):
+                camera_entity_ids.add(image_source)
+            else:
+                other_entity_ids.add(image_source)
 
         # Fetch non-camera entities first (they populate the same cache)
         for entity_id in other_entity_ids:

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -9,8 +9,6 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import __version__ as ha_version
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .connection_backoff import ConnectionBackoff
@@ -29,9 +27,10 @@ from .const import (
     MODEL_PRO,
 )
 from .device import DeviceState, GeekMagicDevice, SpaceInfo
-from .history_fetcher import HistoryFetcher, extract_numeric_values
+from .history_fetcher import extract_numeric_values
 from .layouts.hero import HeroLayout
 from .notification_manager import NotificationManager
+from .render_data_pipeline import RenderDataPipeline
 from .renderer import Renderer
 from .screen_builder import (
     CONF_ASSIGNED_VIEWS,
@@ -42,14 +41,9 @@ from .screen_builder import (
 )
 from .widget_state_builder import PrefetchedData, build_widget_states
 from .widgets.base import WidgetConfig
-from .widgets.camera import CameraWidget
-from .widgets.candlestick import CandlestickWidget
-from .widgets.chart import ChartWidget
 from .widgets.clock import ClockWidget
-from .widgets.media import MediaWidget
 from .widgets.state import WidgetState
 from .widgets.text import TextWidget
-from .widgets.weather import WeatherWidget
 
 if TYPE_CHECKING:
     from .layouts.base import Layout
@@ -97,11 +91,11 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         self._last_update_success: bool = False
         self._last_update_time: float | None = None
         self.config_entry = config_entry
-        self._camera_images: dict[str, bytes] = {}  # Pre-fetched camera images
-        self._media_images: dict[str, bytes] = {}  # Pre-fetched media player album art
-        self._chart_history: dict[str, list[float]] = {}  # Pre-fetched chart history
-        self._candlestick_data: dict[str, list[tuple[float, float, float, float]]] = {}
-        self._weather_forecasts: dict[str, list[dict[str, Any]]] = {}  # Pre-fetched forecasts
+        self._pipeline = RenderDataPipeline(hass)
+        # Last bundle produced by the pipeline — consulted by _render_display
+        # (in the executor) and by `_build_widget_states`. Set on every
+        # successful update before render.
+        self._prefetched: PrefetchedData = PrefetchedData()
         self._update_preview: bool = True  # Update preview on next refresh
         self._preview_just_updated: bool = False  # True if preview was updated in last refresh
 
@@ -306,17 +300,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
 
     def _build_widget_states(self, layout: Layout) -> dict[int, WidgetState]:
         """Build WidgetState for every populated slot in `layout`."""
-        return build_widget_states(
-            layout,
-            self.hass,
-            PrefetchedData(
-                camera_images=self._camera_images,
-                media_images=self._media_images,
-                chart_history=self._chart_history,
-                candlestick_data=self._candlestick_data,
-                weather_forecasts=self._weather_forecasts,
-            ),
-        )
+        return build_widget_states(layout, self.hass, self._prefetched)
 
     def _render_display(self) -> tuple[bytes, bytes]:
         """Render the display image (runs in executor thread).
@@ -489,11 +473,11 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
 
             # Pre-fetch async data (camera images, media art, chart history, weather forecasts)
             # (must be done in async context)
-            await self._async_fetch_camera_images()
-            await self._async_fetch_media_images()
-            await self._async_fetch_chart_history()
-            await self._async_fetch_candlestick_history()
-            await self._async_fetch_weather_forecasts()
+            if self._layouts and 0 <= self._current_screen < len(self._layouts):
+                self._prefetched = await self._pipeline.prefetch(
+                    self._layouts[self._current_screen],
+                    image_source=self._notifications.image_source,
+                )
 
             # Render image in executor to avoid blocking the event loop
             # (Pillow image operations are CPU-intensive)
@@ -711,268 +695,3 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         self._setup_screens()
         self._update_preview = True
         await self.async_request_refresh()
-
-    async def _async_fetch_camera_images(self) -> None:
-        """Pre-fetch camera images for all camera widgets.
-
-        This must be called from the async context before rendering,
-        since camera.async_get_image() is async.
-        """
-        from homeassistant.components.camera import async_get_image
-
-        # Find all camera/image widgets in current layout
-        camera_entity_ids: set[str] = set()
-        other_entity_ids: set[str] = set()
-
-        if self._layouts and 0 <= self._current_screen < len(self._layouts):
-            layout = self._layouts[self._current_screen]
-            for slot in layout.slots:
-                if slot.widget and isinstance(slot.widget, CameraWidget):
-                    entity_id = slot.widget.config.entity_id
-                    if entity_id:
-                        if entity_id.startswith("camera."):
-                            camera_entity_ids.add(entity_id)
-                        else:
-                            other_entity_ids.add(entity_id)
-
-        # Also collect entities from notification
-        image_source = self._notifications.image_source
-        if image_source:
-            if image_source.startswith("camera."):
-                camera_entity_ids.add(image_source)
-            else:
-                other_entity_ids.add(image_source)
-
-        # Fetch non-camera entities first (they populate the same cache)
-        for entity_id in other_entity_ids:
-            await self._async_fetch_url_image_to_cache(entity_id)
-
-        # Fetch images for each camera
-        for entity_id in camera_entity_ids:
-            try:
-                image = await async_get_image(self.hass, entity_id)
-                if image and image.content:
-                    self._camera_images[entity_id] = image.content
-                    _LOGGER.debug(
-                        "Fetched camera image for %s: %d bytes",
-                        entity_id,
-                        len(image.content),
-                    )
-            except Exception as e:
-                _LOGGER.debug("Failed to fetch camera image for %s: %s", entity_id, e)
-
-    async def _async_fetch_url_image_to_cache(self, source: str) -> None:
-        """Fetch image from entity_picture and save to camera image cache.
-
-        Args:
-            source: Entity ID
-        """
-        # Get state for the entity
-        image_url = None
-        state = self.hass.states.get(source)
-        if state:
-            image_url = state.attributes.get("entity_picture")
-
-        # Only allow internal Home Assistant URLs (starting with /)
-        if not image_url or not image_url.startswith("/"):
-            return
-
-        try:
-            base_url = get_url(self.hass)
-        except NoURLAvailableError:
-            _LOGGER.debug("No base URL available for entity picture fetch")
-            return
-
-        # Ensure base_url doesn't have trailing slash and image_url has leading slash
-        full_url = f"{base_url.rstrip('/')}/{image_url.lstrip('/')}"
-
-        try:
-            # Use Home Assistant's managed session for proper SSL/auth handling
-            session = async_get_clientsession(self.hass)
-            async with session.get(full_url, timeout=10) as response:
-                if response.status == 200:
-                    image_data = await response.read()
-                    self._camera_images[source] = image_data
-                    _LOGGER.debug(
-                        "Fetched image for notification from %s: %d bytes",
-                        source,
-                        len(image_data),
-                    )
-                else:
-                    _LOGGER.debug(
-                        "Failed to fetch notification image from %s: HTTP %d",
-                        source,
-                        response.status,
-                    )
-        except Exception as e:
-            _LOGGER.debug("Failed to fetch notification image from %s: %s", source, e)
-
-    def get_camera_image(self, entity_id: str) -> bytes | None:
-        """Get pre-fetched camera image.
-
-        Args:
-            entity_id: Camera entity ID
-
-        Returns:
-            Image bytes or None if not available
-        """
-        return self._camera_images.get(entity_id)
-
-    async def _async_fetch_media_images(self) -> None:
-        """Pre-fetch album art images for all media player widgets.
-
-        Fetches entity_picture URLs from media player entities and downloads
-        the album art images for display.
-        """
-        # Find all media widgets in current layout
-        media_entity_ids: set[str] = set()
-
-        if self._layouts and 0 <= self._current_screen < len(self._layouts):
-            layout = self._layouts[self._current_screen]
-            for slot in layout.slots:
-                if slot.widget and isinstance(slot.widget, MediaWidget):
-                    entity_id = slot.widget.config.entity_id
-                    if entity_id:
-                        media_entity_ids.add(entity_id)
-
-        if not media_entity_ids:
-            return
-
-        # Fetch album art for each media player
-        for entity_id in media_entity_ids:
-            state = self.hass.states.get(entity_id)
-            if state is None:
-                continue
-
-            # Get entity_picture from attributes
-            entity_picture = state.attributes.get("entity_picture")
-            if not entity_picture or not entity_picture.startswith("/"):
-                # Clear any cached image if no internal picture available
-                self._media_images.pop(entity_id, None)
-                continue
-
-            try:
-                base_url = get_url(self.hass)
-            except NoURLAvailableError:
-                continue
-
-            # Ensure base_url doesn't have trailing slash and entity_picture has leading slash
-            image_url = f"{base_url.rstrip('/')}/{entity_picture.lstrip('/')}"
-
-            try:
-                # Use Home Assistant's managed session so media proxy requests
-                # carry the right auth/cookies.
-                session = async_get_clientsession(self.hass)
-                async with session.get(image_url, timeout=10) as response:
-                    if response.status == 200:
-                        image_data = await response.read()
-                        self._media_images[entity_id] = image_data
-                        _LOGGER.debug(
-                            "Fetched album art for %s: %d bytes",
-                            entity_id,
-                            len(image_data),
-                        )
-                    else:
-                        _LOGGER.debug(
-                            "Failed to fetch album art for %s: HTTP %d",
-                            entity_id,
-                            response.status,
-                        )
-            except Exception as e:
-                _LOGGER.debug("Failed to fetch album art for %s: %s", entity_id, e)
-
-    async def _async_fetch_chart_history(self) -> None:
-        """Pre-fetch numeric history for all chart widgets on the active screen."""
-        chart_widgets: list[tuple[str, ChartWidget]] = []
-        if self._layouts and 0 <= self._current_screen < len(self._layouts):
-            for slot in self._layouts[self._current_screen].slots:
-                if slot.widget and isinstance(slot.widget, ChartWidget):
-                    entity_id = slot.widget.config.entity_id
-                    if entity_id:
-                        chart_widgets.append((entity_id, slot.widget))
-
-        if not chart_widgets:
-            return
-
-        fetcher = HistoryFetcher(self.hass)
-        if not fetcher.available:
-            return
-
-        for entity_id, widget in chart_widgets:
-            values = await fetcher.fetch_numeric(entity_id, widget.hours)
-            if values:
-                self._chart_history[entity_id] = values
-                _LOGGER.debug("Fetched %d history points for %s", len(values), entity_id)
-
-    async def _async_fetch_candlestick_history(self) -> None:
-        """Pre-fetch and aggregate OHLC data for all candlestick widgets."""
-        candlestick_widgets: list[tuple[str, CandlestickWidget]] = []
-        if self._layouts and 0 <= self._current_screen < len(self._layouts):
-            for slot in self._layouts[self._current_screen].slots:
-                if slot.widget and isinstance(slot.widget, CandlestickWidget):
-                    entity_id = slot.widget.config.entity_id
-                    if entity_id:
-                        candlestick_widgets.append((entity_id, slot.widget))
-
-        if not candlestick_widgets:
-            return
-
-        fetcher = HistoryFetcher(self.hass)
-        if not fetcher.available:
-            return
-
-        for entity_id, widget in candlestick_widgets:
-            candles = await fetcher.fetch_ohlc(
-                entity_id, widget.hours, widget.interval_seconds, widget.candle_count
-            )
-            if candles:
-                self._candlestick_data[entity_id] = candles
-                _LOGGER.debug("Aggregated %d candles for %s", len(candles), entity_id)
-
-    async def _async_fetch_weather_forecasts(self) -> None:
-        """Pre-fetch forecast data for all weather widgets.
-
-        This must be called from the async context before rendering,
-        since weather.get_forecasts is a service call that requires async.
-
-        Uses the weather.get_forecasts service introduced in Home Assistant 2023.9,
-        since the forecast attribute was removed from weather entities in 2024.3.
-        """
-        # Find all weather widgets in current layout
-        weather_entity_ids: set[str] = set()
-
-        if self._layouts and 0 <= self._current_screen < len(self._layouts):
-            layout = self._layouts[self._current_screen]
-            for slot in layout.slots:
-                if slot.widget and isinstance(slot.widget, WeatherWidget):
-                    entity_id = slot.widget.config.entity_id
-                    if entity_id:
-                        weather_entity_ids.add(entity_id)
-
-        if not weather_entity_ids:
-            return
-
-        # Fetch forecast for each weather entity
-        for entity_id in weather_entity_ids:
-            try:
-                # Use daily forecast type (most common for weather displays)
-                response = await self.hass.services.async_call(
-                    "weather",
-                    "get_forecasts",
-                    {"type": "daily"},
-                    target={"entity_id": entity_id},
-                    blocking=True,
-                    return_response=True,
-                )
-
-                forecast_response = response.get(entity_id) if isinstance(response, dict) else None
-                if isinstance(forecast_response, dict):
-                    forecast = forecast_response.get("forecast", [])
-                    self._weather_forecasts[entity_id] = forecast
-                    _LOGGER.debug(
-                        "Fetched %d forecast days for %s",
-                        len(forecast),
-                        entity_id,
-                    )
-            except Exception as e:
-                _LOGGER.debug("Failed to fetch forecast for %s: %s", entity_id, e)

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -27,6 +27,7 @@ from .const import (
     MODEL_PRO,
 )
 from .device import DeviceState, GeekMagicDevice, SpaceInfo
+from .display_state import DisplayState
 from .history_fetcher import extract_numeric_values
 from .layouts.hero import HeroLayout
 from .notification_manager import NotificationManager
@@ -109,14 +110,8 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         # Notification subsystem (trigger / expiry / layout override)
         self._notifications = NotificationManager(hass, self.async_request_refresh)
 
-        # Display mode tracking
-        # "custom" = integration renders views, "builtin" = device shows built-in mode
-        self._display_mode: str = "custom"
-        self._builtin_theme: int = 0  # Device theme when in builtin mode (0-2)
-
-        # Sleep/wake state — when paused, the render/upload cycle is skipped entirely
-        self._paused: bool = False
-        self._pre_pause_brightness: int | None = None
+        # Display mode (custom vs builtin) and pause/wake state
+        self._display = DisplayState()
 
         # Backoff state for handling offline devices
         interval = int(self.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL))
@@ -246,9 +241,9 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             self._last_screen_change = time.time()
 
             # If in builtin mode, switch to custom mode so the screen change is rendered
-            if self._display_mode == "builtin":
+            if self._display.mode == "builtin":
                 _LOGGER.debug("Switching from builtin to custom mode for screen change")
-                self._display_mode = "custom"
+                self._display.set_custom()
                 await self.device.set_theme_custom()
 
             await self.async_request_refresh()
@@ -367,7 +362,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             Dictionary with update status
         """
         try:
-            if self._paused:
+            if self._display.is_paused:
                 return {"success": True, "paused": True}
 
             # If device was offline, do a lightweight connectivity check first
@@ -444,31 +439,29 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
 
                 # Sync display mode with device state on first poll
                 # If device is in a built-in theme, respect that
-                if self._device_state and self._device_state.theme is not None:
-                    device_theme = self._device_state.theme
-                    if device_theme < 3 and self._display_mode == "custom":
-                        # Device is in built-in mode but we thought we were in custom
-                        # This can happen on startup - sync to device state
-                        _LOGGER.debug(
-                            "Syncing display mode from device: builtin (theme=%d)",
-                            device_theme,
-                        )
-                        self._display_mode = "builtin"
-                        self._builtin_theme = device_theme
+                if (
+                    self._device_state
+                    and self._device_state.theme is not None
+                    and self._display.sync_from_device_theme(self._device_state.theme)
+                ):
+                    _LOGGER.debug(
+                        "Syncing display mode from device: builtin (theme=%d)",
+                        self._device_state.theme,
+                    )
             except Exception as e:
                 _LOGGER.debug("Failed to fetch device state: %s", e)
 
             # Skip rendering when in built-in mode
             # The device handles display in built-in modes (Clock, Weather, System Info)
-            if self._display_mode == "builtin":
+            if self._display.mode == "builtin":
                 _LOGGER.debug(
                     "Skipping render - device in built-in mode (theme=%d)",
-                    self._builtin_theme,
+                    self._display.builtin_theme,
                 )
                 return {
                     "success": True,
                     "builtin_mode": True,
-                    "theme": self._builtin_theme,
+                    "theme": self._display.builtin_theme,
                 }
 
             # Pre-fetch async data (camera images, media art, chart history, weather forecasts)
@@ -593,7 +586,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
     @property
     def is_active(self) -> bool:
         """Return True when the display is active (not paused/sleeping)."""
-        return not self._paused
+        return self._display.is_active
 
     @property
     def space_info(self) -> SpaceInfo | None:
@@ -611,12 +604,12 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
     @property
     def display_mode(self) -> str:
         """Get current display mode ('custom' or 'builtin')."""
-        return self._display_mode
+        return self._display.mode
 
     @property
     def builtin_theme(self) -> int:
         """Get current builtin theme number (0-2) when in builtin mode."""
-        return self._builtin_theme
+        return self._display.builtin_theme
 
     def set_display_mode(self, mode: str, value: int = 0) -> None:
         """Set display mode.
@@ -625,10 +618,10 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             mode: Either 'custom' or 'builtin'
             value: For 'custom', the view index. For 'builtin', the theme number.
         """
-        self._display_mode = mode
         if mode == "builtin":
-            self._builtin_theme = value
+            self._display.set_builtin(value)
         else:
+            self._display.set_custom()
             # Custom mode - value is view index
             self._current_screen = value
             self._last_screen_change = time.time()
@@ -654,20 +647,17 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             active: True to resume, False to pause/sleep
         """
         if active:
-            self._paused = False
-            if self._pre_pause_brightness is not None:
-                await self.device.set_brightness(self._pre_pause_brightness)
-                self._device_brightness = self._pre_pause_brightness
-                self._pre_pause_brightness = None
+            restore = self._display.exit_pause()
+            if restore is not None:
+                await self.device.set_brightness(restore)
+                self._device_brightness = restore
             _LOGGER.debug("Display activated, triggering refresh")
             await self.async_request_refresh()
         else:
-            if not self._paused:
-                self._pre_pause_brightness = self._device_brightness
+            self._display.enter_pause(self._device_brightness)
             await self.device.set_brightness(0)
             self._device_brightness = 0
-            self._paused = True
-            _LOGGER.debug("Display paused (pre-pause brightness: %s)", self._pre_pause_brightness)
+            _LOGGER.debug("Display paused")
             self.async_update_listeners()
 
     async def async_refresh_display(self) -> None:
@@ -677,9 +667,9 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         and ensures the device is in custom image mode.
         """
         # If switching from builtin to custom, ensure device is in custom image mode
-        if self._display_mode == "builtin":
+        if self._display.mode == "builtin":
             _LOGGER.debug("Switching from builtin to custom mode")
-            self._display_mode = "custom"
+            self._display.set_custom()
 
         # Ensure device is in custom image mode
         await self.device.set_theme_custom()

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -45,6 +44,7 @@ from .screen_builder import (
     migrate_options,
     screen_name_at,
 )
+from .widget_state_builder import PrefetchedData, build_widget_states
 from .widgets.base import WidgetConfig
 from .widgets.camera import CameraWidget
 from .widgets.candlestick import CandlestickWidget
@@ -52,7 +52,7 @@ from .widgets.chart import ChartWidget
 from .widgets.clock import ClockWidget
 from .widgets.icon import IconWidget
 from .widgets.media import MediaWidget
-from .widgets.state import EntityState, WidgetState
+from .widgets.state import WidgetState
 from .widgets.text import TextWidget
 from .widgets.theme import get_theme
 from .widgets.weather import WeatherWidget
@@ -316,100 +316,18 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         self._update_preview = True
 
     def _build_widget_states(self, layout: Layout) -> dict[int, WidgetState]:
-        """Build WidgetState for all widgets in a layout.
-
-        Args:
-            layout: Layout with widgets to build states for
-
-        Returns:
-            Dict mapping slot index to WidgetState
-        """
-        from datetime import UTC
-        from io import BytesIO
-        from zoneinfo import ZoneInfo
-
-        from PIL import Image
-
-        states: dict[int, WidgetState] = {}
-
-        # Get current time with HA timezone
-        tz = getattr(self.hass.config, "time_zone_obj", None) or UTC
-        now = datetime.now(tz=tz)
-
-        for slot in layout.slots:
-            widget = slot.widget
-            if widget is None:
-                continue
-
-            # Build EntityState for primary entity
-            primary_entity = None
-            if widget.config.entity_id:
-                ha_state = self.hass.states.get(widget.config.entity_id)
-                if ha_state:
-                    primary_entity = EntityState(
-                        entity_id=ha_state.entity_id,
-                        state=ha_state.state,
-                        attributes=dict(ha_state.attributes),
-                    )
-
-            # Build EntityState for additional entities
-            additional: dict[str, EntityState] = {}
-            for eid in widget.get_entities():
-                if eid != widget.config.entity_id:
-                    ha_state = self.hass.states.get(eid)
-                    if ha_state:
-                        additional[eid] = EntityState(
-                            entity_id=ha_state.entity_id,
-                            state=ha_state.state,
-                            attributes=dict(ha_state.attributes),
-                        )
-
-            # Get pre-fetched chart history
-            history: list[float] = []
-            if isinstance(widget, ChartWidget) and widget.config.entity_id:
-                history = self._chart_history.get(widget.config.entity_id, [])
-
-            # Get pre-fetched candlestick data
-            candlestick_data: list[tuple[float, float, float, float]] = []
-            if isinstance(widget, CandlestickWidget) and widget.config.entity_id:
-                candlestick_data = self._candlestick_data.get(widget.config.entity_id, [])
-
-            # Get pre-fetched camera image or media album art
-            image = None
-            if isinstance(widget, CameraWidget) and widget.config.entity_id:
-                image_bytes = self._camera_images.get(widget.config.entity_id)
-                if image_bytes:
-                    with contextlib.suppress(Exception):
-                        image = Image.open(BytesIO(image_bytes))
-            elif isinstance(widget, MediaWidget) and widget.config.entity_id:
-                image_bytes = self._media_images.get(widget.config.entity_id)
-                if image_bytes:
-                    with contextlib.suppress(Exception):
-                        image = Image.open(BytesIO(image_bytes))
-
-            # Get pre-fetched weather forecast
-            forecast: list[dict[str, Any]] = []
-            if isinstance(widget, WeatherWidget) and widget.config.entity_id:
-                forecast = self._weather_forecasts.get(widget.config.entity_id, [])
-
-            # Handle clock widget timezone override
-            widget_now = now
-            if isinstance(widget, ClockWidget) and hasattr(widget, "timezone") and widget.timezone:
-                with contextlib.suppress(Exception):
-                    widget_tz = ZoneInfo(widget.timezone)
-                    widget_now = datetime.now(tz=widget_tz)
-
-            states[slot.index] = WidgetState(
-                entity=primary_entity,
-                entities=additional,
-                history=history,
-                candlestick_data=candlestick_data,
-                image=image,
-                forecast=forecast,
-                now=widget_now,
-            )
-
-        return states
+        """Build WidgetState for every populated slot in `layout`."""
+        return build_widget_states(
+            layout,
+            self.hass,
+            PrefetchedData(
+                camera_images=self._camera_images,
+                media_images=self._media_images,
+                chart_history=self._chart_history,
+                candlestick_data=self._candlestick_data,
+                weather_forecasts=self._weather_forecasts,
+            ),
+        )
 
     def _render_display(self) -> tuple[bytes, bytes]:
         """Render the display image (runs in executor thread).

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -16,7 +16,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt as dt_util
 
 from .const import (
     BACKOFF_LOG_INTERVAL,
@@ -34,6 +33,7 @@ from .const import (
     THEME_WATCHOS,
 )
 from .device import DeviceState, GeekMagicDevice, SpaceInfo
+from .history_fetcher import HistoryFetcher, extract_numeric_values
 from .layouts.fullscreen import FullscreenLayout
 from .layouts.hero import HeroLayout
 from .layouts.hero_simple import HeroSimpleLayout
@@ -47,11 +47,7 @@ from .screen_builder import (
 )
 from .widgets.base import WidgetConfig
 from .widgets.camera import CameraWidget
-from .widgets.candlestick import (
-    CandlestickWidget,
-    aggregate_ohlc,
-    extract_timestamped_values,
-)
+from .widgets.candlestick import CandlestickWidget
 from .widgets.chart import ChartWidget
 from .widgets.clock import ClockWidget
 from .widgets.icon import IconWidget
@@ -68,55 +64,14 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 # Re-exported for backwards compatibility (websocket and tests import these
-# from coordinator). New code should import from screen_builder directly.
-__all__ = ["CONF_ASSIGNED_VIEWS", "LAYOUT_CLASSES", "GeekMagicCoordinator"]
-
-
-# Binary states that should be converted to 1.0 (on/true)
-BINARY_ON_STATES = frozenset({"on", "true", "open", "home", "unlocked", "playing", "active"})
-# Binary states that should be converted to 0.0 (off/false)
-BINARY_OFF_STATES = frozenset(
-    {"off", "false", "closed", "not_home", "locked", "paused", "idle", "standby"}
-)
-
-
-def extract_numeric_values(history_states: list) -> list[float]:
-    """Extract numeric values from recorder history states.
-
-    Handles both State objects (with .state attribute) and
-    dictionaries (from minimal_response=True format).
-
-    Also converts binary states (on/off, open/closed, etc.) to 1.0/0.0
-    for charting binary_sensor entities.
-
-    Args:
-        history_states: List of State objects or dicts from recorder
-
-    Returns:
-        List of numeric float values, non-numeric states are skipped
-    """
-    values: list[float] = []
-    for state in history_states:
-        try:
-            # Handle both State objects and minimal_response dicts
-            state_value = state.state if hasattr(state, "state") else state.get("state")
-            if state_value is None:
-                continue
-
-            # Try numeric conversion first
-            try:
-                values.append(float(state_value))
-            except (ValueError, TypeError):
-                # Check for binary states
-                state_lower = str(state_value).lower()
-                if state_lower in BINARY_ON_STATES:
-                    values.append(1.0)
-                elif state_lower in BINARY_OFF_STATES:
-                    values.append(0.0)
-                # Skip other non-numeric states (unavailable, unknown, etc.)
-        except AttributeError:
-            continue
-    return values
+# names from coordinator). New code should import from screen_builder /
+# history_fetcher directly.
+__all__ = [
+    "CONF_ASSIGNED_VIEWS",
+    "LAYOUT_CLASSES",
+    "GeekMagicCoordinator",
+    "extract_numeric_values",
+]
 
 
 class GeekMagicCoordinator(DataUpdateCoordinator):
@@ -1242,47 +1197,11 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             except Exception as e:
                 _LOGGER.debug("Failed to fetch album art for %s: %s", entity_id, e)
 
-    def _fetch_entity_history(self, entity_id: str, start: datetime, end: datetime) -> list:
-        """Fetch history for an entity (sync, runs in executor).
-
-        Uses keyword arguments for state_changes_during_period since
-        async_add_executor_job passes positional args and the function
-        has many optional parameters with defaults.
-
-        Args:
-            entity_id: Entity ID to fetch history for
-            start: Start time (datetime)
-            end: End time (datetime)
-
-        Returns:
-            List of State objects for the entity
-        """
-        from homeassistant.components.recorder import history
-
-        # state_changes_during_period returns dict[entity_id, list[State]]
-        # We need keyword arguments here since the function has many optional params
-        result = history.state_changes_during_period(
-            self.hass,
-            start,
-            end,
-            entity_id,
-            include_start_time_state=True,
-            no_attributes=True,
-        )
-        return result.get(entity_id, [])
-
     async def _async_fetch_chart_history(self) -> None:
-        """Pre-fetch history data for all chart widgets.
-
-        This must be called from the async context before rendering,
-        since recorder queries are async.
-        """
-        # Find all chart widgets in current layout
+        """Pre-fetch numeric history for all chart widgets on the active screen."""
         chart_widgets: list[tuple[str, ChartWidget]] = []
-
         if self._layouts and 0 <= self._current_screen < len(self._layouts):
-            layout = self._layouts[self._current_screen]
-            for slot in layout.slots:
+            for slot in self._layouts[self._current_screen].slots:
                 if slot.widget and isinstance(slot.widget, ChartWidget):
                     entity_id = slot.widget.config.entity_id
                     if entity_id:
@@ -1291,66 +1210,21 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         if not chart_widgets:
             return
 
-        # Get recorder instance
-        try:
-            from homeassistant.components.recorder import get_instance
-        except ImportError:
-            _LOGGER.debug("Recorder not available, charts will show no data")
+        fetcher = HistoryFetcher(self.hass)
+        if not fetcher.available:
             return
-
-        # get_instance() raises KeyError if recorder not available
-        try:
-            recorder = get_instance(self.hass)
-        except KeyError:
-            _LOGGER.debug("Recorder instance not available")
-            return
-
-        now = dt_util.utcnow()
 
         for entity_id, widget in chart_widgets:
-            try:
-                hours = widget.hours
-                start_time = now - timedelta(hours=hours)
-
-                # Use wrapper method to fetch history with keyword arguments
-                # (async_add_executor_job only supports positional args, but
-                # state_changes_during_period needs keyword args for its many optional params)
-                history_states = await recorder.async_add_executor_job(
-                    self._fetch_entity_history,
-                    entity_id,
-                    start_time,
-                    now,
-                )
-
-                if history_states:
-                    values = extract_numeric_values(history_states)
-
-                    if values:
-                        # Store in coordinator for state building
-                        self._chart_history[entity_id] = values
-                        _LOGGER.debug(
-                            "Fetched %d history points for %s",
-                            len(values),
-                            entity_id,
-                        )
-                    else:
-                        _LOGGER.debug(
-                            "No numeric values in history for %s",
-                            entity_id,
-                        )
-                else:
-                    _LOGGER.debug("No history returned for %s", entity_id)
-            except Exception as e:
-                _LOGGER.warning("Failed to fetch history for %s: %s", entity_id, e)
+            values = await fetcher.fetch_numeric(entity_id, widget.hours)
+            if values:
+                self._chart_history[entity_id] = values
+                _LOGGER.debug("Fetched %d history points for %s", len(values), entity_id)
 
     async def _async_fetch_candlestick_history(self) -> None:
-        """Pre-fetch history and aggregate OHLC data for all candlestick widgets."""
-        # Find all candlestick widgets in current layout
+        """Pre-fetch and aggregate OHLC data for all candlestick widgets."""
         candlestick_widgets: list[tuple[str, CandlestickWidget]] = []
-
         if self._layouts and 0 <= self._current_screen < len(self._layouts):
-            layout = self._layouts[self._current_screen]
-            for slot in layout.slots:
+            for slot in self._layouts[self._current_screen].slots:
                 if slot.widget and isinstance(slot.widget, CandlestickWidget):
                     entity_id = slot.widget.config.entity_id
                     if entity_id:
@@ -1359,58 +1233,17 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         if not candlestick_widgets:
             return
 
-        # Get recorder instance
-        try:
-            from homeassistant.components.recorder import get_instance
-        except ImportError:
-            _LOGGER.debug("Recorder not available, candlestick charts will show no data")
+        fetcher = HistoryFetcher(self.hass)
+        if not fetcher.available:
             return
-
-        try:
-            recorder = get_instance(self.hass)
-        except KeyError:
-            _LOGGER.debug("Recorder instance not available")
-            return
-
-        now = dt_util.utcnow()
 
         for entity_id, widget in candlestick_widgets:
-            try:
-                hours = widget.hours
-                start_time = now - timedelta(hours=hours)
-
-                history_states = await recorder.async_add_executor_job(
-                    self._fetch_entity_history,
-                    entity_id,
-                    start_time,
-                    now,
-                )
-
-                if history_states:
-                    timestamped = extract_timestamped_values(history_states)
-
-                    if timestamped:
-                        candles = aggregate_ohlc(
-                            timestamped,
-                            widget.interval_seconds,
-                            widget.candle_count,
-                        )
-                        if candles:
-                            self._candlestick_data[entity_id] = candles
-                            _LOGGER.debug(
-                                "Aggregated %d candles for %s",
-                                len(candles),
-                                entity_id,
-                            )
-                    else:
-                        _LOGGER.debug(
-                            "No numeric timestamped values for %s",
-                            entity_id,
-                        )
-                else:
-                    _LOGGER.debug("No history returned for candlestick %s", entity_id)
-            except Exception as e:
-                _LOGGER.warning("Failed to fetch candlestick history for %s: %s", entity_id, e)
+            candles = await fetcher.fetch_ohlc(
+                entity_id, widget.hours, widget.interval_seconds, widget.candle_count
+            )
+            if candles:
+                self._candlestick_data[entity_id] = candles
+                _LOGGER.debug("Aggregated %d candles for %s", len(candles), entity_id)
 
     async def _async_fetch_weather_forecasts(self) -> None:
         """Pre-fetch forecast data for all weather widgets.

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -6,7 +6,7 @@ import contextlib
 import logging
 import time
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import asyncio
@@ -22,57 +22,29 @@ from .const import (
     BACKOFF_LOG_INTERVAL,
     CONF_DISPLAY_ROTATION,
     CONF_JPEG_QUALITY,
-    CONF_LAYOUT,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
-    CONF_SCREEN_THEME,
-    CONF_SCREENS,
-    CONF_WIDGETS,
     DEFAULT_DISPLAY_ROTATION,
     DEFAULT_JPEG_QUALITY,
     DEFAULT_REFRESH_INTERVAL,
     DEFAULT_SCREEN_CYCLE_INTERVAL,
     DOMAIN,
-    LAYOUT_FULLSCREEN,
-    LAYOUT_GRID_2X2,
-    LAYOUT_GRID_2X3,
-    LAYOUT_GRID_3X2,
-    LAYOUT_GRID_3X3,
-    LAYOUT_HERO,
-    LAYOUT_HERO_BL,
-    LAYOUT_HERO_BR,
-    LAYOUT_HERO_SIMPLE,
-    LAYOUT_HERO_TL,
-    LAYOUT_HERO_TR,
-    LAYOUT_SIDEBAR_LEFT,
-    LAYOUT_SIDEBAR_RIGHT,
-    LAYOUT_SPLIT_H,
-    LAYOUT_SPLIT_H_1_2,
-    LAYOUT_SPLIT_H_2_1,
-    LAYOUT_SPLIT_V,
-    LAYOUT_THREE_COLUMN,
-    LAYOUT_THREE_ROW,
     MAX_BACKOFF_MULTIPLIER,
     MODEL_PRO,
     THEME_WATCHOS,
 )
 from .device import DeviceState, GeekMagicDevice, SpaceInfo
-from .layouts.corner_hero import HeroCornerBL, HeroCornerBR, HeroCornerTL, HeroCornerTR
 from .layouts.fullscreen import FullscreenLayout
-from .layouts.grid import Grid2x2, Grid2x3, Grid3x2, Grid3x3
 from .layouts.hero import HeroLayout
 from .layouts.hero_simple import HeroSimpleLayout
-from .layouts.sidebar import SidebarLeft, SidebarRight
-from .layouts.split import (
-    SplitHorizontal,
-    SplitHorizontal1To2,
-    SplitHorizontal2To1,
-    SplitVertical,
-    ThreeColumnLayout,
-    ThreeRowLayout,
-)
 from .renderer import Renderer
-from .widgets import WIDGET_CLASSES
+from .screen_builder import (
+    CONF_ASSIGNED_VIEWS,
+    LAYOUT_CLASSES,
+    build_screens,
+    migrate_options,
+    screen_name_at,
+)
 from .widgets.base import WidgetConfig
 from .widgets.camera import CameraWidget
 from .widgets.candlestick import (
@@ -95,30 +67,9 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Config key for new global views format
-CONF_ASSIGNED_VIEWS = "assigned_views"
-
-LAYOUT_CLASSES = {
-    LAYOUT_GRID_2X2: Grid2x2,
-    LAYOUT_GRID_2X3: Grid2x3,
-    LAYOUT_GRID_3X2: Grid3x2,
-    LAYOUT_GRID_3X3: Grid3x3,
-    LAYOUT_HERO: HeroLayout,
-    LAYOUT_HERO_SIMPLE: HeroSimpleLayout,
-    LAYOUT_SPLIT_H: SplitHorizontal,
-    LAYOUT_SPLIT_H_1_2: SplitHorizontal1To2,
-    LAYOUT_SPLIT_H_2_1: SplitHorizontal2To1,
-    LAYOUT_SPLIT_V: SplitVertical,
-    LAYOUT_THREE_COLUMN: ThreeColumnLayout,
-    LAYOUT_THREE_ROW: ThreeRowLayout,
-    LAYOUT_SIDEBAR_LEFT: SidebarLeft,
-    LAYOUT_SIDEBAR_RIGHT: SidebarRight,
-    LAYOUT_HERO_TL: HeroCornerTL,
-    LAYOUT_HERO_TR: HeroCornerTR,
-    LAYOUT_HERO_BL: HeroCornerBL,
-    LAYOUT_HERO_BR: HeroCornerBR,
-    LAYOUT_FULLSCREEN: FullscreenLayout,
-}
+# Re-exported for backwards compatibility (websocket and tests import these
+# from coordinator). New code should import from screen_builder directly.
+__all__ = ["CONF_ASSIGNED_VIEWS", "LAYOUT_CLASSES", "GeekMagicCoordinator"]
 
 
 # Binary states that should be converted to 1.0 (on/true)
@@ -187,9 +138,10 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             config_entry: Config entry reference for entity registration
         """
         self.device = device
-        self.options = self._migrate_options(options)
+        self.options = migrate_options(options)
         self.renderer = Renderer()
         self._layouts: list = []  # List of layouts for each screen
+        self._layout_names: list[str] = []  # Names parallel to self._layouts
         self._current_screen: int = 0
         self._last_screen_change: float = time.time()
         self._last_image: bytes | None = None  # PNG bytes for camera preview
@@ -256,103 +208,18 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         # Create welcome layout for when no screens are configured
         self._welcome_layout: Layout | None = None
 
-    def _migrate_options(self, options: dict[str, Any]) -> dict[str, Any]:
-        """Migrate old single-screen options to new multi-screen format.
-
-        Args:
-            options: Original options dictionary
-
-        Returns:
-            Migrated options with screens structure
-        """
-        if CONF_SCREENS in options:
-            return options  # Already in new format
-
-        # Convert old format to new format
-        return {
-            CONF_REFRESH_INTERVAL: options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL),
-            CONF_SCREEN_CYCLE_INTERVAL: DEFAULT_SCREEN_CYCLE_INTERVAL,
-            CONF_SCREENS: [
-                {
-                    "name": "Screen 1",
-                    CONF_LAYOUT: options.get(CONF_LAYOUT, LAYOUT_GRID_2X2),
-                    CONF_WIDGETS: options.get(CONF_WIDGETS, [{"type": "clock", "slot": 0}]),
-                }
-            ],
-        }
-
     def _setup_screens(self) -> None:
-        """Set up all screens with their layouts and widgets.
+        """(Re)build all screens from current options, delegating to screen_builder."""
+        pairs = build_screens(self.options, self._get_store())
+        self._layout_names = [name for name, _ in pairs]
+        self._layouts = [layout for _, layout in pairs]
 
-        Supports two config formats:
-        - New format: assigned_views list referencing global views in store
-        - Legacy format: screens list with inline config (for backward compatibility)
-        """
-        self._layouts = []
-
-        # Check for new format first (global views)
-        assigned_views = self.options.get(CONF_ASSIGNED_VIEWS, [])
-        if assigned_views:
-            self._setup_from_global_views(assigned_views)
-        else:
-            # Fall back to legacy format
-            self._setup_from_legacy_screens()
-
-        # Ensure current screen is valid
         if self._current_screen >= len(self._layouts):
             _LOGGER.debug(
                 "Current screen %d out of range, resetting to 0",
                 self._current_screen,
             )
             self._current_screen = 0
-
-    def _setup_from_global_views(self, view_ids: list[str]) -> None:
-        """Set up layouts from global views in store.
-
-        Args:
-            view_ids: List of view IDs to load
-        """
-        store = self._get_store()
-        if not store:
-            _LOGGER.warning("Store not available, falling back to legacy config")
-            self._setup_from_legacy_screens()
-            return
-
-        _LOGGER.debug("Setting up %d view(s) from global store", len(view_ids))
-
-        for i, view_id in enumerate(view_ids):
-            view_config = store.get_view(view_id)
-            if not view_config:
-                _LOGGER.warning("View %s not found in store, skipping", view_id)
-                continue
-
-            view_name = view_config.get("name", f"View {i + 1}")
-            layout = self._create_layout(view_config)
-            self._layouts.append(layout)
-            _LOGGER.debug(
-                "Created view %d '%s' with layout %s (%d slots)",
-                i,
-                view_name,
-                view_config.get("layout", LAYOUT_GRID_2X2),
-                layout.get_slot_count(),
-            )
-
-    def _setup_from_legacy_screens(self) -> None:
-        """Set up layouts from legacy screens config (backward compatibility)."""
-        screens = self.options.get(CONF_SCREENS, [])
-        _LOGGER.debug("Setting up %d screen(s) from legacy config", len(screens))
-
-        for i, screen_config in enumerate(screens):
-            screen_name = screen_config.get("name", f"Screen {i + 1}")
-            layout = self._create_layout(screen_config)
-            self._layouts.append(layout)
-            _LOGGER.debug(
-                "Created screen %d '%s' with layout %s (%d slots)",
-                i,
-                screen_name,
-                screen_config.get(CONF_LAYOUT, LAYOUT_GRID_2X2),
-                layout.get_slot_count(),
-            )
 
     def _get_store(self) -> GeekMagicStore | None:
         """Get the global view store.
@@ -415,64 +282,6 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         except Exception:
             return 0
 
-    def _create_layout(self, screen_config: dict[str, Any]):
-        """Create a layout from screen configuration.
-
-        Args:
-            screen_config: Screen configuration dictionary
-
-        Returns:
-            Configured layout instance
-        """
-        layout_type = screen_config.get(CONF_LAYOUT, LAYOUT_GRID_2X2)
-        layout_class = LAYOUT_CLASSES.get(layout_type, Grid2x2)
-        layout = layout_class()
-
-        # Set theme on layout
-        theme_name = screen_config.get(CONF_SCREEN_THEME, THEME_WATCHOS)
-        layout.theme = get_theme(theme_name)
-
-        widgets_config = screen_config.get(CONF_WIDGETS, [])
-
-        # If no widgets configured, add default clock widget
-        if not widgets_config:
-            widgets_config = [{"type": "clock", "slot": 0}]
-
-        for widget_config in widgets_config:
-            widget_type = str(widget_config.get("type", "text"))
-            slot = int(widget_config.get("slot", 0))
-
-            if slot >= layout.get_slot_count():
-                continue
-
-            widget_class = WIDGET_CLASSES.get(widget_type)
-            if widget_class is None:
-                continue
-
-            entity_id = widget_config.get("entity_id")
-            label = widget_config.get("label")
-            raw_color = widget_config.get("color")
-            widget_options = widget_config.get("options") or {}
-
-            # Parse color - can be tuple/list of RGB values
-            parsed_color: tuple[int, int, int] | None = None
-            if isinstance(raw_color, list | tuple) and len(raw_color) == 3:
-                parsed_color = (int(raw_color[0]), int(raw_color[1]), int(raw_color[2]))
-
-            config = WidgetConfig(
-                widget_type=widget_type,
-                slot=slot,
-                entity_id=str(entity_id) if entity_id is not None else None,
-                label=str(label) if label is not None else None,
-                color=parsed_color,
-                options=cast("dict[str, Any]", widget_options),
-            )
-
-            widget = widget_class(config)
-            layout.set_widget(slot, widget)
-
-        return layout
-
     @property
     def current_screen(self) -> int:
         """Get current screen index."""
@@ -486,22 +295,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
     @property
     def current_screen_name(self) -> str:
         """Get current screen name."""
-        # Check for new format first
-        assigned_views = self.options.get(CONF_ASSIGNED_VIEWS, [])
-        if assigned_views:
-            if 0 <= self._current_screen < len(assigned_views):
-                store = self._get_store()
-                if store:
-                    view = store.get_view(assigned_views[self._current_screen])
-                    if view:
-                        return view.get("name", f"View {self._current_screen + 1}")
-            return "Unknown"
-
-        # Legacy format
-        screens = self.options.get(CONF_SCREENS, [])
-        if 0 <= self._current_screen < len(screens):
-            return screens[self._current_screen].get("name", f"Screen {self._current_screen + 1}")
-        return "Unknown"
+        return screen_name_at(self.options, self._current_screen, self._get_store())
 
     async def async_set_screen(self, screen_index: int) -> None:
         """Switch to a specific screen.
@@ -553,7 +347,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         Args:
             options: New options dictionary
         """
-        self.options = self._migrate_options(options)
+        self.options = migrate_options(options)
 
         # Update refresh interval
         interval = int(self.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL))

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .connection_backoff import ConnectionBackoff
 from .const import (
     BACKOFF_LOG_INTERVAL,
     CONF_DISPLAY_ROTATION,
@@ -133,16 +134,13 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         self._pre_pause_brightness: int | None = None
 
         # Backoff state for handling offline devices
-        # When device is unreachable, increase update interval exponentially
-        # to reduce log spam and resource usage
-        self._consecutive_failures: int = 0
-        self._device_offline: bool = False
-        self._base_update_interval: int = int(
-            options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL)
+        interval = int(self.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL))
+        self._backoff = ConnectionBackoff(
+            logger=_LOGGER,
+            base_interval_seconds=interval,
+            max_multiplier=MAX_BACKOFF_MULTIPLIER,
+            log_interval=BACKOFF_LOG_INTERVAL,
         )
-
-        # Get refresh interval from options
-        interval = self.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL)
 
         super().__init__(
             hass,
@@ -306,7 +304,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
 
         # Update refresh interval
         interval = int(self.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL))
-        self._base_update_interval = interval
+        self._backoff.base_interval = interval
         self.update_interval = timedelta(seconds=interval)
 
         # Rebuild all screens
@@ -525,31 +523,34 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
 
             # If device was offline, do a lightweight connectivity check first
             # to avoid expensive rendering operations
-            if self._device_offline:
+            if self._backoff.is_offline:
                 try:
                     result = await self.device.test_connection()
                 except Exception as conn_err:
-                    # test_connection itself failed - treat as still offline
-                    self._consecutive_failures += 1
-                    self._apply_backoff()
-                    self._log_offline_status(str(conn_err))
+                    self.update_interval = self._backoff.record_failure()
+                    self._backoff.log_failure(
+                        self.device.host,
+                        str(conn_err),
+                        int(self.update_interval.total_seconds()),
+                    )
                     raise UpdateFailed(f"Device offline: {conn_err}") from conn_err
 
                 if not result.success:
-                    # Still offline - update backoff and raise
-                    self._consecutive_failures += 1
-                    self._apply_backoff()
+                    self.update_interval = self._backoff.record_failure()
                     error_msg = result.message or "Connection failed"
-                    self._log_offline_status(error_msg)
+                    self._backoff.log_failure(
+                        self.device.host,
+                        error_msg,
+                        int(self.update_interval.total_seconds()),
+                    )
                     raise UpdateFailed(f"Device offline: {error_msg}")  # noqa: TRY301
 
-                # Device is back online!
                 _LOGGER.info(
                     "GeekMagic device %s is back online after %d failed attempts",
                     self.device.host,
-                    self._consecutive_failures,
+                    self._backoff.failure_count,
                 )
-                self._reset_backoff()
+                self.update_interval = self._backoff.record_success()
 
             _LOGGER.debug(
                 "Starting display update for screen %d/%d (%s)",
@@ -671,110 +672,11 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             raise
         except Exception as err:
             self._last_update_success = False
-            self._consecutive_failures += 1
-            self._device_offline = True
-            self._apply_backoff()
-            self._log_connection_error(err)
+            self.update_interval = self._backoff.record_failure()
+            self._backoff.log_connection_error(
+                self.device.host, err, int(self.update_interval.total_seconds())
+            )
             raise UpdateFailed(f"Error updating display: {err}") from err
-
-    def _apply_backoff(self) -> None:
-        """Apply exponential backoff to update interval.
-
-        Increases the update interval based on consecutive failures,
-        capped at MAX_BACKOFF_MULTIPLIER times the base interval.
-        """
-        # Calculate backoff: 1, 2, 4, 8, ... up to MAX_BACKOFF_MULTIPLIER
-        multiplier = min(2 ** min(self._consecutive_failures, 10), MAX_BACKOFF_MULTIPLIER)
-        new_interval = self._base_update_interval * multiplier
-        self.update_interval = timedelta(seconds=new_interval)
-        _LOGGER.debug(
-            "Applied backoff: interval=%ds (multiplier=%dx, failures=%d)",
-            new_interval,
-            multiplier,
-            self._consecutive_failures,
-        )
-
-    def _reset_backoff(self) -> None:
-        """Reset backoff state after successful connection."""
-        self._consecutive_failures = 0
-        self._device_offline = False
-        self.update_interval = timedelta(seconds=self._base_update_interval)
-
-    def _log_offline_status(self, message: str) -> None:
-        """Log device offline status with smart verbosity.
-
-        Logs at warning level on first failure and periodically,
-        debug level otherwise to reduce log spam.
-
-        Args:
-            message: Error message to include
-        """
-        if self._consecutive_failures == 1:
-            # First failure - log at warning level with full details
-            _LOGGER.warning(
-                "GeekMagic device %s is offline: %s. Will retry with exponential backoff.",
-                self.device.host,
-                message,
-            )
-        elif self._consecutive_failures % BACKOFF_LOG_INTERVAL == 0:
-            # Periodic summary - log at warning level
-            interval = (
-                int(self.update_interval.total_seconds())
-                if self.update_interval
-                else self._base_update_interval
-            )
-            _LOGGER.warning(
-                "GeekMagic device %s still offline after %d attempts (retry interval: %ds)",
-                self.device.host,
-                self._consecutive_failures,
-                interval,
-            )
-        else:
-            # Subsequent failures - log at debug level only
-            _LOGGER.debug(
-                "GeekMagic device %s offline (attempt %d): %s",
-                self.device.host,
-                self._consecutive_failures,
-                message,
-            )
-
-    def _log_connection_error(self, err: Exception) -> None:
-        """Log connection error with smart verbosity.
-
-        Logs full exception on first failure and periodically,
-        abbreviated message otherwise to reduce log spam.
-
-        Args:
-            err: The exception that occurred
-        """
-        if self._consecutive_failures == 1:
-            # First failure - log at warning level with exception info
-            _LOGGER.warning(
-                "GeekMagic device %s connection failed: %s. Will retry with exponential backoff.",
-                self.device.host,
-                err,
-            )
-        elif self._consecutive_failures % BACKOFF_LOG_INTERVAL == 0:
-            # Periodic summary - log at warning level
-            interval = (
-                int(self.update_interval.total_seconds())
-                if self.update_interval
-                else self._base_update_interval
-            )
-            _LOGGER.warning(
-                "GeekMagic device %s still failing after %d attempts: %s (retry interval: %ds)",
-                self.device.host,
-                self._consecutive_failures,
-                err,
-                interval,
-            )
-        else:
-            # Subsequent failures - log at debug level only
-            _LOGGER.debug(
-                "GeekMagic update failed (attempt %d): %s",
-                self._consecutive_failures,
-                err,
-            )
 
     @property
     def last_image(self) -> bytes | None:

--- a/custom_components/geekmagic/display_state.py
+++ b/custom_components/geekmagic/display_state.py
@@ -1,0 +1,99 @@
+"""Display mode (custom/builtin) and pause/wake state for a GeekMagic device.
+
+Two small state machines that the coordinator used to manage as four
+loose fields:
+
+  - mode: "custom" (integration renders + uploads) vs "builtin" (device
+    handles its own display via its native themes 0-2)
+  - paused: when True, the render/upload cycle is skipped entirely; the
+    device is dimmed to 0 and the pre-pause brightness is remembered so
+    resume can restore it
+
+The invariants that used to live nowhere are now this module's contract:
+- `pre_pause_brightness` is captured exactly once per pause and cleared
+  exactly once per resume.
+- `builtin_theme` is only meaningful when `mode == "builtin"`.
+- `pre_pause_brightness` is private; callers ask for what to restore via
+  `exit_pause()`.
+"""
+
+from __future__ import annotations
+
+
+class DisplayState:
+    """Holds the display-mode + pause state. Pure in-memory, no I/O."""
+
+    def __init__(self) -> None:
+        self._mode: str = "custom"
+        self._builtin_theme: int = 0
+        self._paused: bool = False
+        self._pre_pause_brightness: int | None = None
+
+    # --- mode (custom vs builtin) ---
+
+    @property
+    def mode(self) -> str:
+        """'custom' (integration renders) or 'builtin' (device themes)."""
+        return self._mode
+
+    @property
+    def builtin_theme(self) -> int:
+        """The device theme number (0-2) currently active in builtin mode.
+
+        Value is meaningless when `mode == "custom"`.
+        """
+        return self._builtin_theme
+
+    def set_custom(self) -> None:
+        """Switch to integration-driven rendering."""
+        self._mode = "custom"
+
+    def set_builtin(self, theme: int) -> None:
+        """Switch to a device built-in theme (0-2)."""
+        self._mode = "builtin"
+        self._builtin_theme = theme
+
+    def sync_from_device_theme(self, device_theme: int) -> bool:
+        """Adopt a device-reported builtin theme if we currently think we're custom.
+
+        Returns True if the mode flipped (caller may want to log). Themes
+        ≥ 3 are the integration's own "custom image" mode and don't
+        trigger a flip.
+        """
+        if device_theme < 3 and self._mode == "custom":
+            self._mode = "builtin"
+            self._builtin_theme = device_theme
+            return True
+        return False
+
+    # --- pause / wake ---
+
+    @property
+    def is_paused(self) -> bool:
+        return self._paused
+
+    @property
+    def is_active(self) -> bool:
+        """Inverse of is_paused — convenience for entities."""
+        return not self._paused
+
+    def enter_pause(self, current_brightness: int | None) -> None:
+        """Mark paused and remember the pre-pause brightness for resume.
+
+        Idempotent: re-pausing doesn't overwrite the remembered brightness,
+        so a double-pause + resume still restores the original value.
+        """
+        if not self._paused:
+            self._pre_pause_brightness = current_brightness
+        self._paused = True
+
+    def exit_pause(self) -> int | None:
+        """Mark resumed and return the brightness the caller should restore.
+
+        Returns None if nothing was remembered (e.g. resume without a
+        prior pause).
+        """
+        self._paused = False
+        restore = self._pre_pause_brightness
+        self._pre_pause_brightness = None
+        return restore

--- a/custom_components/geekmagic/history_fetcher.py
+++ b/custom_components/geekmagic/history_fetcher.py
@@ -1,0 +1,158 @@
+"""Fetch numeric / OHLC history from the Home Assistant recorder.
+
+Wraps the recorder's `state_changes_during_period` lookup, the executor-job
+positional-arg workaround, the time-range math, and the numeric / OHLC
+extraction step. Callers ask for "give me numeric history for this entity
+over the last N hours" and don't need to know about the recorder API.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.util import dt as dt_util
+
+from .widgets.candlestick import aggregate_ohlc, extract_timestamped_values
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Binary states that should be converted to 1.0 (on/true)
+BINARY_ON_STATES = frozenset({"on", "true", "open", "home", "unlocked", "playing", "active"})
+# Binary states that should be converted to 0.0 (off/false)
+BINARY_OFF_STATES = frozenset(
+    {"off", "false", "closed", "not_home", "locked", "paused", "idle", "standby"}
+)
+
+
+def extract_numeric_values(history_states: list) -> list[float]:
+    """Extract numeric values from recorder history states.
+
+    Handles both State objects and dicts (from minimal_response=True).
+    Converts on/off-style binary states to 1.0/0.0 so binary_sensor
+    entities can be charted. Unparseable values (unavailable, unknown,
+    text states) are skipped.
+    """
+    values: list[float] = []
+    for state in history_states:
+        try:
+            state_value = state.state if hasattr(state, "state") else state.get("state")
+            if state_value is None:
+                continue
+            try:
+                values.append(float(state_value))
+            except (ValueError, TypeError):
+                state_lower = str(state_value).lower()
+                if state_lower in BINARY_ON_STATES:
+                    values.append(1.0)
+                elif state_lower in BINARY_OFF_STATES:
+                    values.append(0.0)
+        except AttributeError:
+            continue
+    return values
+
+
+class HistoryFetcher:
+    """Resolves the recorder and fetches entity history asynchronously.
+
+    A fetcher whose recorder isn't available (HA without recorder, or
+    during early-startup) becomes a no-op — every method returns an
+    empty list. Callers don't need to special-case absence.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+        self._recorder = self._resolve_recorder()
+
+    def _resolve_recorder(self):
+        """Return the recorder instance, or None if unavailable."""
+        try:
+            from homeassistant.components.recorder import get_instance
+        except ImportError:
+            _LOGGER.debug("Recorder not available")
+            return None
+        try:
+            return get_instance(self.hass)
+        except KeyError:
+            _LOGGER.debug("Recorder instance not available")
+            return None
+
+    @property
+    def available(self) -> bool:
+        return self._recorder is not None
+
+    def _fetch_sync(self, entity_id: str, start: datetime, end: datetime) -> list:
+        """Sync history fetch — must run in the recorder's executor.
+
+        Wraps `state_changes_during_period` so it can be invoked through
+        `recorder.async_add_executor_job`, which only forwards positional
+        arguments but the underlying function has many keyword-only ones.
+        """
+        from homeassistant.components.recorder import history
+
+        result = history.state_changes_during_period(
+            self.hass,
+            start,
+            end,
+            entity_id,
+            include_start_time_state=True,
+            no_attributes=True,
+        )
+        return result.get(entity_id, [])
+
+    async def fetch_numeric(self, entity_id: str, hours: float) -> list[float]:
+        """Fetch numeric history values for `entity_id` over the last `hours`.
+
+        Returns an empty list if the recorder is unavailable, the entity
+        has no history, or no values were parseable as numeric.
+        """
+        if self._recorder is None:
+            return []
+        now = dt_util.utcnow()
+        start = now - timedelta(hours=hours)
+        try:
+            states = await self._recorder.async_add_executor_job(
+                self._fetch_sync, entity_id, start, now
+            )
+        except Exception as err:
+            _LOGGER.warning("Failed to fetch history for %s: %s", entity_id, err)
+            return []
+        return extract_numeric_values(states) if states else []
+
+    async def fetch_ohlc(
+        self,
+        entity_id: str,
+        hours: float,
+        interval_seconds: int,
+        candle_count: int,
+    ) -> list[tuple[float, float, float, float]]:
+        """Fetch and aggregate OHLC candles for `entity_id`.
+
+        Returns an empty list if the recorder is unavailable, the entity
+        has no numeric history in the window, or aggregation produced no
+        candles.
+        """
+        if self._recorder is None:
+            return []
+        now = dt_util.utcnow()
+        start = now - timedelta(hours=hours)
+        try:
+            states = await self._recorder.async_add_executor_job(
+                self._fetch_sync, entity_id, start, now
+            )
+        except Exception as err:
+            _LOGGER.warning("Failed to fetch candlestick history for %s: %s", entity_id, err)
+            return []
+        if not states:
+            return []
+        timestamped = extract_timestamped_values(states)
+        if not timestamped:
+            return []
+        return aggregate_ohlc(timestamped, interval_seconds, candle_count)

--- a/custom_components/geekmagic/history_fetcher.py
+++ b/custom_components/geekmagic/history_fetcher.py
@@ -74,7 +74,7 @@ class HistoryFetcher:
     def _resolve_recorder(self):
         """Return the recorder instance, or None if unavailable."""
         try:
-            from homeassistant.components.recorder import get_instance
+            from homeassistant.components.recorder import get_instance  # noqa: PLC0415
         except ImportError:
             _LOGGER.debug("Recorder not available")
             return None
@@ -95,7 +95,7 @@ class HistoryFetcher:
         `recorder.async_add_executor_job`, which only forwards positional
         arguments but the underlying function has many keyword-only ones.
         """
-        from homeassistant.components.recorder import history
+        from homeassistant.components.recorder import history  # noqa: PLC0415
 
         result = history.state_changes_during_period(
             self.hass,

--- a/custom_components/geekmagic/notification_manager.py
+++ b/custom_components/geekmagic/notification_manager.py
@@ -1,0 +1,155 @@
+"""Active notification subsystem for the GeekMagic display.
+
+Owns the entire lifecycle of a transient on-screen notification:
+- trigger / retrigger (with auto-cancel of any in-flight expiry timer)
+- expiry via HA's event loop (`call_later`) and explicit clear
+- the layout-override decision used by the render loop
+- the message-vs-image-vs-icon layout construction
+
+Single instance per coordinator. Callers (the notify service handler, the
+render loop, the pre-fetch pipeline) ask this module rather than reaching
+into coordinator state.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from .const import THEME_WATCHOS
+from .layouts.fullscreen import FullscreenLayout
+from .layouts.hero_simple import HeroSimpleLayout
+from .widgets.base import WidgetConfig
+from .widgets.camera import CameraWidget
+from .widgets.icon import IconWidget
+from .widgets.text import TextWidget
+from .widgets.theme import get_theme
+
+if TYPE_CHECKING:
+    import asyncio
+    from collections.abc import Awaitable, Callable
+
+    from homeassistant.core import HomeAssistant
+
+    from .layouts.base import Layout
+
+
+DEFAULT_DURATION_SECONDS = 10
+DEFAULT_ICON = "mdi:bell-ring"
+
+
+class NotificationManager:
+    """Holds the active notification (if any) and owns its lifecycle."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        request_refresh: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Build a manager bound to a coordinator's `async_request_refresh`.
+
+        `request_refresh` is invoked on trigger and on auto-expiry so the
+        display picks up the appearance and the disappearance of the
+        notification on the next render cycle.
+        """
+        self._hass = hass
+        self._request_refresh = request_refresh
+        self._data: dict[str, Any] | None = None
+        self._expiry: float = 0
+        self._clear_handle: asyncio.TimerHandle | None = None
+
+    @property
+    def is_active(self) -> bool:
+        """True when a notification should currently be shown."""
+        return self._data is not None and time.time() < self._expiry
+
+    @property
+    def image_source(self) -> str | None:
+        """The image entity/URL the active notification wants displayed.
+
+        Returned so the pre-fetch pipeline knows to download it before
+        the next render cycle. None when there's no notification or the
+        notification has no image.
+        """
+        if not self.is_active or self._data is None:
+            return None
+        source = self._data.get("image")
+        return source if isinstance(source, str) and source else None
+
+    async def trigger(self, data: dict[str, Any]) -> None:
+        """Show a new notification, replacing any in-flight one.
+
+        Cancels and reschedules the auto-clear timer so retriggering
+        before expiry doesn't fire the previous timer mid-way.
+        """
+        duration = data.get("duration", DEFAULT_DURATION_SECONDS)
+        self._data = data
+        self._expiry = time.time() + duration
+
+        if self._clear_handle is not None:
+            self._clear_handle.cancel()
+
+        self._clear_handle = self._hass.loop.call_later(duration, self._on_expiry)
+
+        await self._request_refresh()
+
+    def _on_expiry(self) -> None:
+        """Auto-clear callback fired by the HA event loop."""
+        self._expiry = 0
+        self._data = None
+        self._clear_handle = None
+        # Fire-and-forget — we're inside a sync callback on the loop.
+        self._hass.async_create_task(self._request_refresh())
+
+    def build_layout(self) -> Layout | None:
+        """Return the layout to render right now, or None to use the screen.
+
+        Two shapes:
+          - message present → `HeroSimpleLayout` (hero icon/image, footer text)
+          - message absent → `FullscreenLayout` (icon/image only)
+        """
+        if not self.is_active or self._data is None:
+            return None
+        data = self._data
+        message = data.get("message")
+        theme = get_theme(data.get("theme", THEME_WATCHOS))
+        image_url = data.get("image")
+        icon = data.get("icon", DEFAULT_ICON)
+
+        if not message:
+            layout = FullscreenLayout()
+            layout.theme = theme
+            layout.set_widget(0, _hero_visual(image_url, icon, show_panel=False))
+            return layout
+
+        layout = HeroSimpleLayout()
+        layout.theme = theme
+        layout.set_widget(0, _hero_visual(image_url, icon, show_panel=True))
+        layout.set_widget(
+            1,
+            TextWidget(
+                WidgetConfig(
+                    widget_type="text",
+                    slot=1,
+                    options={"text": message, "size": "medium", "align": "center"},
+                )
+            ),
+        )
+        return layout
+
+
+def _hero_visual(image_url: str | None, icon: str, *, show_panel: bool):
+    """Hero slot widget: image if provided, otherwise the icon."""
+    if image_url:
+        return CameraWidget(
+            WidgetConfig(
+                widget_type="camera",
+                slot=0,
+                entity_id=image_url,
+                options={"fit": "contain"},
+            )
+        )
+    options: dict[str, Any] = {"icon": icon, "size": "huge"}
+    if not show_panel:
+        options["show_panel"] = False
+    return IconWidget(WidgetConfig(widget_type="icon", slot=0, options=options))

--- a/custom_components/geekmagic/notification_manager.py
+++ b/custom_components/geekmagic/notification_manager.py
@@ -27,7 +27,7 @@ from .widgets.theme import get_theme
 
 if TYPE_CHECKING:
     import asyncio
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Callable, Coroutine
 
     from homeassistant.core import HomeAssistant
 
@@ -44,7 +44,7 @@ class NotificationManager:
     def __init__(
         self,
         hass: HomeAssistant,
-        request_refresh: Callable[[], Awaitable[None]],
+        request_refresh: Callable[[], Coroutine[None, None, None]],
     ) -> None:
         """Build a manager bound to a coordinator's `async_request_refresh`.
 

--- a/custom_components/geekmagic/preview.py
+++ b/custom_components/geekmagic/preview.py
@@ -4,68 +4,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
-from .const import (
-    CONF_LAYOUT,
-    CONF_WIDGETS,
-    LAYOUT_GRID_2X2,
-    LAYOUT_GRID_2X3,
-    LAYOUT_GRID_3X2,
-    LAYOUT_GRID_3X3,
-    LAYOUT_HERO,
-    LAYOUT_HERO_BL,
-    LAYOUT_HERO_BR,
-    LAYOUT_HERO_TL,
-    LAYOUT_HERO_TR,
-    LAYOUT_SIDEBAR_LEFT,
-    LAYOUT_SIDEBAR_RIGHT,
-    LAYOUT_SPLIT_H,
-    LAYOUT_SPLIT_H_1_2,
-    LAYOUT_SPLIT_H_2_1,
-    LAYOUT_SPLIT_V,
-    LAYOUT_THREE_COLUMN,
-    LAYOUT_THREE_ROW,
-)
-from .layouts.corner_hero import HeroCornerBL, HeroCornerBR, HeroCornerTL, HeroCornerTR
-from .layouts.grid import Grid2x2, Grid2x3, Grid3x2, Grid3x3
-from .layouts.hero import HeroLayout
-from .layouts.sidebar import SidebarLeft, SidebarRight
-from .layouts.split import (
-    SplitHorizontal,
-    SplitHorizontal1To2,
-    SplitHorizontal2To1,
-    SplitVertical,
-    ThreeColumnLayout,
-    ThreeRowLayout,
-)
+from .const import CONF_LAYOUT, CONF_WIDGETS, LAYOUT_GRID_2X2
 from .renderer import Renderer
-from .widgets import WIDGET_CLASSES
-from .widgets.base import WidgetConfig
+from .screen_builder import build_layout
 from .widgets.state import EntityState, WidgetState
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-
-LAYOUT_CLASSES = {
-    LAYOUT_GRID_2X2: Grid2x2,
-    LAYOUT_GRID_2X3: Grid2x3,
-    LAYOUT_GRID_3X2: Grid3x2,
-    LAYOUT_GRID_3X3: Grid3x3,
-    LAYOUT_HERO: HeroLayout,
-    LAYOUT_SPLIT_H: SplitHorizontal,
-    LAYOUT_SPLIT_H_1_2: SplitHorizontal1To2,
-    LAYOUT_SPLIT_H_2_1: SplitHorizontal2To1,
-    LAYOUT_SPLIT_V: SplitVertical,
-    LAYOUT_THREE_COLUMN: ThreeColumnLayout,
-    LAYOUT_THREE_ROW: ThreeRowLayout,
-    LAYOUT_SIDEBAR_LEFT: SidebarLeft,
-    LAYOUT_SIDEBAR_RIGHT: SidebarRight,
-    LAYOUT_HERO_TL: HeroCornerTL,
-    LAYOUT_HERO_TR: HeroCornerTR,
-    LAYOUT_HERO_BL: HeroCornerBL,
-    LAYOUT_HERO_BR: HeroCornerBR,
-}
 
 
 @dataclass
@@ -341,53 +288,22 @@ def render_preview(
     for widget_config in widgets_config:
         _set_mock_state_for_widget(mock, widget_config)
 
-    # Create renderer and layout
-    renderer = Renderer()
-    layout_class = LAYOUT_CLASSES.get(layout_type, Grid2x2)
-    layout = layout_class()
+    # Build the layout (with theme + widgets wired) using the same
+    # construction path as production rendering.
+    layout = build_layout({CONF_LAYOUT: layout_type, CONF_WIDGETS: widgets_config})
 
-    # Build widget_states dict for all slots
+    # Mock widget states keyed by slot — only for widgets that were actually
+    # placed into the layout (build_layout silently drops out-of-range and
+    # unknown-type widgets).
+    placed_slots = {slot.index for slot in layout.slots if slot.widget is not None}
     widget_states: dict[int, WidgetState] = {}
-
-    # Create and assign widgets
     for widget_config in widgets_config:
-        widget_type = str(widget_config.get("type", "text"))
         slot = int(widget_config.get("slot", 0))
+        if slot in placed_slots:
+            widget_states[slot] = _build_widget_state_for_preview(widget_config, mock)
 
-        if slot >= layout.get_slot_count():
-            continue
-
-        widget_class = WIDGET_CLASSES.get(widget_type)
-        if widget_class is None:
-            continue
-
-        entity_id = widget_config.get("entity_id")
-        label = widget_config.get("label")
-        raw_color = widget_config.get("color")
-        widget_options = widget_config.get("options") or {}
-
-        # Parse color
-        parsed_color: tuple[int, int, int] | None = None
-        if isinstance(raw_color, list | tuple) and len(raw_color) == 3:
-            parsed_color = (int(raw_color[0]), int(raw_color[1]), int(raw_color[2]))
-
-        config = WidgetConfig(
-            widget_type=widget_type,
-            slot=slot,
-            entity_id=str(entity_id) if entity_id is not None else None,
-            label=str(label) if label is not None else None,
-            color=parsed_color,
-            options=cast("dict[str, Any]", widget_options),
-        )
-
-        widget = widget_class(config)
-        layout.set_widget(slot, widget)
-
-        # Build widget state for this slot
-        widget_states[slot] = _build_widget_state_for_preview(widget_config, mock)
-
-    # Render to image
-    img, draw = renderer.create_canvas()
+    renderer = Renderer()
+    img, draw = renderer.create_canvas(background=layout.theme.background)
     layout.render(renderer, draw, widget_states)
 
     return renderer.to_png(img)

--- a/custom_components/geekmagic/render_data_pipeline.py
+++ b/custom_components/geekmagic/render_data_pipeline.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from aiohttp import ClientTimeout
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
@@ -32,6 +33,10 @@ if TYPE_CHECKING:
     from .layouts.base import Layout
 
 _LOGGER = logging.getLogger(__name__)
+
+# 10s upper bound on any single image download — keeps a slow camera or
+# stalled media-proxy connection from blocking the whole pre-fetch step.
+_IMAGE_FETCH_TIMEOUT = ClientTimeout(total=10)
 
 
 class RenderDataPipeline:
@@ -137,7 +142,7 @@ class RenderDataPipeline:
         full_url = f"{base_url.rstrip('/')}/{image_url.lstrip('/')}"
         session = async_get_clientsession(self._hass)
         try:
-            async with session.get(full_url, timeout=10) as response:
+            async with session.get(full_url, timeout=_IMAGE_FETCH_TIMEOUT) as response:
                 if response.status == 200:
                     image_data = await response.read()
                     self._camera_images[source] = image_data
@@ -182,7 +187,7 @@ class RenderDataPipeline:
             image_url = f"{base_url.rstrip('/')}/{entity_picture.lstrip('/')}"
             session = async_get_clientsession(self._hass)
             try:
-                async with session.get(image_url, timeout=10) as response:
+                async with session.get(image_url, timeout=_IMAGE_FETCH_TIMEOUT) as response:
                     if response.status == 200:
                         image_data = await response.read()
                         self._media_images[entity_id] = image_data
@@ -271,7 +276,14 @@ class RenderDataPipeline:
                 continue
 
             forecast_response = response.get(entity_id) if isinstance(response, dict) else None
-            if isinstance(forecast_response, dict):
-                forecast = forecast_response.get("forecast", [])
-                self._weather_forecasts[entity_id] = forecast
-                _LOGGER.debug("Fetched %d forecast days for %s", len(forecast), entity_id)
+            if not isinstance(forecast_response, dict):
+                continue
+            raw_forecast = forecast_response.get("forecast", [])
+            # Coerce to list[dict] — HA's response is typed as JsonValueType.
+            # We trust the documented shape but defend against an unexpected
+            # one rather than letting a stray int/str poison the cache.
+            if not isinstance(raw_forecast, list):
+                continue
+            forecast: list[dict[str, Any]] = [d for d in raw_forecast if isinstance(d, dict)]
+            self._weather_forecasts[entity_id] = forecast
+            _LOGGER.debug("Fetched %d forecast days for %s", len(forecast), entity_id)

--- a/custom_components/geekmagic/render_data_pipeline.py
+++ b/custom_components/geekmagic/render_data_pipeline.py
@@ -1,0 +1,277 @@
+"""Pre-fetch every piece of async data a layout's widgets need before render.
+
+Owns the five caches (camera images, media album art, chart history,
+candlestick OHLC, weather forecasts) and the five fetcher methods that
+populate them. Single entry point — `prefetch(layout, image_source)` —
+hands callers back a `PrefetchedData` ready for `build_widget_states`.
+
+The coordinator (production) and the websocket preview (already passes
+its own caches) are the two callers. New pre-fetchable widget types add a
+case here; the coordinator's update loop doesn't change.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.network import NoURLAvailableError, get_url
+
+from .history_fetcher import HistoryFetcher
+from .widget_state_builder import PrefetchedData
+from .widgets.camera import CameraWidget
+from .widgets.candlestick import CandlestickWidget
+from .widgets.chart import ChartWidget
+from .widgets.media import MediaWidget
+from .widgets.weather import WeatherWidget
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .layouts.base import Layout
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RenderDataPipeline:
+    """Pre-fetches everything `build_widget_states` will need for a layout."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
+        # Caches persist across update cycles; widgets that don't repopulate
+        # their entry simply see the stale value, matching the original
+        # coordinator behaviour. The exception is media album art, which is
+        # cleared per-cycle when the entity_picture goes away.
+        self._camera_images: dict[str, bytes] = {}
+        self._media_images: dict[str, bytes] = {}
+        self._chart_history: dict[str, list[float]] = {}
+        self._candlestick_data: dict[str, list[tuple[float, float, float, float]]] = {}
+        self._weather_forecasts: dict[str, list[dict[str, Any]]] = {}
+
+    # Coordinator surface for entities/callers that want raw cache access
+    # (e.g. the camera preview entity reads back a fetched image).
+
+    def get_camera_image(self, entity_id: str) -> bytes | None:
+        return self._camera_images.get(entity_id)
+
+    async def prefetch(
+        self,
+        layout: Layout,
+        image_source: str | None = None,
+    ) -> PrefetchedData:
+        """Run all relevant pre-fetches for `layout`, return the result bundle.
+
+        `image_source` is an optional extra entity id (typically the active
+        notification's image) added to the camera/media-image fetch set.
+        Each fan-out is gated on the layout actually containing a widget
+        of that type, so empty layouts pay no recorder/HTTP cost.
+        """
+        await self._fetch_camera_and_url_images(layout, image_source)
+        await self._fetch_media_images(layout)
+        await self._fetch_chart_history(layout)
+        await self._fetch_candlestick_history(layout)
+        await self._fetch_weather_forecasts(layout)
+        return PrefetchedData(
+            camera_images=self._camera_images,
+            media_images=self._media_images,
+            chart_history=self._chart_history,
+            candlestick_data=self._candlestick_data,
+            weather_forecasts=self._weather_forecasts,
+        )
+
+    # --- camera / image / notification ---
+
+    async def _fetch_camera_and_url_images(self, layout: Layout, image_source: str | None) -> None:
+        camera_entity_ids: set[str] = set()
+        other_entity_ids: set[str] = set()
+
+        for slot in layout.slots:
+            if slot.widget and isinstance(slot.widget, CameraWidget):
+                entity_id = slot.widget.config.entity_id
+                if entity_id:
+                    (
+                        camera_entity_ids if entity_id.startswith("camera.") else other_entity_ids
+                    ).add(entity_id)
+
+        if image_source:
+            (camera_entity_ids if image_source.startswith("camera.") else other_entity_ids).add(
+                image_source
+            )
+
+        # Non-camera entities first — they populate the same cache and may
+        # be overwritten if a camera widget has the same id (unlikely).
+        for entity_id in other_entity_ids:
+            await self._fetch_url_image_to_cache(entity_id)
+
+        from homeassistant.components.camera import async_get_image  # noqa: PLC0415
+
+        for entity_id in camera_entity_ids:
+            try:
+                image = await async_get_image(self._hass, entity_id)
+            except Exception as e:
+                _LOGGER.debug("Failed to fetch camera image for %s: %s", entity_id, e)
+                continue
+            if image and image.content:
+                self._camera_images[entity_id] = image.content
+                _LOGGER.debug(
+                    "Fetched camera image for %s: %d bytes", entity_id, len(image.content)
+                )
+
+    async def _fetch_url_image_to_cache(self, source: str) -> None:
+        """Fetch entity_picture for an entity (image./media_player./etc.) and cache it."""
+        image_url = None
+        state = self._hass.states.get(source)
+        if state:
+            image_url = state.attributes.get("entity_picture")
+
+        if not image_url or not image_url.startswith("/"):
+            return
+
+        try:
+            base_url = get_url(self._hass)
+        except NoURLAvailableError:
+            _LOGGER.debug("No base URL available for entity picture fetch")
+            return
+
+        full_url = f"{base_url.rstrip('/')}/{image_url.lstrip('/')}"
+        session = async_get_clientsession(self._hass)
+        try:
+            async with session.get(full_url, timeout=10) as response:
+                if response.status == 200:
+                    image_data = await response.read()
+                    self._camera_images[source] = image_data
+                    _LOGGER.debug(
+                        "Fetched image for notification from %s: %d bytes", source, len(image_data)
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Failed to fetch notification image from %s: HTTP %d",
+                        source,
+                        response.status,
+                    )
+        except Exception as e:
+            _LOGGER.debug("Failed to fetch notification image from %s: %s", source, e)
+
+    # --- media album art ---
+
+    async def _fetch_media_images(self, layout: Layout) -> None:
+        media_entity_ids: set[str] = {
+            slot.widget.config.entity_id
+            for slot in layout.slots
+            if slot.widget and isinstance(slot.widget, MediaWidget) and slot.widget.config.entity_id
+        }
+        if not media_entity_ids:
+            return
+
+        for entity_id in media_entity_ids:
+            state = self._hass.states.get(entity_id)
+            if state is None:
+                continue
+            entity_picture = state.attributes.get("entity_picture")
+            if not entity_picture or not entity_picture.startswith("/"):
+                # Clear any cached image if no internal picture available
+                self._media_images.pop(entity_id, None)
+                continue
+
+            try:
+                base_url = get_url(self._hass)
+            except NoURLAvailableError:
+                continue
+
+            image_url = f"{base_url.rstrip('/')}/{entity_picture.lstrip('/')}"
+            session = async_get_clientsession(self._hass)
+            try:
+                async with session.get(image_url, timeout=10) as response:
+                    if response.status == 200:
+                        image_data = await response.read()
+                        self._media_images[entity_id] = image_data
+                        _LOGGER.debug(
+                            "Fetched album art for %s: %d bytes", entity_id, len(image_data)
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "Failed to fetch album art for %s: HTTP %d",
+                            entity_id,
+                            response.status,
+                        )
+            except Exception as e:
+                _LOGGER.debug("Failed to fetch album art for %s: %s", entity_id, e)
+
+    # --- chart / candlestick history ---
+
+    async def _fetch_chart_history(self, layout: Layout) -> None:
+        widgets: list[tuple[str, ChartWidget]] = []
+        for slot in layout.slots:
+            if slot.widget and isinstance(slot.widget, ChartWidget):
+                entity_id = slot.widget.config.entity_id
+                if entity_id:
+                    widgets.append((entity_id, slot.widget))
+        if not widgets:
+            return
+
+        fetcher = HistoryFetcher(self._hass)
+        if not fetcher.available:
+            return
+
+        for entity_id, widget in widgets:
+            values = await fetcher.fetch_numeric(entity_id, widget.hours)
+            if values:
+                self._chart_history[entity_id] = values
+                _LOGGER.debug("Fetched %d history points for %s", len(values), entity_id)
+
+    async def _fetch_candlestick_history(self, layout: Layout) -> None:
+        widgets: list[tuple[str, CandlestickWidget]] = []
+        for slot in layout.slots:
+            if slot.widget and isinstance(slot.widget, CandlestickWidget):
+                entity_id = slot.widget.config.entity_id
+                if entity_id:
+                    widgets.append((entity_id, slot.widget))
+        if not widgets:
+            return
+
+        fetcher = HistoryFetcher(self._hass)
+        if not fetcher.available:
+            return
+
+        for entity_id, widget in widgets:
+            candles = await fetcher.fetch_ohlc(
+                entity_id, widget.hours, widget.interval_seconds, widget.candle_count
+            )
+            if candles:
+                self._candlestick_data[entity_id] = candles
+                _LOGGER.debug("Aggregated %d candles for %s", len(candles), entity_id)
+
+    # --- weather forecasts ---
+
+    async def _fetch_weather_forecasts(self, layout: Layout) -> None:
+        """Pre-fetch daily forecasts via `weather.get_forecasts` (HA 2024.3+)."""
+        weather_entity_ids: set[str] = {
+            slot.widget.config.entity_id
+            for slot in layout.slots
+            if slot.widget
+            and isinstance(slot.widget, WeatherWidget)
+            and slot.widget.config.entity_id
+        }
+        if not weather_entity_ids:
+            return
+
+        for entity_id in weather_entity_ids:
+            try:
+                response = await self._hass.services.async_call(
+                    "weather",
+                    "get_forecasts",
+                    {"type": "daily"},
+                    target={"entity_id": entity_id},
+                    blocking=True,
+                    return_response=True,
+                )
+            except Exception as e:
+                _LOGGER.debug("Failed to fetch forecast for %s: %s", entity_id, e)
+                continue
+
+            forecast_response = response.get(entity_id) if isinstance(response, dict) else None
+            if isinstance(forecast_response, dict):
+                forecast = forecast_response.get("forecast", [])
+                self._weather_forecasts[entity_id] = forecast
+                _LOGGER.debug("Fetched %d forecast days for %s", len(forecast), entity_id)

--- a/custom_components/geekmagic/screen_builder.py
+++ b/custom_components/geekmagic/screen_builder.py
@@ -1,0 +1,249 @@
+"""Build Layout + Widget trees from a coordinator's options or a raw view config.
+
+Single source of truth for:
+- the layout-type → Layout-class registry
+- the legacy → new options format migration
+- the two-format read (assigned_views via store, or inline screens)
+- per-widget instantiation (registry lookup, color coercion, default widget)
+- per-view theme resolution
+
+Callers (coordinator, websocket preview, configuration preview) hand in a
+config dict; they don't need to know which format it is, what the registries
+are, or how widgets get wired into slots.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from .const import (
+    CONF_LAYOUT,
+    CONF_REFRESH_INTERVAL,
+    CONF_SCREEN_CYCLE_INTERVAL,
+    CONF_SCREEN_THEME,
+    CONF_SCREENS,
+    CONF_WIDGETS,
+    DEFAULT_REFRESH_INTERVAL,
+    DEFAULT_SCREEN_CYCLE_INTERVAL,
+    LAYOUT_FULLSCREEN,
+    LAYOUT_GRID_2X2,
+    LAYOUT_GRID_2X3,
+    LAYOUT_GRID_3X2,
+    LAYOUT_GRID_3X3,
+    LAYOUT_HERO,
+    LAYOUT_HERO_BL,
+    LAYOUT_HERO_BR,
+    LAYOUT_HERO_SIMPLE,
+    LAYOUT_HERO_TL,
+    LAYOUT_HERO_TR,
+    LAYOUT_SIDEBAR_LEFT,
+    LAYOUT_SIDEBAR_RIGHT,
+    LAYOUT_SPLIT_H,
+    LAYOUT_SPLIT_H_1_2,
+    LAYOUT_SPLIT_H_2_1,
+    LAYOUT_SPLIT_V,
+    LAYOUT_THREE_COLUMN,
+    LAYOUT_THREE_ROW,
+    THEME_WATCHOS,
+)
+from .layouts.corner_hero import HeroCornerBL, HeroCornerBR, HeroCornerTL, HeroCornerTR
+from .layouts.fullscreen import FullscreenLayout
+from .layouts.grid import Grid2x2, Grid2x3, Grid3x2, Grid3x3
+from .layouts.hero import HeroLayout
+from .layouts.hero_simple import HeroSimpleLayout
+from .layouts.sidebar import SidebarLeft, SidebarRight
+from .layouts.split import (
+    SplitHorizontal,
+    SplitHorizontal1To2,
+    SplitHorizontal2To1,
+    SplitVertical,
+    ThreeColumnLayout,
+    ThreeRowLayout,
+)
+from .widgets import WIDGET_CLASSES
+from .widgets.base import WidgetConfig
+from .widgets.theme import get_theme
+
+if TYPE_CHECKING:
+    from .layouts.base import Layout
+
+_LOGGER = logging.getLogger(__name__)
+
+# Config key for new global views format
+CONF_ASSIGNED_VIEWS = "assigned_views"
+
+
+LAYOUT_CLASSES: dict[str, type[Layout]] = {
+    LAYOUT_GRID_2X2: Grid2x2,
+    LAYOUT_GRID_2X3: Grid2x3,
+    LAYOUT_GRID_3X2: Grid3x2,
+    LAYOUT_GRID_3X3: Grid3x3,
+    LAYOUT_HERO: HeroLayout,
+    LAYOUT_HERO_SIMPLE: HeroSimpleLayout,
+    LAYOUT_SPLIT_H: SplitHorizontal,
+    LAYOUT_SPLIT_H_1_2: SplitHorizontal1To2,
+    LAYOUT_SPLIT_H_2_1: SplitHorizontal2To1,
+    LAYOUT_SPLIT_V: SplitVertical,
+    LAYOUT_THREE_COLUMN: ThreeColumnLayout,
+    LAYOUT_THREE_ROW: ThreeRowLayout,
+    LAYOUT_SIDEBAR_LEFT: SidebarLeft,
+    LAYOUT_SIDEBAR_RIGHT: SidebarRight,
+    LAYOUT_HERO_TL: HeroCornerTL,
+    LAYOUT_HERO_TR: HeroCornerTR,
+    LAYOUT_HERO_BL: HeroCornerBL,
+    LAYOUT_HERO_BR: HeroCornerBR,
+    LAYOUT_FULLSCREEN: FullscreenLayout,
+}
+
+
+def migrate_options(options: dict[str, Any]) -> dict[str, Any]:
+    """Migrate legacy single-screen options to the multi-screen format.
+
+    Idempotent: options already in new format are returned unchanged.
+    """
+    if CONF_SCREENS in options:
+        return options
+
+    return {
+        CONF_REFRESH_INTERVAL: options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL),
+        CONF_SCREEN_CYCLE_INTERVAL: DEFAULT_SCREEN_CYCLE_INTERVAL,
+        CONF_SCREENS: [
+            {
+                "name": "Screen 1",
+                CONF_LAYOUT: options.get(CONF_LAYOUT, LAYOUT_GRID_2X2),
+                CONF_WIDGETS: options.get(CONF_WIDGETS, [{"type": "clock", "slot": 0}]),
+            }
+        ],
+    }
+
+
+def build_layout(view_config: dict[str, Any]) -> Layout:
+    """Build one Layout (with theme + widgets wired into slots) from a view config.
+
+    A view config is the dict shape used by both inline `screens` entries and
+    entries in the global view store: `{layout, theme, widgets, name}`.
+    """
+    layout_type = view_config.get(CONF_LAYOUT, LAYOUT_GRID_2X2)
+    layout_class = LAYOUT_CLASSES.get(layout_type, Grid2x2)
+    layout = layout_class()
+
+    theme_name = view_config.get(CONF_SCREEN_THEME, THEME_WATCHOS)
+    layout.theme = get_theme(theme_name)
+
+    widgets_config = view_config.get(CONF_WIDGETS, []) or [{"type": "clock", "slot": 0}]
+
+    for widget_config in widgets_config:
+        widget_type = str(widget_config.get("type", "text"))
+        slot = int(widget_config.get("slot", 0))
+
+        if slot >= layout.get_slot_count():
+            continue
+
+        widget_class = WIDGET_CLASSES.get(widget_type)
+        if widget_class is None:
+            continue
+
+        entity_id = widget_config.get("entity_id")
+        label = widget_config.get("label")
+        raw_color = widget_config.get("color")
+        widget_options = widget_config.get("options") or {}
+
+        parsed_color: tuple[int, int, int] | None = None
+        if isinstance(raw_color, list | tuple) and len(raw_color) == 3:
+            parsed_color = (int(raw_color[0]), int(raw_color[1]), int(raw_color[2]))
+
+        config = WidgetConfig(
+            widget_type=widget_type,
+            slot=slot,
+            entity_id=str(entity_id) if entity_id is not None else None,
+            label=str(label) if label is not None else None,
+            color=parsed_color,
+            options=cast("dict[str, Any]", widget_options),
+        )
+        layout.set_widget(slot, widget_class(config))
+
+    return layout
+
+
+def build_screens(
+    options: dict[str, Any],
+    store: Any,
+) -> list[tuple[str, Layout]]:
+    """Build (name, Layout) pairs for every screen described by options.
+
+    Handles both formats:
+      - new: `assigned_views: [view_id, ...]` resolved via `store`
+      - legacy: `screens: [{name, layout, widgets, ...}]` inline
+
+    Missing views are skipped with a warning. If the new format is requested
+    but no store is available, falls back to the legacy format.
+    """
+    assigned_views = options.get(CONF_ASSIGNED_VIEWS, [])
+    if assigned_views:
+        if store is None:
+            _LOGGER.warning("Store not available, falling back to legacy config")
+            return _build_legacy_screens(options)
+        return _build_from_global_views(assigned_views, store)
+    return _build_legacy_screens(options)
+
+
+def _build_from_global_views(view_ids: list[str], store: Any) -> list[tuple[str, Layout]]:
+    """Resolve view IDs against the store and build their layouts."""
+    _LOGGER.debug("Setting up %d view(s) from global store", len(view_ids))
+    results: list[tuple[str, Layout]] = []
+    for i, view_id in enumerate(view_ids):
+        view_config = store.get_view(view_id)
+        if not view_config:
+            _LOGGER.warning("View %s not found in store, skipping", view_id)
+            continue
+        name = view_config.get("name", f"View {i + 1}")
+        layout = build_layout(view_config)
+        results.append((name, layout))
+        _LOGGER.debug(
+            "Created view %d '%s' with layout %s (%d slots)",
+            i,
+            name,
+            view_config.get(CONF_LAYOUT, LAYOUT_GRID_2X2),
+            layout.get_slot_count(),
+        )
+    return results
+
+
+def _build_legacy_screens(options: dict[str, Any]) -> list[tuple[str, Layout]]:
+    """Build layouts from inline `screens` entries."""
+    screens = options.get(CONF_SCREENS, [])
+    _LOGGER.debug("Setting up %d screen(s) from legacy config", len(screens))
+    results: list[tuple[str, Layout]] = []
+    for i, screen_config in enumerate(screens):
+        name = screen_config.get("name", f"Screen {i + 1}")
+        layout = build_layout(screen_config)
+        results.append((name, layout))
+        _LOGGER.debug(
+            "Created screen %d '%s' with layout %s (%d slots)",
+            i,
+            name,
+            screen_config.get(CONF_LAYOUT, LAYOUT_GRID_2X2),
+            layout.get_slot_count(),
+        )
+    return results
+
+
+def screen_name_at(
+    options: dict[str, Any],
+    index: int,
+    store: Any,
+) -> str:
+    """Return the configured name of the screen at `index`, or 'Unknown'."""
+    assigned_views = options.get(CONF_ASSIGNED_VIEWS, [])
+    if assigned_views:
+        if 0 <= index < len(assigned_views) and store is not None:
+            view = store.get_view(assigned_views[index])
+            if view:
+                return view.get("name", f"View {index + 1}")
+        return "Unknown"
+
+    screens = options.get(CONF_SCREENS, [])
+    if 0 <= index < len(screens):
+        return screens[index].get("name", f"Screen {index + 1}")
+    return "Unknown"

--- a/custom_components/geekmagic/websocket.py
+++ b/custom_components/geekmagic/websocket.py
@@ -465,7 +465,11 @@ async def ws_preview_render(
                         response.get(entity_id) if isinstance(response, dict) else None
                     )
                     if isinstance(forecast_response, dict):
-                        weather_forecasts[entity_id] = forecast_response.get("forecast", [])
+                        raw = forecast_response.get("forecast", [])
+                        if isinstance(raw, list):
+                            weather_forecasts[entity_id] = [
+                                d for d in raw if isinstance(d, dict)
+                            ]
                 except Exception as err:
                     _LOGGER.debug("Failed to fetch forecast for %s: %s", entity_id, err)
 

--- a/custom_components/geekmagic/websocket.py
+++ b/custom_components/geekmagic/websocket.py
@@ -8,14 +8,13 @@ from __future__ import annotations
 import base64
 import contextlib
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_REFRESH_INTERVAL,
@@ -391,48 +390,6 @@ async def ws_devices_settings(
 # =============================================================================
 
 
-def _fetch_entity_history(
-    hass: HomeAssistant, entity_id: str, start: datetime, end: datetime
-) -> list:
-    """Fetch history for an entity (sync, runs in executor).
-
-    Args:
-        hass: Home Assistant instance
-        entity_id: Entity ID to fetch history for
-        start: Start time (datetime)
-        end: End time (datetime)
-
-    Returns:
-        List of State objects for the entity
-    """
-    from homeassistant.components.recorder import history
-
-    result = history.state_changes_during_period(
-        hass,
-        start,
-        end,
-        entity_id,
-        include_start_time_state=True,
-        no_attributes=True,
-    )
-    return result.get(entity_id, [])
-
-
-def _extract_numeric_values(history_states: list) -> list[float]:
-    """Extract numeric values from recorder history states.
-
-    Args:
-        history_states: List of State objects or dicts from recorder
-
-    Returns:
-        List of numeric float values
-    """
-    # Import the shared function from coordinator
-    from .coordinator import extract_numeric_values
-
-    return extract_numeric_values(history_states)
-
-
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "geekmagic/preview/render",
@@ -449,97 +406,46 @@ async def ws_preview_render(
     view_config = msg["view_config"]
 
     # Import here to avoid circular imports
+    from .history_fetcher import HistoryFetcher
     from .screen_builder import build_layout
+    from .widgets.candlestick import INTERVAL_TO_SECONDS
 
-    # Pre-fetch history for chart widgets
+    fetcher = HistoryFetcher(hass)
+
     chart_history: dict[str, list[float]] = {}
-
-    try:
-        from homeassistant.components.recorder import get_instance
-
-        recorder = get_instance(hass)
-        now = dt_util.utcnow()
-
-        for widget_data in view_config.get("widgets", []):
-            if widget_data.get("type") == "chart":
-                entity_id = widget_data.get("entity_id")
-                if entity_id:
-                    # Get period from widget options (default 24 hours)
-                    options = widget_data.get("options", {})
-                    period = options.get("period", "24 hours")
-
-                    # Convert period to hours
-                    period_hours = {
-                        "5 min": 5 / 60,
-                        "15 min": 15 / 60,
-                        "1 hour": 1,
-                        "6 hours": 6,
-                        "24 hours": 24,
-                    }.get(period, 24)
-
-                    start_time = now - timedelta(hours=period_hours)
-
-                    # Fetch history in executor
-                    history_states = await recorder.async_add_executor_job(
-                        _fetch_entity_history,
-                        hass,
-                        entity_id,
-                        start_time,
-                        now,
-                    )
-
-                    if history_states:
-                        values = _extract_numeric_values(history_states)
-                        if values:
-                            chart_history[entity_id] = values
-    except (ImportError, KeyError):
-        # Recorder not available, charts will show no data
-        pass
-
-    # Pre-fetch history for candlestick widgets
     candlestick_data: dict[str, list[tuple[float, float, float, float]]] = {}
-    try:
-        from homeassistant.components.recorder import get_instance
 
-        from .widgets.candlestick import (
-            INTERVAL_TO_SECONDS,
-            aggregate_ohlc,
-            extract_timestamped_values,
-        )
+    for widget_data in view_config.get("widgets", []):
+        widget_type = widget_data.get("type")
+        entity_id = widget_data.get("entity_id")
+        if not entity_id:
+            continue
+        options = widget_data.get("options", {})
 
-        recorder = get_instance(hass)
-        now = dt_util.utcnow()
+        if widget_type == "chart":
+            period = options.get("period", "24 hours")
+            period_hours = {
+                "5 min": 5 / 60,
+                "15 min": 15 / 60,
+                "1 hour": 1,
+                "6 hours": 6,
+                "24 hours": 24,
+            }.get(period, 24)
+            values = await fetcher.fetch_numeric(entity_id, period_hours)
+            if values:
+                chart_history[entity_id] = values
 
-        for widget_data in view_config.get("widgets", []):
-            if widget_data.get("type") == "candlestick":
-                entity_id = widget_data.get("entity_id")
-                if entity_id:
-                    options = widget_data.get("options", {})
-                    candle_interval = options.get("candle_interval", "4 hours")
-                    candle_count = int(options.get("candle_count", 20))
-                    interval_hours = {"1 hour": 1, "4 hours": 4, "1 day": 24}.get(
-                        candle_interval, 4
-                    )
-                    interval_seconds = INTERVAL_TO_SECONDS.get(candle_interval, 14400)
-                    total_hours = interval_hours * candle_count
-                    start_time = now - timedelta(hours=total_hours)
-
-                    history_states = await recorder.async_add_executor_job(
-                        _fetch_entity_history,
-                        hass,
-                        entity_id,
-                        start_time,
-                        now,
-                    )
-
-                    if history_states:
-                        timestamped = extract_timestamped_values(history_states)
-                        if timestamped:
-                            candles = aggregate_ohlc(timestamped, interval_seconds, candle_count)
-                            if candles:
-                                candlestick_data[entity_id] = candles
-    except (ImportError, KeyError):
-        pass
+        elif widget_type == "candlestick":
+            candle_interval = options.get("candle_interval", "4 hours")
+            candle_count = int(options.get("candle_count", 20))
+            interval_hours = {"1 hour": 1, "4 hours": 4, "1 day": 24}.get(candle_interval, 4)
+            interval_seconds = INTERVAL_TO_SECONDS.get(candle_interval, 14400)
+            total_hours = interval_hours * candle_count
+            candles = await fetcher.fetch_ohlc(
+                entity_id, total_hours, interval_seconds, candle_count
+            )
+            if candles:
+                candlestick_data[entity_id] = candles
 
     # Pre-fetch forecast for weather widgets
     # Uses weather.get_forecasts service (required since HA 2024.3+)

--- a/custom_components/geekmagic/websocket.py
+++ b/custom_components/geekmagic/websocket.py
@@ -6,9 +6,7 @@ Provides commands for managing views, devices, and preview rendering.
 from __future__ import annotations
 
 import base64
-import contextlib
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -29,7 +27,6 @@ from .const import (
 )
 from .renderer import Renderer
 from .widgets import WIDGET_TYPE_SCHEMAS
-from .widgets.state import EntityState, WidgetState
 
 if TYPE_CHECKING:
     from .coordinator import GeekMagicCoordinator
@@ -408,6 +405,7 @@ async def ws_preview_render(
     # Import here to avoid circular imports
     from .history_fetcher import HistoryFetcher
     from .screen_builder import build_layout
+    from .widget_state_builder import PrefetchedData, build_widget_states
     from .widgets.candlestick import INTERVAL_TO_SECONDS
 
     fetcher = HistoryFetcher(hass)
@@ -475,68 +473,15 @@ async def ws_preview_render(
         """Render the view (runs in executor)."""
         renderer = Renderer()
         layout = build_layout(view_config)
-
-        # Build widget_states for rendering
-        from datetime import UTC
-        from zoneinfo import ZoneInfo
-
-        widget_states: dict[int, WidgetState] = {}
-        tz = getattr(hass.config, "time_zone_obj", None) or UTC
-        now = datetime.now(tz=tz)
-
-        for widget_data in view_config.get("widgets", []):
-            slot = widget_data.get("slot", 0)
-            if slot >= layout.get_slot_count():
-                continue
-
-            entity_id = widget_data.get("entity_id")
-            entity: EntityState | None = None
-
-            # Build entity state from hass
-            if entity_id:
-                state = hass.states.get(entity_id)
-                if state:
-                    entity = EntityState(
-                        entity_id=entity_id,
-                        state=state.state,
-                        attributes=dict(state.attributes),
-                    )
-
-            # Get chart history if available
-            history: list[float] = []
-            widget_type = widget_data.get("type")
-            if widget_type == "chart" and entity_id in chart_history:
-                history = chart_history[entity_id]
-
-            # Get candlestick data if available
-            candle_data: list[tuple[float, float, float, float]] = []
-            if widget_type == "candlestick" and entity_id in candlestick_data:
-                candle_data = candlestick_data[entity_id]
-
-            # Get weather forecast if available
-            forecast: list[dict[str, Any]] = []
-            if widget_type == "weather" and entity_id in weather_forecasts:
-                forecast = weather_forecasts[entity_id]
-
-            # Handle clock widget timezone override
-            widget_now = now
-            if widget_type == "clock":
-                tz_option = widget_data.get("options", {}).get("timezone")
-                if tz_option:
-                    with contextlib.suppress(Exception):
-                        widget_now = datetime.now(tz=ZoneInfo(tz_option))
-
-            widget_states[slot] = WidgetState(
-                entity=entity,
-                entities={},
-                history=history,
-                candlestick_data=candle_data,
-                forecast=forecast,
-                image=None,
-                now=widget_now,
-            )
-
-        # Render
+        widget_states = build_widget_states(
+            layout,
+            hass,
+            PrefetchedData(
+                chart_history=chart_history,
+                candlestick_data=candlestick_data,
+                weather_forecasts=weather_forecasts,
+            ),
+        )
         img, draw = renderer.create_canvas(background=layout.theme.background)
         layout.render(renderer, draw, widget_states)
         return renderer.to_png(img)

--- a/custom_components/geekmagic/websocket.py
+++ b/custom_components/geekmagic/websocket.py
@@ -30,7 +30,6 @@ from .const import (
 )
 from .renderer import Renderer
 from .widgets import WIDGET_TYPE_SCHEMAS
-from .widgets.base import WidgetConfig
 from .widgets.state import EntityState, WidgetState
 
 if TYPE_CHECKING:
@@ -450,9 +449,7 @@ async def ws_preview_render(
     view_config = msg["view_config"]
 
     # Import here to avoid circular imports
-    from .coordinator import LAYOUT_CLASSES
-    from .widgets import WIDGET_CLASSES
-    from .widgets.theme import get_theme
+    from .screen_builder import build_layout
 
     # Pre-fetch history for chart widgets
     chart_history: dict[str, list[float]] = {}
@@ -571,45 +568,7 @@ async def ws_preview_render(
     def _render() -> bytes:
         """Render the view (runs in executor)."""
         renderer = Renderer()
-
-        # Create layout
-        layout_type = view_config.get("layout", LAYOUT_GRID_2X2)
-        layout_class = LAYOUT_CLASSES.get(layout_type)
-        if not layout_class:
-            layout_class = LAYOUT_CLASSES[LAYOUT_GRID_2X2]
-        layout = layout_class()
-
-        # Set theme
-        theme_name = view_config.get("theme", THEME_CLASSIC)
-        layout.theme = get_theme(theme_name)
-
-        # Add widgets
-        for widget_data in view_config.get("widgets", []):
-            widget_type = widget_data.get("type")
-            slot = widget_data.get("slot", 0)
-
-            if slot >= layout.get_slot_count():
-                continue
-
-            widget_class = WIDGET_CLASSES.get(widget_type)
-            if not widget_class:
-                continue
-
-            raw_color = widget_data.get("color")
-            parsed_color = None
-            if isinstance(raw_color, list | tuple) and len(raw_color) == 3:
-                parsed_color = (int(raw_color[0]), int(raw_color[1]), int(raw_color[2]))
-
-            config = WidgetConfig(
-                widget_type=widget_type,
-                slot=slot,
-                entity_id=widget_data.get("entity_id"),
-                label=widget_data.get("label"),
-                color=parsed_color,
-                options=widget_data.get("options", {}),
-            )
-            widget = widget_class(config)
-            layout.set_widget(slot, widget)
+        layout = build_layout(view_config)
 
         # Build widget_states for rendering
         from datetime import UTC

--- a/custom_components/geekmagic/widget_state_builder.py
+++ b/custom_components/geekmagic/widget_state_builder.py
@@ -1,0 +1,156 @@
+"""Assemble per-widget WidgetState for a layout from pre-fetched data + hass.
+
+The coordinator and the websocket preview both need to turn a Layout plus
+its pre-fetched extras (camera images, chart history, weather forecasts,
+…) into a `dict[slot_index, WidgetState]` ready to hand to
+`layout.render`. Both call `build_widget_states` here so the per-widget
+assembly rules — which widget reads which cache, how clock timezone
+overrides work, how additional entities are resolved — live in one place.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from io import BytesIO
+from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
+
+from PIL import Image
+
+from .widgets.camera import CameraWidget
+from .widgets.candlestick import CandlestickWidget
+from .widgets.chart import ChartWidget
+from .widgets.clock import ClockWidget
+from .widgets.media import MediaWidget
+from .widgets.state import EntityState, WidgetState
+from .widgets.weather import WeatherWidget
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .layouts.base import Layout
+
+
+@dataclass
+class PrefetchedData:
+    """All pre-fetched data the widgets on a layout might need.
+
+    Each dict is keyed by entity_id. Widgets that don't find their entity
+    in the relevant dict simply render with empty/no data — this is the
+    same fallback behaviour the coordinator and websocket both had inline.
+    """
+
+    camera_images: dict[str, bytes] = field(default_factory=dict)
+    media_images: dict[str, bytes] = field(default_factory=dict)
+    chart_history: dict[str, list[float]] = field(default_factory=dict)
+    candlestick_data: dict[str, list[tuple[float, float, float, float]]] = field(
+        default_factory=dict
+    )
+    weather_forecasts: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+
+
+def build_widget_states(
+    layout: Layout,
+    hass: HomeAssistant,
+    prefetched: PrefetchedData,
+) -> dict[int, WidgetState]:
+    """Build a WidgetState for every populated slot in `layout`."""
+    states: dict[int, WidgetState] = {}
+
+    tz = getattr(hass.config, "time_zone_obj", None) or UTC
+    base_now = datetime.now(tz=tz)
+
+    for slot in layout.slots:
+        widget = slot.widget
+        if widget is None:
+            continue
+
+        primary_entity = _build_primary_entity(hass, widget.config.entity_id)
+        additional = _build_additional_entities(hass, widget, widget.config.entity_id)
+
+        history: list[float] = []
+        if isinstance(widget, ChartWidget) and widget.config.entity_id:
+            history = prefetched.chart_history.get(widget.config.entity_id, [])
+
+        candlestick_data: list[tuple[float, float, float, float]] = []
+        if isinstance(widget, CandlestickWidget) and widget.config.entity_id:
+            candlestick_data = prefetched.candlestick_data.get(widget.config.entity_id, [])
+
+        image = _load_image_for_widget(widget, prefetched)
+
+        forecast: list[dict[str, Any]] = []
+        if isinstance(widget, WeatherWidget) and widget.config.entity_id:
+            forecast = prefetched.weather_forecasts.get(widget.config.entity_id, [])
+
+        widget_now = _resolve_widget_now(widget, base_now)
+
+        states[slot.index] = WidgetState(
+            entity=primary_entity,
+            entities=additional,
+            history=history,
+            candlestick_data=candlestick_data,
+            image=image,
+            forecast=forecast,
+            now=widget_now,
+        )
+
+    return states
+
+
+def _build_primary_entity(hass: HomeAssistant, entity_id: str | None) -> EntityState | None:
+    if not entity_id:
+        return None
+    ha_state = hass.states.get(entity_id)
+    if ha_state is None:
+        return None
+    return EntityState(
+        entity_id=ha_state.entity_id,
+        state=ha_state.state,
+        attributes=dict(ha_state.attributes),
+    )
+
+
+def _build_additional_entities(
+    hass: HomeAssistant, widget, primary_id: str | None
+) -> dict[str, EntityState]:
+    additional: dict[str, EntityState] = {}
+    for eid in widget.get_entities():
+        if eid == primary_id:
+            continue
+        ha_state = hass.states.get(eid)
+        if ha_state is None:
+            continue
+        additional[eid] = EntityState(
+            entity_id=ha_state.entity_id,
+            state=ha_state.state,
+            attributes=dict(ha_state.attributes),
+        )
+    return additional
+
+
+def _load_image_for_widget(widget, prefetched: PrefetchedData):
+    """Decode pre-fetched bytes into a PIL image for camera/media widgets."""
+    entity_id = widget.config.entity_id
+    if not entity_id:
+        return None
+    if isinstance(widget, CameraWidget):
+        image_bytes = prefetched.camera_images.get(entity_id)
+    elif isinstance(widget, MediaWidget):
+        image_bytes = prefetched.media_images.get(entity_id)
+    else:
+        return None
+    if not image_bytes:
+        return None
+    with contextlib.suppress(Exception):
+        return Image.open(BytesIO(image_bytes))
+    return None
+
+
+def _resolve_widget_now(widget, base_now: datetime) -> datetime:
+    """Honour ClockWidget's timezone option; otherwise return the base time."""
+    if isinstance(widget, ClockWidget) and getattr(widget, "timezone", None):
+        with contextlib.suppress(Exception):
+            return datetime.now(tz=ZoneInfo(widget.timezone))
+    return base_now

--- a/scripts/frontend-run.sh
+++ b/scripts/frontend-run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Run an npm script inside the frontend directory, installing dependencies
+# first if node_modules is missing.
+#
+# Usage: ./scripts/frontend-run.sh <npm-script-name>
+# Example: ./scripts/frontend-run.sh typecheck
+#
+# Bootstrapping `npm ci` on demand makes the pre-commit hooks work in fresh
+# clones and CI environments without requiring contributors to remember a
+# manual setup step.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <npm-script-name>" >&2
+  exit 2
+fi
+
+cd "$(dirname "$0")/../custom_components/geekmagic/frontend"
+
+if [[ ! -d node_modules ]]; then
+  echo "frontend: node_modules missing, running npm ci..." >&2
+  npm ci --silent
+fi
+
+exec npm run --silent "$1"

--- a/tests/test_connection_backoff.py
+++ b/tests/test_connection_backoff.py
@@ -1,0 +1,111 @@
+"""Tests for the connection_backoff module."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from custom_components.geekmagic.connection_backoff import ConnectionBackoff
+
+
+def _make_backoff(base: int = 10, max_mult: int = 16, log_interval: int = 30):
+    logger = MagicMock(spec=logging.Logger)
+    return ConnectionBackoff(
+        logger=logger,
+        base_interval_seconds=base,
+        max_multiplier=max_mult,
+        log_interval=log_interval,
+    )
+
+
+class TestState:
+    def test_initial_state(self):
+        b = _make_backoff()
+        assert b.failure_count == 0
+        assert b.is_offline is False
+        assert b.base_interval == 10
+
+    def test_base_interval_is_settable(self):
+        b = _make_backoff()
+        b.base_interval = 30
+        assert b.base_interval == 30
+
+
+class TestRecordFailure:
+    def test_exponential_progression(self):
+        b = _make_backoff(base=10)
+        assert b.record_failure() == timedelta(seconds=20)
+        assert b.record_failure() == timedelta(seconds=40)
+        assert b.record_failure() == timedelta(seconds=80)
+        assert b.record_failure() == timedelta(seconds=160)
+
+    def test_capped_at_max_multiplier(self):
+        b = _make_backoff(base=10, max_mult=16)
+        for _ in range(100):
+            interval = b.record_failure()
+        assert interval == timedelta(seconds=160)  # 10 * 16
+
+    def test_failure_marks_offline(self):
+        b = _make_backoff()
+        b.record_failure()
+        assert b.is_offline is True
+        assert b.failure_count == 1
+
+
+class TestRecordSuccess:
+    def test_success_resets_state(self):
+        b = _make_backoff(base=10)
+        for _ in range(5):
+            b.record_failure()
+        assert b.is_offline is True
+
+        interval = b.record_success()
+        assert interval == timedelta(seconds=10)
+        assert b.failure_count == 0
+        assert b.is_offline is False
+
+
+class TestLogging:
+    def test_first_failure_logs_warning(self):
+        b = _make_backoff()
+        b.record_failure()
+        b._logger.reset_mock()
+        b.log_failure("host", "boom", 20)
+        b._logger.warning.assert_called_once()
+        b._logger.debug.assert_not_called()
+
+    def test_subsequent_failure_logs_debug(self):
+        b = _make_backoff(log_interval=30)
+        b.record_failure()
+        b.record_failure()  # second failure
+        b._logger.reset_mock()
+        b.log_failure("host", "boom", 40)
+        b._logger.debug.assert_called_once()
+        b._logger.warning.assert_not_called()
+
+    def test_periodic_summary_logs_warning(self):
+        b = _make_backoff(log_interval=5)
+        # 5 failures = periodic summary
+        for _ in range(5):
+            b.record_failure()
+        b._logger.reset_mock()
+        b.log_failure("host", "boom", 160)
+        b._logger.warning.assert_called_once()
+        b._logger.debug.assert_not_called()
+
+    def test_log_connection_error_first_failure_warns(self):
+        b = _make_backoff()
+        b.record_failure()
+        b._logger.reset_mock()
+        b.log_connection_error("host", Exception("boom"), 20)
+        b._logger.warning.assert_called_once()
+
+    def test_log_connection_error_subsequent_debug(self):
+        b = _make_backoff(log_interval=30)
+        b.record_failure()
+        b.record_failure()
+        b._logger.reset_mock()
+        b.log_connection_error("host", Exception("boom"), 40)
+        b._logger.debug.assert_called_once()
+        b._logger.warning.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -675,14 +675,14 @@ class TestCoordinatorPause:
         """Test that coordinator starts unpaused."""
         coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
 
-        assert coordinator._paused is False
-        assert coordinator._pre_pause_brightness is None
+        assert coordinator._display.is_paused is False
+        assert coordinator._display._pre_pause_brightness is None
 
     @pytest.mark.asyncio
     async def test_update_skips_render_when_paused(self, hass, pause_device, simple_options):
         """Test that _async_update_data returns early without rendering when paused."""
         coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
-        coordinator._paused = True
+        coordinator._display.enter_pause(None)
 
         result = await coordinator._async_update_data()
 
@@ -699,8 +699,8 @@ class TestCoordinatorPause:
 
         await coordinator.async_set_active(False)
 
-        assert coordinator._paused is True
-        assert coordinator._pre_pause_brightness == 75
+        assert coordinator._display.is_paused is True
+        assert coordinator._display._pre_pause_brightness == 75
         assert coordinator._device_brightness == 0
         pause_device.set_brightness.assert_called_once_with(0)
 
@@ -710,8 +710,7 @@ class TestCoordinatorPause:
     ):
         """Test async_set_active(True) restores brightness and triggers refresh."""
         coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
-        coordinator._paused = True
-        coordinator._pre_pause_brightness = 75
+        coordinator._display.enter_pause(75)
         coordinator._device_brightness = 0
 
         with patch.object(
@@ -719,8 +718,8 @@ class TestCoordinatorPause:
         ) as mock_refresh:
             await coordinator.async_set_active(True)
 
-        assert coordinator._paused is False
-        assert coordinator._pre_pause_brightness is None
+        assert coordinator._display.is_paused is False
+        assert coordinator._display._pre_pause_brightness is None
         assert coordinator._device_brightness == 75
         pause_device.set_brightness.assert_called_once_with(75)
         mock_refresh.assert_called_once()
@@ -733,8 +732,8 @@ class TestCoordinatorPause:
 
         await coordinator.async_set_active(False)
 
-        assert coordinator._paused is True
-        assert coordinator._pre_pause_brightness is None
+        assert coordinator._display.is_paused is True
+        assert coordinator._display._pre_pause_brightness is None
         pause_device.set_brightness.assert_called_once_with(0)
 
     @pytest.mark.asyncio
@@ -743,15 +742,14 @@ class TestCoordinatorPause:
     ):
         """Test async_set_active(True) does not call set_brightness if none was stored."""
         coordinator = GeekMagicCoordinator(hass, pause_device, simple_options)
-        coordinator._paused = True
-        coordinator._pre_pause_brightness = None
+        coordinator._display.enter_pause(None)
 
         with patch.object(
             coordinator, "async_request_refresh", new_callable=AsyncMock
         ) as mock_refresh:
             await coordinator.async_set_active(True)
 
-        assert coordinator._paused is False
+        assert coordinator._display.is_paused is False
         pause_device.set_brightness.assert_not_called()
         mock_refresh.assert_called_once()
 
@@ -764,11 +762,11 @@ class TestCoordinatorPause:
         coordinator._device_brightness = 80
 
         await coordinator.async_set_active(False)
-        assert coordinator._pre_pause_brightness == 80
+        assert coordinator._display._pre_pause_brightness == 80
 
         # Second call while already paused should not overwrite the stored value
         await coordinator.async_set_active(False)
-        assert coordinator._pre_pause_brightness == 80
+        assert coordinator._display._pre_pause_brightness == 80
 
     @pytest.mark.asyncio
     async def test_set_active_false_notifies_listeners(self, hass, pause_device, simple_options):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -169,7 +169,7 @@ class TestCoordinatorWidgetRegistration:
 
     def test_all_widgets_registered(self):
         """Test that all widget types are registered."""
-        from custom_components.geekmagic.coordinator import WIDGET_CLASSES
+        from custom_components.geekmagic.widgets import WIDGET_CLASSES
 
         expected_widgets = [
             "attribute_list",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,16 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.geekmagic.const import (
-    BACKOFF_LOG_INTERVAL,
     CONF_LAYOUT,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
     CONF_SCREENS,
     CONF_WIDGETS,
-    DEFAULT_REFRESH_INTERVAL,
     LAYOUT_GRID_2X2,
     LAYOUT_SPLIT_H,
-    MAX_BACKOFF_MULTIPLIER,
 )
 from custom_components.geekmagic.coordinator import GeekMagicCoordinator
 from custom_components.geekmagic.device import ConnectionResult
@@ -501,165 +498,22 @@ class TestCoordinatorBackoff:
         """Test that coordinator starts with no backoff state."""
         coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
 
-        assert coordinator._consecutive_failures == 0
-        assert coordinator._device_offline is False
-        assert coordinator._base_update_interval == 10
+        assert coordinator._backoff.failure_count == 0
+        assert coordinator._backoff.is_offline is False
+        assert coordinator._backoff.base_interval == 10
         assert coordinator.update_interval == timedelta(seconds=10)
-
-    def test_apply_backoff_exponential(self, hass, backoff_device, simple_options):
-        """Test that backoff increases exponentially."""
-        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
-
-        # Simulate failures and check backoff progression
-        # Failure 1: multiplier = 2^1 = 2
-        coordinator._consecutive_failures = 1
-        coordinator._apply_backoff()
-        assert coordinator.update_interval == timedelta(seconds=20)
-
-        # Failure 2: multiplier = 2^2 = 4
-        coordinator._consecutive_failures = 2
-        coordinator._apply_backoff()
-        assert coordinator.update_interval == timedelta(seconds=40)
-
-        # Failure 3: multiplier = 2^3 = 8
-        coordinator._consecutive_failures = 3
-        coordinator._apply_backoff()
-        assert coordinator.update_interval == timedelta(seconds=80)
-
-        # Failure 4: multiplier = 2^4 = 16
-        coordinator._consecutive_failures = 4
-        coordinator._apply_backoff()
-        assert coordinator.update_interval == timedelta(seconds=160)
-
-    def test_apply_backoff_capped_at_max(self, hass, backoff_device, simple_options):
-        """Test that backoff is capped at MAX_BACKOFF_MULTIPLIER."""
-        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
-
-        # Simulate many failures - should be capped at max
-        coordinator._consecutive_failures = 100
-        coordinator._apply_backoff()
-
-        expected_interval = DEFAULT_REFRESH_INTERVAL * MAX_BACKOFF_MULTIPLIER
-        assert coordinator.update_interval == timedelta(seconds=expected_interval)
-
-    def test_reset_backoff(self, hass, backoff_device, simple_options):
-        """Test that reset_backoff restores normal state."""
-        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
-
-        # Set up backoff state
-        coordinator._consecutive_failures = 5
-        coordinator._device_offline = True
-        coordinator._apply_backoff()
-        assert coordinator.update_interval != timedelta(seconds=10)
-
-        # Reset backoff
-        coordinator._reset_backoff()
-
-        assert coordinator._consecutive_failures == 0
-        assert coordinator._device_offline is False
-        assert coordinator.update_interval == timedelta(seconds=10)
-
-    @patch("custom_components.geekmagic.coordinator._LOGGER")
-    def test_log_offline_status_first_failure(
-        self, mock_logger, hass, backoff_device, simple_options
-    ):
-        """Test that first failure logs at warning level."""
-        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
-
-        coordinator._consecutive_failures = 1
-        coordinator._log_offline_status("Connection refused")
-
-        mock_logger.warning.assert_called_once()
-        call_args = mock_logger.warning.call_args[0][0]
-        assert "is offline" in call_args
-        assert "exponential backoff" in call_args
-
-    @patch("custom_components.geekmagic.coordinator._LOGGER")
-    def test_log_offline_status_subsequent_debug(
-        self, mock_logger, hass, backoff_device, simple_options
-    ):
-        """Test that subsequent failures log at debug level."""
-        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
-
-        # Reset mock to ignore constructor calls
-        mock_logger.reset_mock()
-
-        coordinator._consecutive_failures = 2
-        coordinator._log_offline_status("Connection refused")
-
-        # Check the specific debug call was made
-        mock_logger.debug.assert_called_with(
-            "GeekMagic device %s offline (attempt %d): %s",
-            "192.168.1.100",
-            2,
-            "Connection refused",
-        )
-        mock_logger.warning.assert_not_called()
-
-    @patch("custom_components.geekmagic.coordinator._LOGGER")
-    def test_log_offline_status_periodic_summary(
-        self, mock_logger, hass, backoff_device, simple_options
-    ):
-        """Test that periodic summary logs at warning level."""
-        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
-        coordinator.update_interval = timedelta(seconds=180)
-
-        # At BACKOFF_LOG_INTERVAL failures, should log summary
-        coordinator._consecutive_failures = BACKOFF_LOG_INTERVAL
-        coordinator._log_offline_status("Connection refused")
-
-        mock_logger.warning.assert_called_once()
-        call_args = mock_logger.warning.call_args[0][0]
-        assert "still offline" in call_args
-        assert "attempts" in call_args
-
-    @patch("custom_components.geekmagic.coordinator._LOGGER")
-    def test_log_connection_error_first_failure(
-        self, mock_logger, hass, backoff_device, simple_options
-    ):
-        """Test that first connection error logs at warning level."""
-        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
-
-        coordinator._consecutive_failures = 1
-        coordinator._log_connection_error(Exception("Connection refused"))
-
-        mock_logger.warning.assert_called_once()
-        call_args = mock_logger.warning.call_args[0][0]
-        assert "connection failed" in call_args
-
-    @patch("custom_components.geekmagic.coordinator._LOGGER")
-    def test_log_connection_error_subsequent_debug(
-        self, mock_logger, hass, backoff_device, simple_options
-    ):
-        """Test that subsequent errors log at debug level."""
-        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
-
-        # Reset mock to ignore constructor calls
-        mock_logger.reset_mock()
-
-        coordinator._consecutive_failures = 5
-        test_exception = Exception("Connection refused")
-        coordinator._log_connection_error(test_exception)
-
-        # Check the specific debug call was made
-        mock_logger.debug.assert_called_with(
-            "GeekMagic update failed (attempt %d): %s",
-            5,
-            test_exception,
-        )
-        mock_logger.warning.assert_not_called()
 
     def test_update_options_preserves_base_interval(self, hass, backoff_device, simple_options):
         """Test that update_options updates base interval for backoff."""
         coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
-        assert coordinator._base_update_interval == 10
+        assert coordinator._backoff.base_interval == 10
 
         # Update with new interval
         new_options = simple_options.copy()
         new_options[CONF_REFRESH_INTERVAL] = 30
         coordinator.update_options(new_options)
 
-        assert coordinator._base_update_interval == 30
+        assert coordinator._backoff.base_interval == 30
         assert coordinator.update_interval == timedelta(seconds=30)
 
     @pytest.mark.asyncio
@@ -673,9 +527,12 @@ class TestCoordinatorBackoff:
 
         coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
 
-        # Mark device as offline
-        coordinator._device_offline = True
-        coordinator._consecutive_failures = 5
+        # Mark device as offline via the backoff manager
+        coordinator._backoff.record_failure()
+        coordinator._backoff.record_failure()
+        coordinator._backoff.record_failure()
+        coordinator._backoff.record_failure()
+        coordinator._backoff.record_failure()
 
         # Set up failed connection test
         backoff_device.test_connection = AsyncMock(
@@ -702,9 +559,8 @@ class TestCoordinatorBackoff:
         coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
 
         # Mark device as offline with significant backoff
-        coordinator._device_offline = True
-        coordinator._consecutive_failures = 10
-        coordinator._apply_backoff()
+        for _ in range(10):
+            coordinator.update_interval = coordinator._backoff.record_failure()
 
         # Set up successful connection test
         backoff_device.test_connection = AsyncMock(
@@ -716,8 +572,8 @@ class TestCoordinatorBackoff:
             result = await coordinator._async_update_data()
 
         # Verify backoff was reset
-        assert coordinator._consecutive_failures == 0
-        assert coordinator._device_offline is False
+        assert coordinator._backoff.failure_count == 0
+        assert coordinator._backoff.is_offline is False
         assert coordinator.update_interval == timedelta(seconds=10)
 
         # Verify update succeeded
@@ -741,8 +597,8 @@ class TestCoordinatorBackoff:
             await coordinator._async_update_data()
 
         # Verify offline state was set
-        assert coordinator._device_offline is True
-        assert coordinator._consecutive_failures == 1
+        assert coordinator._backoff.is_offline is True
+        assert coordinator._backoff.failure_count == 1
         assert coordinator._last_update_success is False
 
         # Verify backoff was applied
@@ -759,9 +615,9 @@ class TestCoordinatorBackoff:
 
         coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
 
-        # Mark device as offline
-        coordinator._device_offline = True
-        coordinator._consecutive_failures = 3
+        # Mark device as offline with a few failures already
+        for _ in range(3):
+            coordinator._backoff.record_failure()
 
         # Set up test_connection to raise an exception
         backoff_device.test_connection = AsyncMock(side_effect=Exception("Network timeout"))
@@ -773,8 +629,8 @@ class TestCoordinatorBackoff:
         assert "Network timeout" in str(exc_info.value)
 
         # Verify backoff was applied
-        assert coordinator._consecutive_failures == 4
-        assert coordinator._device_offline is True
+        assert coordinator._backoff.failure_count == 4
+        assert coordinator._backoff.is_offline is True
 
         # Verify expensive operations were NOT called
         backoff_device.upload_and_display.assert_not_called()

--- a/tests/test_display_state.py
+++ b/tests/test_display_state.py
@@ -1,0 +1,82 @@
+"""Tests for the display_state module."""
+
+from __future__ import annotations
+
+from custom_components.geekmagic.display_state import DisplayState
+
+
+class TestInitial:
+    def test_starts_custom_not_paused(self):
+        d = DisplayState()
+        assert d.mode == "custom"
+        assert d.is_paused is False
+        assert d.is_active is True
+
+
+class TestModeTransitions:
+    def test_set_builtin_records_theme(self):
+        d = DisplayState()
+        d.set_builtin(2)
+        assert d.mode == "builtin"
+        assert d.builtin_theme == 2
+
+    def test_set_custom_does_not_clear_recorded_theme(self):
+        # `builtin_theme` is meaningless when mode != builtin; we don't promise to clear it.
+        d = DisplayState()
+        d.set_builtin(1)
+        d.set_custom()
+        assert d.mode == "custom"
+
+
+class TestSyncFromDeviceTheme:
+    def test_flips_to_builtin_when_custom_and_device_theme_low(self):
+        d = DisplayState()
+        flipped = d.sync_from_device_theme(1)
+        assert flipped is True
+        assert d.mode == "builtin"
+        assert d.builtin_theme == 1
+
+    def test_no_flip_when_device_theme_is_3_or_higher(self):
+        # Themes >= 3 are the integration's own "custom image" slot
+        d = DisplayState()
+        flipped = d.sync_from_device_theme(3)
+        assert flipped is False
+        assert d.mode == "custom"
+
+    def test_no_flip_when_already_builtin(self):
+        d = DisplayState()
+        d.set_builtin(2)
+        flipped = d.sync_from_device_theme(0)
+        assert flipped is False
+        # mode stays builtin, theme not overwritten by sync
+        assert d.mode == "builtin"
+        assert d.builtin_theme == 2
+
+
+class TestPauseLifecycle:
+    def test_enter_pause_remembers_brightness(self):
+        d = DisplayState()
+        d.enter_pause(75)
+        assert d.is_paused is True
+        restore = d.exit_pause()
+        assert restore == 75
+        assert d.is_paused is False
+
+    def test_exit_pause_clears_brightness(self):
+        d = DisplayState()
+        d.enter_pause(50)
+        d.exit_pause()
+        # second exit returns None
+        assert d.exit_pause() is None
+
+    def test_double_enter_pause_keeps_first_brightness(self):
+        d = DisplayState()
+        d.enter_pause(80)
+        d.enter_pause(10)  # called while already paused — should not overwrite
+        assert d.exit_pause() == 80
+
+    def test_enter_pause_with_none_brightness(self):
+        d = DisplayState()
+        d.enter_pause(None)
+        assert d.is_paused is True
+        assert d.exit_pause() is None

--- a/tests/test_history_fetcher.py
+++ b/tests/test_history_fetcher.py
@@ -1,0 +1,101 @@
+"""Tests for the history_fetcher module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.geekmagic.history_fetcher import (
+    HistoryFetcher,
+    extract_numeric_values,
+)
+
+
+class FakeState:
+    def __init__(self, state: str) -> None:
+        self.state = state
+
+
+class TestExtractNumericValues:
+    def test_numeric_strings_are_parsed(self):
+        states = [FakeState("1"), FakeState("2.5"), FakeState("-3")]
+        assert extract_numeric_values(states) == [1.0, 2.5, -3.0]
+
+    def test_binary_on_states_become_1(self):
+        states = [FakeState("on"), FakeState("OPEN"), FakeState("playing")]
+        assert extract_numeric_values(states) == [1.0, 1.0, 1.0]
+
+    def test_binary_off_states_become_0(self):
+        states = [FakeState("off"), FakeState("Closed"), FakeState("IDLE")]
+        assert extract_numeric_values(states) == [0.0, 0.0, 0.0]
+
+    def test_non_numeric_non_binary_skipped(self):
+        states = [FakeState("unavailable"), FakeState("unknown"), FakeState("hello")]
+        assert extract_numeric_values(states) == []
+
+    def test_none_state_skipped(self):
+        states = [FakeState(None), FakeState("1")]  # type: ignore[arg-type]
+        assert extract_numeric_values(states) == [1.0]
+
+    def test_dict_minimal_response_format(self):
+        states = [{"state": "5"}, {"state": "on"}, {"state": None}]
+        assert extract_numeric_values(states) == [5.0, 1.0]
+
+    def test_empty_list_returns_empty(self):
+        assert extract_numeric_values([]) == []
+
+
+class TestHistoryFetcher:
+    @pytest.mark.asyncio
+    async def test_fetch_numeric_returns_empty_when_recorder_unavailable(self):
+        hass = MagicMock()
+        with patch(
+            "homeassistant.components.recorder.get_instance", side_effect=KeyError
+        ):
+            fetcher = HistoryFetcher(hass)
+        assert not fetcher.available
+        assert await fetcher.fetch_numeric("sensor.foo", 1) == []
+        assert await fetcher.fetch_ohlc("sensor.foo", 1, 60, 10) == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_numeric_returns_values_from_recorder(self):
+        hass = MagicMock()
+
+        recorder = MagicMock()
+        recorder.async_add_executor_job = AsyncMock(
+            return_value=[FakeState("1"), FakeState("2"), FakeState("on")]
+        )
+
+        with patch(
+            "homeassistant.components.recorder.get_instance", return_value=recorder
+        ):
+            fetcher = HistoryFetcher(hass)
+
+        result = await fetcher.fetch_numeric("sensor.foo", 1)
+        assert result == [1.0, 2.0, 1.0]
+        recorder.async_add_executor_job.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_numeric_swallows_executor_errors(self):
+        hass = MagicMock()
+        recorder = MagicMock()
+        recorder.async_add_executor_job = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch(
+            "homeassistant.components.recorder.get_instance", return_value=recorder
+        ):
+            fetcher = HistoryFetcher(hass)
+
+        assert await fetcher.fetch_numeric("sensor.foo", 1) == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_ohlc_returns_empty_when_no_history(self):
+        hass = MagicMock()
+        recorder = MagicMock()
+        recorder.async_add_executor_job = AsyncMock(return_value=[])
+        with patch(
+            "homeassistant.components.recorder.get_instance", return_value=recorder
+        ):
+            fetcher = HistoryFetcher(hass)
+
+        assert await fetcher.fetch_ohlc("sensor.foo", 1, 60, 10) == []

--- a/tests/test_history_fetcher.py
+++ b/tests/test_history_fetcher.py
@@ -50,9 +50,7 @@ class TestHistoryFetcher:
     @pytest.mark.asyncio
     async def test_fetch_numeric_returns_empty_when_recorder_unavailable(self):
         hass = MagicMock()
-        with patch(
-            "homeassistant.components.recorder.get_instance", side_effect=KeyError
-        ):
+        with patch("homeassistant.components.recorder.get_instance", side_effect=KeyError):
             fetcher = HistoryFetcher(hass)
         assert not fetcher.available
         assert await fetcher.fetch_numeric("sensor.foo", 1) == []
@@ -67,9 +65,7 @@ class TestHistoryFetcher:
             return_value=[FakeState("1"), FakeState("2"), FakeState("on")]
         )
 
-        with patch(
-            "homeassistant.components.recorder.get_instance", return_value=recorder
-        ):
+        with patch("homeassistant.components.recorder.get_instance", return_value=recorder):
             fetcher = HistoryFetcher(hass)
 
         result = await fetcher.fetch_numeric("sensor.foo", 1)
@@ -81,9 +77,7 @@ class TestHistoryFetcher:
         hass = MagicMock()
         recorder = MagicMock()
         recorder.async_add_executor_job = AsyncMock(side_effect=RuntimeError("boom"))
-        with patch(
-            "homeassistant.components.recorder.get_instance", return_value=recorder
-        ):
+        with patch("homeassistant.components.recorder.get_instance", return_value=recorder):
             fetcher = HistoryFetcher(hass)
 
         assert await fetcher.fetch_numeric("sensor.foo", 1) == []
@@ -93,9 +87,7 @@ class TestHistoryFetcher:
         hass = MagicMock()
         recorder = MagicMock()
         recorder.async_add_executor_job = AsyncMock(return_value=[])
-        with patch(
-            "homeassistant.components.recorder.get_instance", return_value=recorder
-        ):
+        with patch("homeassistant.components.recorder.get_instance", return_value=recorder):
             fetcher = HistoryFetcher(hass)
 
         assert await fetcher.fetch_ohlc("sensor.foo", 1, 60, 10) == []

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,4 +1,4 @@
-"""Tests for GeekMagic notification service."""
+"""Integration tests for the notification flow through the coordinator."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,8 +12,6 @@ from custom_components.geekmagic.const import (
     LAYOUT_GRID_2X2,
 )
 from custom_components.geekmagic.coordinator import GeekMagicCoordinator
-from custom_components.geekmagic.layouts.fullscreen import FullscreenLayout
-from custom_components.geekmagic.layouts.hero_simple import HeroSimpleLayout
 
 
 @pytest.fixture
@@ -44,16 +42,18 @@ def options():
 
 
 class TestNotification:
-    """Test notification functionality."""
+    """Coordinator-level notification behaviour: delegates to NotificationManager."""
 
     @pytest.mark.asyncio
-    async def test_trigger_notification(self, hass, coordinator_device, options):
-        """Test triggering a notification sets state."""
+    async def test_trigger_notification_routes_to_manager(self, hass, coordinator_device, options):
+        """trigger_notification stores data on the manager and requests a refresh."""
         coordinator = GeekMagicCoordinator(hass, coordinator_device, options)
         refresh = AsyncMock()
         object.__setattr__(coordinator, "async_request_refresh", refresh)
+        # NotificationManager was bound to the original bound method; rebind it.
+        coordinator._notifications._request_refresh = refresh
 
-        data = {"message": "Hello World", "title": "Alert", "duration": 5, "icon": "mdi:test"}
+        data = {"message": "Hello World", "duration": 5, "icon": "mdi:test"}
 
         with (
             patch("time.time", return_value=1000),
@@ -61,143 +61,22 @@ class TestNotification:
         ):
             await coordinator.trigger_notification(data)
 
-            assert coordinator._notification_data == data
-            assert coordinator._notification_expiry == 1005
-            assert refresh.called
+            assert coordinator._notifications.is_active is True
+            assert coordinator._notifications.image_source is None
+            refresh.assert_awaited()
             mock_call_later.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_notification_layout_creation(self, hass, coordinator_device, options):
-        """Test notification layout is created correctly (HeroSimpleLayout)."""
+    async def test_render_uses_notification_layout_when_active(
+        self, hass, coordinator_device, options
+    ):
+        """Active notification overrides the screen layout in the render loop."""
         coordinator = GeekMagicCoordinator(hass, coordinator_device, options)
 
-        data = {
-            "message": "Test Message",
-            # title is removed from expected logic
-            "icon": "mdi:check",
-            "image": "camera.test",
-        }
+        # Make a notification active without going through the asyncio timer.
+        coordinator._notifications._data = {"message": "Active"}
+        coordinator._notifications._expiry = 2000
 
-        layout = coordinator._create_notification_layout(data)
-
-        assert isinstance(layout, HeroSimpleLayout)
-        # Slot 0 should be CameraWidget because image starts with camera.
-        camera_slot = layout.get_slot(0)
-        assert camera_slot is not None
-        assert camera_slot.widget is not None
-        assert camera_slot.widget.config.widget_type == "camera"
-
-        # Slot 1 should be TextWidget with message only
-        text_slot = layout.get_slot(1)
-        assert text_slot is not None
-        assert text_slot.widget is not None
-        text_widget = text_slot.widget
-        assert text_widget.config.widget_type == "text"
-        assert text_widget.config.options["text"] == "Test Message"
-        assert text_widget.config.options["align"] == "center"
-
-    @pytest.mark.asyncio
-    async def test_notification_layout_image_only(self, hass, coordinator_device, options):
-        """Test notification layout with no message (FullscreenLayout)."""
-        coordinator = GeekMagicCoordinator(hass, coordinator_device, options)
-
-        data = {
-            # No message provided
-            "image": "camera.test"
-        }
-
-        layout = coordinator._create_notification_layout(data)
-        assert isinstance(layout, FullscreenLayout)
-
-        # Slot 0 should be full screen camera
-        camera_slot = layout.get_slot(0)
-        assert camera_slot is not None
-        assert camera_slot.widget is not None
-        camera_widget = camera_slot.widget
-        assert camera_widget.config.widget_type == "camera"
-        assert camera_widget.config.options["fit"] == "contain"
-
-    @pytest.mark.asyncio
-    async def test_notification_layout_image_entity(self, hass, coordinator_device, options):
-        """Test notification layout with an image entity."""
-        coordinator = GeekMagicCoordinator(hass, coordinator_device, options)
-
-        data = {"message": "Image Entity", "image": "image.reolink_snap"}
-
-        layout = coordinator._create_notification_layout(data)
-        assert isinstance(layout, HeroSimpleLayout)
-
-        # Slot 0 should be CameraWidget even for image. entities
-        image_slot = layout.get_slot(0)
-        assert image_slot is not None
-        assert image_slot.widget is not None
-        image_widget = image_slot.widget
-        assert image_widget.config.widget_type == "camera"
-        assert image_widget.config.entity_id == "image.reolink_snap"
-
-    @pytest.mark.asyncio
-    async def test_notification_layout_icon_only(self, hass, coordinator_device, options):
-        """Test notification with no message and no image (Fullscreen Icon)."""
-        coordinator = GeekMagicCoordinator(hass, coordinator_device, options)
-
-        data = {
-            "icon": "mdi:alert"
-            # No message
-        }
-
-        layout = coordinator._create_notification_layout(data)
-        assert isinstance(layout, FullscreenLayout)
-
-        icon_slot = layout.get_slot(0)
-        assert icon_slot is not None
-        assert icon_slot.widget is not None
-        icon_widget = icon_slot.widget
-        assert icon_widget.config.widget_type == "icon"
-        assert icon_widget.config.options["icon"] == "mdi:alert"
-        assert icon_widget.config.options["size"] == "huge"
-
-    @pytest.mark.asyncio
-    async def test_render_notification_active(self, hass, coordinator_device, options):
-        """Test render loop uses notification layout when active."""
-        coordinator = GeekMagicCoordinator(hass, coordinator_device, options)
-
-        # Setup active notification
-        coordinator._notification_data = {"message": "Active"}
-        coordinator._notification_expiry = 2000
-
-        # Mock renderer methods to avoid actual PIL calls
-        object.__setattr__(
-            coordinator.renderer,
-            "create_canvas",
-            MagicMock(return_value=(MagicMock(), MagicMock())),
-        )
-        object.__setattr__(coordinator.renderer, "to_jpeg", MagicMock(return_value=b"jpeg"))
-        object.__setattr__(coordinator.renderer, "to_png", MagicMock(return_value=b"png"))
-
-        # Build widget states mock
-        object.__setattr__(coordinator, "_build_widget_states", MagicMock(return_value={}))
-
-        with (
-            patch("time.time", return_value=1000),
-            patch.object(
-                coordinator,
-                "_create_notification_layout",
-                wraps=coordinator._create_notification_layout,
-            ) as mock_create,
-        ):
-            coordinator._render_display()
-            mock_create.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_render_notification_expired(self, hass, coordinator_device, options):
-        """Test render loop ignores notification when expired."""
-        coordinator = GeekMagicCoordinator(hass, coordinator_device, options)
-
-        # Setup expired notification
-        coordinator._notification_data = {"message": "Expired"}
-        coordinator._notification_expiry = 900
-
-        # Mock renderer methods
         object.__setattr__(
             coordinator.renderer,
             "create_canvas",
@@ -210,10 +89,34 @@ class TestNotification:
         with (
             patch("time.time", return_value=1000),
             patch.object(
-                coordinator,
-                "_create_notification_layout",
-                wraps=coordinator._create_notification_layout,
-            ) as mock_create,
+                coordinator._notifications,
+                "build_layout",
+                wraps=coordinator._notifications.build_layout,
+            ) as mock_build,
         ):
             coordinator._render_display()
-            mock_create.assert_not_called()
+            mock_build.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_render_ignores_notification_when_expired(
+        self, hass, coordinator_device, options
+    ):
+        """Expired notification yields no layout override."""
+        coordinator = GeekMagicCoordinator(hass, coordinator_device, options)
+
+        coordinator._notifications._data = {"message": "Expired"}
+        coordinator._notifications._expiry = 900
+
+        object.__setattr__(
+            coordinator.renderer,
+            "create_canvas",
+            MagicMock(return_value=(MagicMock(), MagicMock())),
+        )
+        object.__setattr__(coordinator.renderer, "to_jpeg", MagicMock(return_value=b"jpeg"))
+        object.__setattr__(coordinator.renderer, "to_png", MagicMock(return_value=b"png"))
+        object.__setattr__(coordinator, "_build_widget_states", MagicMock(return_value={}))
+
+        with patch("time.time", return_value=1000):
+            coordinator._render_display()
+            # Expired: build_layout returns None, and the screen layout is used.
+            assert coordinator._notifications.build_layout() is None

--- a/tests/test_notification_manager.py
+++ b/tests/test_notification_manager.py
@@ -1,0 +1,142 @@
+"""Tests for the notification_manager module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.geekmagic.layouts.fullscreen import FullscreenLayout
+from custom_components.geekmagic.layouts.hero_simple import HeroSimpleLayout
+from custom_components.geekmagic.notification_manager import NotificationManager
+
+
+def _make_manager():
+    hass = MagicMock()
+    hass.loop.call_later = MagicMock()
+    hass.async_create_task = MagicMock()
+    refresh = AsyncMock()
+    manager = NotificationManager(hass, refresh)
+    return manager, hass, refresh
+
+
+class TestActiveState:
+    def test_starts_inactive(self):
+        manager, _, _ = _make_manager()
+        assert manager.is_active is False
+        assert manager.image_source is None
+
+    @pytest.mark.asyncio
+    async def test_trigger_marks_active(self):
+        manager, _, refresh = _make_manager()
+        with patch("time.time", return_value=1000):
+            await manager.trigger({"message": "hi", "duration": 5})
+        # is_active checks time.time() < expiry, so we need to be inside the window
+        with patch("time.time", return_value=1004):
+            assert manager.is_active is True
+        refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_expiry_marks_inactive(self):
+        manager, _, _ = _make_manager()
+        with patch("time.time", return_value=1000):
+            await manager.trigger({"message": "hi", "duration": 5})
+        with patch("time.time", return_value=2000):
+            assert manager.is_active is False
+
+    @pytest.mark.asyncio
+    async def test_retrigger_cancels_previous_timer(self):
+        manager, hass, _ = _make_manager()
+        first_handle = MagicMock()
+        second_handle = MagicMock()
+        hass.loop.call_later.side_effect = [first_handle, second_handle]
+
+        await manager.trigger({"message": "first", "duration": 5})
+        await manager.trigger({"message": "second", "duration": 5})
+
+        first_handle.cancel.assert_called_once()
+
+
+class TestImageSource:
+    @pytest.mark.asyncio
+    async def test_image_source_returned_when_active(self):
+        manager, _, _ = _make_manager()
+        with patch("time.time", return_value=1000):
+            await manager.trigger({"image": "camera.front", "duration": 5})
+        with patch("time.time", return_value=1004):
+            assert manager.image_source == "camera.front"
+
+    @pytest.mark.asyncio
+    async def test_image_source_none_when_no_image(self):
+        manager, _, _ = _make_manager()
+        with patch("time.time", return_value=1000):
+            await manager.trigger({"message": "no image", "duration": 5})
+        with patch("time.time", return_value=1004):
+            assert manager.image_source is None
+
+
+class TestBuildLayout:
+    def test_returns_none_when_inactive(self):
+        manager, _, _ = _make_manager()
+        assert manager.build_layout() is None
+
+    @pytest.mark.asyncio
+    async def test_message_with_image_returns_hero_simple_with_camera_hero(self):
+        manager, _, _ = _make_manager()
+        with patch("time.time", return_value=1000):
+            await manager.trigger({"message": "Test", "image": "camera.test", "duration": 5})
+        with patch("time.time", return_value=1004):
+            layout = manager.build_layout()
+        assert isinstance(layout, HeroSimpleLayout)
+        hero = layout.get_slot(0).widget
+        text = layout.get_slot(1).widget
+        assert hero is not None and hero.config.widget_type == "camera"
+        assert hero.config.entity_id == "camera.test"
+        assert text is not None and text.config.options["text"] == "Test"
+
+    @pytest.mark.asyncio
+    async def test_message_without_image_uses_icon_hero(self):
+        manager, _, _ = _make_manager()
+        with patch("time.time", return_value=1000):
+            await manager.trigger({"message": "Hi", "icon": "mdi:bell", "duration": 5})
+        with patch("time.time", return_value=1004):
+            layout = manager.build_layout()
+        assert isinstance(layout, HeroSimpleLayout)
+        hero = layout.get_slot(0).widget
+        assert hero is not None and hero.config.widget_type == "icon"
+        assert hero.config.options["icon"] == "mdi:bell"
+
+    @pytest.mark.asyncio
+    async def test_no_message_with_image_returns_fullscreen(self):
+        manager, _, _ = _make_manager()
+        with patch("time.time", return_value=1000):
+            await manager.trigger({"image": "camera.test", "duration": 5})
+        with patch("time.time", return_value=1004):
+            layout = manager.build_layout()
+        assert isinstance(layout, FullscreenLayout)
+        hero = layout.get_slot(0).widget
+        assert hero is not None and hero.config.widget_type == "camera"
+
+    @pytest.mark.asyncio
+    async def test_no_message_no_image_returns_fullscreen_icon(self):
+        manager, _, _ = _make_manager()
+        with patch("time.time", return_value=1000):
+            await manager.trigger({"icon": "mdi:alert", "duration": 5})
+        with patch("time.time", return_value=1004):
+            layout = manager.build_layout()
+        assert isinstance(layout, FullscreenLayout)
+        hero = layout.get_slot(0).widget
+        assert hero is not None and hero.config.widget_type == "icon"
+        assert hero.config.options["icon"] == "mdi:alert"
+        assert hero.config.options.get("show_panel") is False
+
+    @pytest.mark.asyncio
+    async def test_default_icon_when_none_provided(self):
+        manager, _, _ = _make_manager()
+        with patch("time.time", return_value=1000):
+            await manager.trigger({"duration": 5})
+        with patch("time.time", return_value=1004):
+            layout = manager.build_layout()
+        hero = layout.get_slot(0).widget
+        assert hero is not None
+        assert hero.config.options["icon"] == "mdi:bell-ring"

--- a/tests/test_render_data_pipeline.py
+++ b/tests/test_render_data_pipeline.py
@@ -1,0 +1,123 @@
+"""Tests for the render_data_pipeline module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.geekmagic.layouts.grid import Grid2x2
+from custom_components.geekmagic.render_data_pipeline import RenderDataPipeline
+from custom_components.geekmagic.widget_state_builder import PrefetchedData
+from custom_components.geekmagic.widgets.base import WidgetConfig
+from custom_components.geekmagic.widgets.chart import ChartWidget
+from custom_components.geekmagic.widgets.clock import ClockWidget
+from custom_components.geekmagic.widgets.media import MediaWidget
+
+
+def _hass_with_states(states: dict | None = None):
+    hass = MagicMock()
+    resolved = states or {}
+    hass.states.get = resolved.get
+    hass.services.async_call = AsyncMock(return_value={})
+    return hass
+
+
+class TestEmptyLayout:
+    @pytest.mark.asyncio
+    async def test_empty_layout_does_no_fetches(self):
+        pipeline = RenderDataPipeline(_hass_with_states())
+        result = await pipeline.prefetch(Grid2x2())
+        assert isinstance(result, PrefetchedData)
+        assert result.camera_images == {}
+        assert result.chart_history == {}
+        assert result.weather_forecasts == {}
+
+    @pytest.mark.asyncio
+    async def test_layout_with_no_prefetchable_widgets_skips_io(self):
+        layout = Grid2x2()
+        layout.set_widget(0, ClockWidget(WidgetConfig(widget_type="clock", slot=0)))
+        hass = _hass_with_states()
+        pipeline = RenderDataPipeline(hass)
+        await pipeline.prefetch(layout)
+        # No service calls — weather/recorder/camera weren't touched
+        hass.services.async_call.assert_not_awaited()
+
+
+class TestChartFetch:
+    @pytest.mark.asyncio
+    async def test_chart_widget_history_lands_in_prefetched(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            ChartWidget(WidgetConfig(widget_type="chart", slot=0, entity_id="sensor.temp")),
+        )
+        hass = _hass_with_states()
+        pipeline = RenderDataPipeline(hass)
+
+        with patch(
+            "custom_components.geekmagic.render_data_pipeline.HistoryFetcher"
+        ) as mock_fetcher_cls:
+            instance = mock_fetcher_cls.return_value
+            instance.available = True
+            instance.fetch_numeric = AsyncMock(return_value=[1.0, 2.0, 3.0])
+            result = await pipeline.prefetch(layout)
+
+        assert result.chart_history["sensor.temp"] == [1.0, 2.0, 3.0]
+
+    @pytest.mark.asyncio
+    async def test_chart_skipped_when_recorder_unavailable(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            ChartWidget(WidgetConfig(widget_type="chart", slot=0, entity_id="sensor.temp")),
+        )
+        pipeline = RenderDataPipeline(_hass_with_states())
+
+        with patch(
+            "custom_components.geekmagic.render_data_pipeline.HistoryFetcher"
+        ) as mock_fetcher_cls:
+            mock_fetcher_cls.return_value.available = False
+            result = await pipeline.prefetch(layout)
+
+        assert result.chart_history == {}
+
+
+class TestMediaImagesClearedWhenAttributeGone:
+    @pytest.mark.asyncio
+    async def test_media_image_cleared_when_entity_picture_missing(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            MediaWidget(WidgetConfig(widget_type="media", slot=0, entity_id="media_player.spk")),
+        )
+        # First populate the cache, then run a fetch where the state has no entity_picture
+        state = MagicMock()
+        state.attributes = {}  # no entity_picture
+        hass = _hass_with_states({"media_player.spk": state})
+
+        pipeline = RenderDataPipeline(hass)
+        pipeline._media_images["media_player.spk"] = b"stale"
+
+        await pipeline.prefetch(layout)
+        assert "media_player.spk" not in pipeline._media_images
+
+
+class TestNotificationImageSourcePassedThrough:
+    @pytest.mark.asyncio
+    async def test_image_source_camera_id_added_to_fetch_set(self):
+        layout = Grid2x2()
+        layout.set_widget(0, ClockWidget(WidgetConfig(widget_type="clock", slot=0)))
+        hass = _hass_with_states()
+        pipeline = RenderDataPipeline(hass)
+
+        mock_image = MagicMock()
+        mock_image.content = b"jpegbytes"
+        with patch(
+            "homeassistant.components.camera.async_get_image",
+            new=AsyncMock(return_value=mock_image),
+        ) as mock_get:
+            await pipeline.prefetch(layout, image_source="camera.front_door")
+
+        mock_get.assert_awaited_once()
+        assert pipeline._camera_images["camera.front_door"] == b"jpegbytes"

--- a/tests/test_screen_builder.py
+++ b/tests/test_screen_builder.py
@@ -1,0 +1,153 @@
+"""Tests for the screen_builder module."""
+
+from __future__ import annotations
+
+from custom_components.geekmagic.const import (
+    CONF_LAYOUT,
+    CONF_SCREENS,
+    CONF_WIDGETS,
+    LAYOUT_GRID_2X2,
+    LAYOUT_HERO,
+)
+from custom_components.geekmagic.layouts.grid import Grid2x2
+from custom_components.geekmagic.layouts.hero import HeroLayout
+from custom_components.geekmagic.screen_builder import (
+    CONF_ASSIGNED_VIEWS,
+    LAYOUT_CLASSES,
+    build_layout,
+    build_screens,
+    migrate_options,
+    screen_name_at,
+)
+from custom_components.geekmagic.widgets.clock import ClockWidget
+
+
+class FakeStore:
+    """Stand-in for GeekMagicStore used in tests."""
+
+    def __init__(self, views: dict[str, dict]) -> None:
+        self._views = views
+
+    def get_view(self, view_id: str):
+        return self._views.get(view_id)
+
+
+class TestMigrateOptions:
+    def test_already_in_new_format_is_unchanged(self):
+        options = {CONF_SCREENS: [{"name": "A", CONF_LAYOUT: LAYOUT_GRID_2X2}]}
+        assert migrate_options(options) is options
+
+    def test_legacy_options_get_wrapped_in_screens(self):
+        legacy = {CONF_LAYOUT: LAYOUT_HERO, CONF_WIDGETS: [{"type": "clock", "slot": 0}]}
+        migrated = migrate_options(legacy)
+        assert CONF_SCREENS in migrated
+        assert migrated[CONF_SCREENS][0][CONF_LAYOUT] == LAYOUT_HERO
+
+    def test_legacy_empty_options_get_default_clock(self):
+        migrated = migrate_options({})
+        assert migrated[CONF_SCREENS][0][CONF_WIDGETS] == [{"type": "clock", "slot": 0}]
+
+
+class TestBuildLayout:
+    def test_returns_correct_layout_class_for_known_type(self):
+        layout = build_layout({CONF_LAYOUT: LAYOUT_HERO, CONF_WIDGETS: []})
+        assert isinstance(layout, HeroLayout)
+
+    def test_falls_back_to_grid_2x2_for_unknown_type(self):
+        layout = build_layout({CONF_LAYOUT: "totally-made-up", CONF_WIDGETS: []})
+        assert isinstance(layout, Grid2x2)
+
+    def test_wires_widget_into_slot(self):
+        layout = build_layout(
+            {CONF_LAYOUT: LAYOUT_GRID_2X2, CONF_WIDGETS: [{"type": "clock", "slot": 1}]}
+        )
+        assert isinstance(layout.slots[1].widget, ClockWidget)
+        assert layout.slots[0].widget is None
+
+    def test_skips_widget_in_out_of_range_slot(self):
+        layout = build_layout(
+            {CONF_LAYOUT: LAYOUT_GRID_2X2, CONF_WIDGETS: [{"type": "clock", "slot": 99}]}
+        )
+        assert all(slot.widget is None for slot in layout.slots)
+
+    def test_skips_unknown_widget_type(self):
+        layout = build_layout(
+            {CONF_LAYOUT: LAYOUT_GRID_2X2, CONF_WIDGETS: [{"type": "not-real", "slot": 0}]}
+        )
+        assert layout.slots[0].widget is None
+
+    def test_color_list_is_coerced_to_rgb_tuple(self):
+        layout = build_layout(
+            {
+                CONF_LAYOUT: LAYOUT_GRID_2X2,
+                CONF_WIDGETS: [{"type": "clock", "slot": 0, "color": [10, 20, 30]}],
+            }
+        )
+        widget = layout.slots[0].widget
+        assert widget is not None
+        assert widget.config.color == (10, 20, 30)
+
+    def test_empty_widget_list_gets_default_clock(self):
+        layout = build_layout({CONF_LAYOUT: LAYOUT_GRID_2X2, CONF_WIDGETS: []})
+        assert isinstance(layout.slots[0].widget, ClockWidget)
+
+
+class TestBuildScreens:
+    def test_legacy_screens_path(self):
+        options = {
+            CONF_SCREENS: [
+                {"name": "Home", CONF_LAYOUT: LAYOUT_GRID_2X2, CONF_WIDGETS: []},
+                {"name": "Office", CONF_LAYOUT: LAYOUT_HERO, CONF_WIDGETS: []},
+            ]
+        }
+        pairs = build_screens(options, store=None)
+        assert [name for name, _ in pairs] == ["Home", "Office"]
+        assert isinstance(pairs[0][1], Grid2x2)
+        assert isinstance(pairs[1][1], HeroLayout)
+
+    def test_global_views_path(self):
+        store = FakeStore(
+            {
+                "v1": {"name": "Dash", CONF_LAYOUT: LAYOUT_HERO, CONF_WIDGETS: []},
+                "v2": {"name": "Stats", CONF_LAYOUT: LAYOUT_GRID_2X2, CONF_WIDGETS: []},
+            }
+        )
+        pairs = build_screens({CONF_ASSIGNED_VIEWS: ["v1", "v2"]}, store=store)
+        assert [name for name, _ in pairs] == ["Dash", "Stats"]
+
+    def test_missing_view_is_skipped(self):
+        store = FakeStore({"v1": {"name": "Only", CONF_LAYOUT: LAYOUT_HERO, CONF_WIDGETS: []}})
+        pairs = build_screens({CONF_ASSIGNED_VIEWS: ["v1", "ghost"]}, store=store)
+        assert len(pairs) == 1
+        assert pairs[0][0] == "Only"
+
+    def test_global_views_without_store_falls_back_to_legacy(self):
+        options = {
+            CONF_ASSIGNED_VIEWS: ["v1"],
+            CONF_SCREENS: [{"name": "Fallback", CONF_LAYOUT: LAYOUT_GRID_2X2, CONF_WIDGETS: []}],
+        }
+        pairs = build_screens(options, store=None)
+        assert pairs[0][0] == "Fallback"
+
+
+class TestScreenNameAt:
+    def test_legacy_screen_name(self):
+        options = {CONF_SCREENS: [{"name": "Home"}, {"name": "Office"}]}
+        assert screen_name_at(options, 1, store=None) == "Office"
+
+    def test_legacy_screen_out_of_range(self):
+        options = {CONF_SCREENS: [{"name": "Home"}]}
+        assert screen_name_at(options, 5, store=None) == "Unknown"
+
+    def test_global_view_name(self):
+        store = FakeStore({"v1": {"name": "Dash"}})
+        assert screen_name_at({CONF_ASSIGNED_VIEWS: ["v1"]}, 0, store=store) == "Dash"
+
+    def test_global_view_unknown_without_store(self):
+        assert screen_name_at({CONF_ASSIGNED_VIEWS: ["v1"]}, 0, store=None) == "Unknown"
+
+
+def test_layout_classes_registry_covers_known_layouts():
+    # Sanity: registry contains entries for every layout constant string used in tests
+    assert LAYOUT_GRID_2X2 in LAYOUT_CLASSES
+    assert LAYOUT_HERO in LAYOUT_CLASSES

--- a/tests/test_widget_state_builder.py
+++ b/tests/test_widget_state_builder.py
@@ -48,9 +48,7 @@ class TestBuildWidgetStates:
         layout = Grid2x2()
         layout.set_widget(
             0,
-            EntityWidget(
-                WidgetConfig(widget_type="entity", slot=0, entity_id="sensor.temp")
-            ),
+            EntityWidget(WidgetConfig(widget_type="entity", slot=0, entity_id="sensor.temp")),
         )
         hass = _make_hass({"sensor.temp": _ha_state("sensor.temp", "22", {"unit": "°C"})})
         states = build_widget_states(layout, hass, PrefetchedData())
@@ -61,9 +59,7 @@ class TestBuildWidgetStates:
         layout = Grid2x2()
         layout.set_widget(
             0,
-            ChartWidget(
-                WidgetConfig(widget_type="chart", slot=0, entity_id="sensor.temp")
-            ),
+            ChartWidget(WidgetConfig(widget_type="chart", slot=0, entity_id="sensor.temp")),
         )
         hass = _make_hass({"sensor.temp": _ha_state("sensor.temp", "22")})
         states = build_widget_states(
@@ -77,9 +73,7 @@ class TestBuildWidgetStates:
         layout = Grid2x2()
         layout.set_widget(
             0,
-            ChartWidget(
-                WidgetConfig(widget_type="chart", slot=0, entity_id="sensor.temp")
-            ),
+            ChartWidget(WidgetConfig(widget_type="chart", slot=0, entity_id="sensor.temp")),
         )
         hass = _make_hass({"sensor.temp": _ha_state("sensor.temp", "22")})
         states = build_widget_states(layout, hass, PrefetchedData())
@@ -89,9 +83,7 @@ class TestBuildWidgetStates:
         layout = Grid2x2()
         layout.set_widget(
             0,
-            EntityWidget(
-                WidgetConfig(widget_type="entity", slot=0, entity_id="sensor.temp")
-            ),
+            EntityWidget(WidgetConfig(widget_type="entity", slot=0, entity_id="sensor.temp")),
         )
         hass = _make_hass({"sensor.temp": _ha_state("sensor.temp", "22")})
         states = build_widget_states(

--- a/tests/test_widget_state_builder.py
+++ b/tests/test_widget_state_builder.py
@@ -1,0 +1,109 @@
+"""Tests for the widget_state_builder module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.geekmagic.layouts.grid import Grid2x2
+from custom_components.geekmagic.widget_state_builder import (
+    PrefetchedData,
+    build_widget_states,
+)
+from custom_components.geekmagic.widgets.base import WidgetConfig
+from custom_components.geekmagic.widgets.chart import ChartWidget
+from custom_components.geekmagic.widgets.clock import ClockWidget
+from custom_components.geekmagic.widgets.entity import EntityWidget
+
+
+def _make_hass(states: dict[str, MagicMock] | None = None):
+    resolved = states or {}
+    hass = MagicMock()
+    hass.config.time_zone_obj = None
+    hass.states.get = resolved.get
+    return hass
+
+
+def _ha_state(entity_id: str, state: str, attributes: dict | None = None):
+    s = MagicMock()
+    s.entity_id = entity_id
+    s.state = state
+    s.attributes = attributes or {}
+    return s
+
+
+class TestBuildWidgetStates:
+    def test_empty_layout_returns_empty(self):
+        layout = Grid2x2()
+        states = build_widget_states(layout, _make_hass(), PrefetchedData())
+        assert states == {}
+
+    def test_widget_with_no_entity_gets_state_with_none_entity(self):
+        layout = Grid2x2()
+        layout.set_widget(0, ClockWidget(WidgetConfig(widget_type="clock", slot=0)))
+        states = build_widget_states(layout, _make_hass(), PrefetchedData())
+        assert states[0].entity is None
+        assert states[0].now is not None
+
+    def test_widget_resolves_primary_entity_from_hass(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            EntityWidget(
+                WidgetConfig(widget_type="entity", slot=0, entity_id="sensor.temp")
+            ),
+        )
+        hass = _make_hass({"sensor.temp": _ha_state("sensor.temp", "22", {"unit": "°C"})})
+        states = build_widget_states(layout, hass, PrefetchedData())
+        assert states[0].entity is not None
+        assert states[0].entity.state == "22"
+
+    def test_chart_widget_pulls_history_from_prefetched(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            ChartWidget(
+                WidgetConfig(widget_type="chart", slot=0, entity_id="sensor.temp")
+            ),
+        )
+        hass = _make_hass({"sensor.temp": _ha_state("sensor.temp", "22")})
+        states = build_widget_states(
+            layout,
+            hass,
+            PrefetchedData(chart_history={"sensor.temp": [1.0, 2.0, 3.0]}),
+        )
+        assert states[0].history == [1.0, 2.0, 3.0]
+
+    def test_chart_widget_without_history_gets_empty_list(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            ChartWidget(
+                WidgetConfig(widget_type="chart", slot=0, entity_id="sensor.temp")
+            ),
+        )
+        hass = _make_hass({"sensor.temp": _ha_state("sensor.temp", "22")})
+        states = build_widget_states(layout, hass, PrefetchedData())
+        assert states[0].history == []
+
+    def test_non_chart_widget_ignores_chart_history(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            EntityWidget(
+                WidgetConfig(widget_type="entity", slot=0, entity_id="sensor.temp")
+            ),
+        )
+        hass = _make_hass({"sensor.temp": _ha_state("sensor.temp", "22")})
+        states = build_widget_states(
+            layout,
+            hass,
+            PrefetchedData(chart_history={"sensor.temp": [99.0]}),
+        )
+        assert states[0].history == []
+
+    def test_empty_slot_is_skipped(self):
+        layout = Grid2x2()
+        layout.set_widget(0, ClockWidget(WidgetConfig(widget_type="clock", slot=0)))
+        # Slots 1, 2, 3 left empty
+        states = build_widget_states(layout, _make_hass(), PrefetchedData())
+        assert list(states.keys()) == [0]

--- a/tests/test_widget_state_builder.py
+++ b/tests/test_widget_state_builder.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from io import BytesIO
 from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+from PIL import Image
 
 from custom_components.geekmagic.layouts.grid import Grid2x2
 from custom_components.geekmagic.widget_state_builder import (
@@ -10,9 +14,21 @@ from custom_components.geekmagic.widget_state_builder import (
     build_widget_states,
 )
 from custom_components.geekmagic.widgets.base import WidgetConfig
+from custom_components.geekmagic.widgets.camera import CameraWidget
+from custom_components.geekmagic.widgets.candlestick import CandlestickWidget
 from custom_components.geekmagic.widgets.chart import ChartWidget
 from custom_components.geekmagic.widgets.clock import ClockWidget
 from custom_components.geekmagic.widgets.entity import EntityWidget
+from custom_components.geekmagic.widgets.media import MediaWidget
+from custom_components.geekmagic.widgets.progress import MultiProgressWidget
+from custom_components.geekmagic.widgets.weather import WeatherWidget
+
+
+def _png_bytes(size: tuple[int, int] = (4, 4)) -> bytes:
+    """Tiny in-memory PNG so Image.open works without disk I/O."""
+    buf = BytesIO()
+    Image.new("RGB", size, color=(1, 2, 3)).save(buf, format="PNG")
+    return buf.getvalue()
 
 
 def _make_hass(states: dict[str, MagicMock] | None = None):
@@ -99,3 +115,193 @@ class TestBuildWidgetStates:
         # Slots 1, 2, 3 left empty
         states = build_widget_states(layout, _make_hass(), PrefetchedData())
         assert list(states.keys()) == [0]
+
+
+class TestImageLoading:
+    def test_camera_widget_loads_image_from_camera_cache(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            CameraWidget(WidgetConfig(widget_type="camera", slot=0, entity_id="camera.front")),
+        )
+        states = build_widget_states(
+            layout,
+            _make_hass(),
+            PrefetchedData(camera_images={"camera.front": _png_bytes()}),
+        )
+        assert isinstance(states[0].image, Image.Image)
+
+    def test_camera_widget_with_no_cached_bytes_gets_none(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            CameraWidget(WidgetConfig(widget_type="camera", slot=0, entity_id="camera.front")),
+        )
+        states = build_widget_states(layout, _make_hass(), PrefetchedData())
+        assert states[0].image is None
+
+    def test_camera_widget_with_corrupt_bytes_gets_none_not_raise(self):
+        # Image.open raising should be suppressed
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            CameraWidget(WidgetConfig(widget_type="camera", slot=0, entity_id="camera.front")),
+        )
+        states = build_widget_states(
+            layout,
+            _make_hass(),
+            PrefetchedData(camera_images={"camera.front": b"not-an-image"}),
+        )
+        assert states[0].image is None
+
+    def test_media_widget_loads_image_from_media_cache(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            MediaWidget(WidgetConfig(widget_type="media", slot=0, entity_id="media_player.spk")),
+        )
+        hass = _make_hass({"media_player.spk": _ha_state("media_player.spk", "playing")})
+        states = build_widget_states(
+            layout,
+            hass,
+            PrefetchedData(media_images={"media_player.spk": _png_bytes()}),
+        )
+        assert isinstance(states[0].image, Image.Image)
+
+    def test_non_image_widget_ignores_caches(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            EntityWidget(WidgetConfig(widget_type="entity", slot=0, entity_id="sensor.temp")),
+        )
+        hass = _make_hass({"sensor.temp": _ha_state("sensor.temp", "22")})
+        states = build_widget_states(
+            layout,
+            hass,
+            PrefetchedData(camera_images={"sensor.temp": _png_bytes()}),
+        )
+        assert states[0].image is None
+
+
+class TestForecastAndCandlestick:
+    def test_weather_widget_pulls_forecast_from_prefetched(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            WeatherWidget(WidgetConfig(widget_type="weather", slot=0, entity_id="weather.home")),
+        )
+        hass = _make_hass({"weather.home": _ha_state("weather.home", "sunny")})
+        forecast = [{"datetime": "2026-01-01T00:00:00+00:00", "temperature": 20}]
+        states = build_widget_states(
+            layout, hass, PrefetchedData(weather_forecasts={"weather.home": forecast})
+        )
+        assert states[0].forecast == forecast
+
+    def test_weather_widget_without_forecast_gets_empty_list(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            WeatherWidget(WidgetConfig(widget_type="weather", slot=0, entity_id="weather.home")),
+        )
+        hass = _make_hass({"weather.home": _ha_state("weather.home", "sunny")})
+        states = build_widget_states(layout, hass, PrefetchedData())
+        assert states[0].forecast == []
+
+    def test_candlestick_widget_pulls_data_from_prefetched(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            CandlestickWidget(
+                WidgetConfig(widget_type="candlestick", slot=0, entity_id="sensor.btc")
+            ),
+        )
+        hass = _make_hass({"sensor.btc": _ha_state("sensor.btc", "100")})
+        candles = [(100.0, 110.0, 90.0, 105.0), (105.0, 115.0, 100.0, 110.0)]
+        states = build_widget_states(
+            layout, hass, PrefetchedData(candlestick_data={"sensor.btc": candles})
+        )
+        assert states[0].candlestick_data == candles
+
+
+class TestClockTimezoneOverride:
+    def test_clock_with_timezone_option_overrides_widget_now(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            ClockWidget(
+                WidgetConfig(widget_type="clock", slot=0, options={"timezone": "Asia/Tokyo"})
+            ),
+        )
+        states = build_widget_states(layout, _make_hass(), PrefetchedData())
+        # Should be in Tokyo's tz, not the base/UTC
+        assert states[0].now.tzinfo == ZoneInfo("Asia/Tokyo")
+
+    def test_clock_without_timezone_uses_base_now(self):
+        layout = Grid2x2()
+        layout.set_widget(0, ClockWidget(WidgetConfig(widget_type="clock", slot=0)))
+        states = build_widget_states(layout, _make_hass(), PrefetchedData())
+        # Base time = UTC fallback (no time_zone_obj on mock)
+        assert states[0].now.tzinfo is not None
+
+    def test_clock_with_invalid_timezone_falls_back_silently(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            ClockWidget(
+                WidgetConfig(widget_type="clock", slot=0, options={"timezone": "Not/A/Zone"})
+            ),
+        )
+        # Must not raise — ZoneInfo error is suppressed and base time used
+        states = build_widget_states(layout, _make_hass(), PrefetchedData())
+        assert states[0].now is not None
+
+
+class TestAdditionalEntities:
+    def test_multi_progress_widget_resolves_each_item_entity(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            MultiProgressWidget(
+                WidgetConfig(
+                    widget_type="multi_progress",
+                    slot=0,
+                    options={
+                        "items": [
+                            {"entity_id": "sensor.a", "label": "A"},
+                            {"entity_id": "sensor.b", "label": "B"},
+                        ]
+                    },
+                )
+            ),
+        )
+        hass = _make_hass(
+            {
+                "sensor.a": _ha_state("sensor.a", "1"),
+                "sensor.b": _ha_state("sensor.b", "2"),
+            }
+        )
+        states = build_widget_states(layout, hass, PrefetchedData())
+        assert set(states[0].entities.keys()) == {"sensor.a", "sensor.b"}
+        assert states[0].entities["sensor.a"].state == "1"
+        assert states[0].entities["sensor.b"].state == "2"
+
+    def test_additional_entity_missing_in_hass_is_skipped(self):
+        layout = Grid2x2()
+        layout.set_widget(
+            0,
+            MultiProgressWidget(
+                WidgetConfig(
+                    widget_type="multi_progress",
+                    slot=0,
+                    options={
+                        "items": [
+                            {"entity_id": "sensor.a"},
+                            {"entity_id": "sensor.gone"},
+                        ]
+                    },
+                )
+            ),
+        )
+        hass = _make_hass({"sensor.a": _ha_state("sensor.a", "1")})
+        states = build_widget_states(layout, hass, PrefetchedData())
+        assert set(states[0].entities.keys()) == {"sensor.a"}


### PR DESCRIPTION
The legacy/new options format detection, LAYOUT_CLASSES registry, store
lookups, and per-widget instantiation (registry lookup, color coercion,
default widget) lived as a shallow procedure copied across three callers
— coordinator._setup_screens/_create_layout, preview.render_preview, and
websocket.ws_preview_render — with LAYOUT_CLASSES literally duplicated
between coordinator.py and preview.py.

Collapses that procedure into one deep module: callers hand in a config
dict and get back ready-to-render Layout instances. The two-format read
and registry resolution disappear behind the seam.