### PR TITLE
fix: treat cleared icon ('') as no icon in DataCard

### DIFF
--- a/custom_components/geekmagic/widgets/data_card.py
+++ b/custom_components/geekmagic/widgets/data_card.py
@@ -319,7 +319,11 @@ class DataCard(Component):
         entity / gauge widgets relied on.
         """
         bands: list[Component] = []
-        feature_icon = self.icon_role == "feature" and self.icon is not None
+        # Truthy check (not ``is not None``): the icon-picker frontend
+        # writes ``""`` when the user clears it, and a blank name resolves
+        # to ``help-circle`` in ``get_mdi_char`` — which would surface as a
+        # stray question-mark glyph instead of "no icon".
+        feature_icon = self.icon_role == "feature" and bool(self.icon)
         # Count bands up front so the icon can be sized to fit its
         # share of the cell — preventing overflow when the watchOS
         # three-band layout has to coexist with a chip strip in a
@@ -432,7 +436,7 @@ class DataCard(Component):
         bottom. The header uses ``Adaptive`` so it stacks vertically when too
         narrow to lay out horizontally.
         """
-        feature_icon = self.icon_role == "feature" and self.icon is not None
+        feature_icon = self.icon_role == "feature" and bool(self.icon)
         rows: list[Component] = []
         if feature_icon and (self.caption or self.hero):
             # Feature icon in compact mode: place the icon on the left

--- a/custom_components/geekmagic/widgets/gauge.py
+++ b/custom_components/geekmagic/widgets/gauge.py
@@ -43,7 +43,9 @@ class GaugeWidget(Widget):
             {"key": "min", "type": "number", "label": "Minimum", "default": 0},
             {"key": "max", "type": "number", "label": "Maximum", "default": 100},
             {"key": "unit", "type": "text", "label": "Unit Override"},
+            {"key": "show_name", "type": "boolean", "label": "Show Name", "default": True},
             {"key": "show_value", "type": "boolean", "label": "Show Value", "default": True},
+            {"key": "show_unit", "type": "boolean", "label": "Show Unit", "default": True},
             {"key": "icon", "type": "icon", "label": "Icon"},
             {"key": "attribute", "type": "text", "label": "Entity Attribute"},
             {"key": "color_thresholds", "type": "thresholds", "label": "Color Thresholds"},
@@ -58,8 +60,12 @@ class GaugeWidget(Widget):
         self.orientation = config.options.get("orientation", "auto")
         self.min_value = config.options.get("min", 0)
         self.max_value = config.options.get("max", 100)
-        self.icon = config.options.get("icon")
+        # Normalise icon: ``ha-icon-picker`` writes ``""`` when cleared, but
+        # downstream the empty string used to render as ``help-circle``.
+        self.icon = config.options.get("icon") or None
+        self.show_name = config.options.get("show_name", True)
         self.show_value = config.options.get("show_value", True)
+        self.show_unit = config.options.get("show_unit", True)
         self.unit = config.options.get("unit", "")
         # Attribute to read value from
         self.attribute = config.options.get("attribute")
@@ -105,16 +111,19 @@ class GaugeWidget(Widget):
         value = entity.numeric(self.attribute) if entity is not None else 0.0
         display_value = f"{value:.0f}" if entity is not None else "--"
 
-        # Get unit from entity if not configured
-        unit = self.unit
-        if not unit and entity is not None:
-            unit = entity.unit or ""
+        # Get unit (override > entity unit, suppressed when show_unit is off).
+        if not self.show_unit:
+            unit = ""
+        else:
+            unit = self.unit
+            if not unit and entity is not None:
+                unit = entity.unit or ""
 
         # Calculate percentage
         percent = calculate_percent(value, self.min_value, self.max_value)
 
-        # Get label
-        name = self.label_for(entity)
+        # Get label — empty string when hidden so DataCard drops the caption band.
+        name = self.label_for(entity) if self.show_name else ""
 
         # Determine color
         threshold_color = self._get_threshold_color(value)

--- a/tests/widgets/test_data_card.py
+++ b/tests/widgets/test_data_card.py
@@ -174,6 +174,24 @@ class TestDataCardStacked:
         col = self._stacked(caption="CPU", hero="73%", indicator=bar)
         assert col.children[-1] is bar
 
+    def test_empty_string_icon_treated_as_no_icon_chip_role(self) -> None:
+        """ha-icon-picker writes ``""`` when cleared; without truthy
+        guard the chip-role caption band would render ``Icon("")`` →
+        ``help-circle`` fallback (issue #125)."""
+        col = self._stacked(caption="CPU", icon="", hero="73%")
+        caption_row = col.children[0]
+        assert isinstance(caption_row, Row)
+        assert all(not isinstance(c, Icon) for c in caption_row.children)
+
+    def test_empty_string_icon_treated_as_no_icon_feature_role(self) -> None:
+        """In feature-icon mode the empty-string icon used to be promoted
+        to its own band as ``help-circle`` (issue #125)."""
+        col = self._stacked(caption="CPU", icon="", icon_role="feature", hero="73%")
+        # No band should contain an Icon — feature_icon must be False.
+        for band in col.children:
+            if isinstance(band, Row):
+                assert all(not isinstance(c, Icon) for c in band.children)
+
 
 class TestDataCardCompact:
     """Compact mode — header pinned top via Adaptive, indicator pinned bottom."""
@@ -225,6 +243,25 @@ class TestDataCardCompact:
         bar = Bar(percent=73, color=THEME_PRIMARY)
         col = self._compact(caption="CPU", hero="73%", indicator=bar)
         assert col.children[-1] is bar
+
+    def test_empty_string_icon_treated_as_no_icon_feature_role(self) -> None:
+        """Compact mode's feature-icon branch must also reject ``""``
+        (issue #125)."""
+        col = self._compact(caption="CPU", icon="", icon_role="feature", hero="73%")
+
+        # Walk the tree; no Icon component should appear anywhere.
+        def _has_icon(comp: object) -> bool:
+            if isinstance(comp, Icon):
+                return True
+            children = getattr(comp, "children", None)
+            if children:
+                return any(_has_icon(c) for c in children)
+            child = getattr(comp, "child", None)
+            if child is not None:
+                return _has_icon(child)
+            return False
+
+        assert not _has_icon(col)
 
 
 class TestDataCardRing:

--- a/tests/widgets/test_widgets.py
+++ b/tests/widgets/test_widgets.py
@@ -940,6 +940,69 @@ class TestGaugeWidget:
         widget.render(ctx, state)
         assert img.size == (480, 480)
 
+    def test_defaults_show_name_and_show_unit(self):
+        """show_name / show_unit default to True (parity with EntityWidget)."""
+        config = WidgetConfig(widget_type="gauge", slot=0, entity_id="sensor.cpu")
+        widget = GaugeWidget(config)
+        assert widget.show_name is True
+        assert widget.show_unit is True
+
+    def test_show_name_false_drops_caption(self, renderer, canvas, rect, hass):
+        """When show_name=False, the BarGauge label is empty so DataCard
+        drops the caption band entirely (no friendly_name fallback)."""
+        _img, draw = canvas
+        ctx = RenderContext(draw, rect, renderer)
+        hass.states.async_set("sensor.cpu", "75", {"friendly_name": "CPU Usage"})
+
+        config = WidgetConfig(
+            widget_type="gauge",
+            slot=0,
+            entity_id="sensor.cpu",
+            options={"show_name": False},
+        )
+        widget = GaugeWidget(config)
+        state = _build_widget_state(hass, "sensor.cpu")
+        component = widget.render(ctx, state)
+        from custom_components.geekmagic.widgets.component_helpers import BarGauge
+
+        assert isinstance(component, BarGauge)
+        assert component.label == ""
+
+    def test_show_unit_false_strips_entity_unit(self, renderer, canvas, rect, hass):
+        """show_unit=False suppresses both the unit override and the
+        entity's native unit (issue #125 — no way to hide ``%``)."""
+        _img, draw = canvas
+        ctx = RenderContext(draw, rect, renderer)
+        hass.states.async_set(
+            "sensor.cpu",
+            "75",
+            {"friendly_name": "CPU", "unit_of_measurement": "%"},
+        )
+
+        config = WidgetConfig(
+            widget_type="gauge",
+            slot=0,
+            entity_id="sensor.cpu",
+            options={"show_unit": False},
+        )
+        widget = GaugeWidget(config)
+        state = _build_widget_state(hass, "sensor.cpu")
+        component = widget.render(ctx, state)
+        assert component.value == "75"  # no trailing "%"
+
+    def test_cleared_icon_normalises_to_none(self):
+        """ha-icon-picker writes ``""`` when cleared — the gauge widget
+        normalises that to ``None`` so DataCard doesn't render
+        ``help-circle`` as a placeholder (issue #125)."""
+        config = WidgetConfig(
+            widget_type="gauge",
+            slot=0,
+            entity_id="sensor.cpu",
+            options={"icon": ""},
+        )
+        widget = GaugeWidget(config)
+        assert widget.icon is None
+
 
 class TestProgressWidget:
     """Tests for ProgressWidget."""


### PR DESCRIPTION
The ha-icon-picker writes an empty string when the user clears the
field. DataCard's feature_icon guard used 'is not None', so '' fell
through, Icon('') rendered, and get_mdi_char fell back to help-circle —
surfacing a stray question-mark glyph instead of removing the icon.

Switch the stacked + compact feature_icon branches to a truthy check so
empty strings collapse the icon band cleanly, matching the chip-mode
'if self.icon:' guards elsewhere in the file.

Fixes part of #125 (cleared icon shows error/help icon).