### PR TITLE
feat: driver/strategy architecture for multi-firmware support

### DIFF
--- a/custom_components/geekmagic/__init__.py
+++ b/custom_components/geekmagic/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
+from .const import DOMAIN, MODEL_UNKNOWN
 from .coordinator import GeekMagicCoordinator
 from .device import GeekMagicDevice
 from .panel import async_register_panel
@@ -120,10 +120,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"Could not connect to GeekMagic device at {host}: {result.message}"
         )
 
-    _LOGGER.debug("Successfully connected to GeekMagic device at %s", host)
+    _LOGGER.debug(
+        "Successfully connected to GeekMagic device at %s (model=%s, sw=%s)",
+        host,
+        device.model,
+        device.sw_version,
+    )
 
-    # Detect device model (Pro vs Ultra)
-    await device.detect_model()
+    # `test_connection()` runs detection as part of its probe, so the driver
+    # is already wired here. Re-detect only if for some reason it isn't.
+    if device.model == MODEL_UNKNOWN:
+        await device.detect_model()
 
     # Create coordinator
     coordinator = GeekMagicCoordinator(

--- a/custom_components/geekmagic/config_flow.py
+++ b/custom_components/geekmagic/config_flow.py
@@ -27,6 +27,7 @@ from .const import (
     DEFAULT_SCREEN_CYCLE_INTERVAL,
     DOMAIN,
     LAYOUT_GRID_2X2,
+    MODEL_SDPRO,
     THEME_WATCHOS,
 )
 from .device import GeekMagicDevice
@@ -40,6 +41,12 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_SDPRO_CONFIRM_SCHEMA = vol.Schema(
+    {
+        vol.Required("disable_other_themes", default=True): bool,
+    }
+)
+
 
 class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for GeekMagic.
@@ -49,6 +56,13 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Carried across steps when the SD_PRO confirmation screen is shown.
+        self._pending_user_input: dict[str, Any] | None = None
+        self._pending_device_host: str | None = None
+        self._pending_theme_names: list[str] = []
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step - device connection."""
@@ -68,7 +82,26 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             result = await device.test_connection()
 
             if result.success:
-                _LOGGER.info("Config flow: successfully connected to %s", host)
+                _LOGGER.info("Config flow: connected to %s (model=%s)", host, device.model)
+
+                # SD_PRO firmware rotates through built-in themes by default,
+                # which would replace the integration's rendered image every
+                # few seconds. Ask the user before disabling those themes.
+                if device.model == MODEL_SDPRO:
+                    try:
+                        themes = await device.list_themes()
+                    except Exception as err:
+                        _LOGGER.warning("SD_PRO theme list lookup failed: %s", err)
+                        themes = []
+                    self._pending_theme_names = [
+                        str(t.get("name", f"theme {t.get('id')}"))
+                        for t in themes
+                        if t.get("enabled")
+                        and int(t.get("id", -1)) != device.driver.custom_image_theme
+                    ]
+                    self._pending_user_input = user_input
+                    self._pending_device_host = host
+                    return await self.async_step_sdpro_confirm()
 
                 # Create entry with default options
                 return self.async_create_entry(
@@ -83,6 +116,50 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
+        )
+
+    async def async_step_sdpro_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Warn the SD_PRO user that built-in themes will be disabled."""
+        assert self._pending_user_input is not None
+        assert self._pending_device_host is not None
+
+        if user_input is not None:
+            if user_input.get("disable_other_themes", True):
+                session = async_get_clientsession(self.hass)
+                device = GeekMagicDevice(self._pending_device_host, session=session)
+                await device.detect_model()
+                try:
+                    disabled = await device.disable_other_themes()
+                    if disabled:
+                        _LOGGER.info(
+                            "SD_PRO: disabled built-in themes: %s",
+                            ", ".join(disabled),
+                        )
+                except Exception as err:
+                    _LOGGER.warning("SD_PRO: could not disable built-in themes: %s", err)
+
+            saved_input = self._pending_user_input
+            self._pending_user_input = None
+            self._pending_device_host = None
+            self._pending_theme_names = []
+
+            return self.async_create_entry(
+                title=saved_input.get(CONF_NAME, f"GeekMagic ({self.unique_id})"),
+                data=saved_input,
+                options=self._get_default_options(),
+            )
+
+        themes_text = (
+            ", ".join(self._pending_theme_names)
+            if self._pending_theme_names
+            else "(none currently enabled)"
+        )
+        return self.async_show_form(
+            step_id="sdpro_confirm",
+            data_schema=STEP_SDPRO_CONFIRM_SCHEMA,
+            description_placeholders={"themes": themes_text},
         )
 
     def _get_default_options(self) -> dict[str, Any]:

--- a/custom_components/geekmagic/const.py
+++ b/custom_components/geekmagic/const.py
@@ -5,7 +5,25 @@ DOMAIN = "geekmagic"
 # Device models
 MODEL_ULTRA = "ultra"
 MODEL_PRO = "pro"
+MODEL_SDPRO = "sdpro"
 MODEL_UNKNOWN = "unknown"
+
+# Human-readable model names shown in the HA device registry.
+MODEL_DISPLAY_NAMES = {
+    MODEL_PRO: "SmallTV Pro",
+    MODEL_ULTRA: "SmallTV Ultra",
+    MODEL_SDPRO: "SmallTV Ultra (SD_PRO firmware)",
+    MODEL_UNKNOWN: "SmallTV",
+}
+
+# Per-firmware theme number for the "show a custom image" display mode.
+THEME_CUSTOM_IMAGE_PRO = 4  # Picture
+THEME_CUSTOM_IMAGE_ULTRA = 3  # Photo Album
+THEME_CUSTOM_IMAGE_SDPRO = 2  # Photo slideshow
+
+# Per-firmware brightness ranges accepted by the device.
+BRIGHTNESS_RANGE_STOCK = (0, 100)
+BRIGHTNESS_RANGE_SDPRO = (2, 99)
 
 # Display dimensions
 DISPLAY_WIDTH = 240

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -53,7 +53,6 @@ from .const import (
     LAYOUT_THREE_COLUMN,
     LAYOUT_THREE_ROW,
     MAX_BACKOFF_MULTIPLIER,
-    MODEL_PRO,
     THEME_WATCHOS,
 )
 from .device import DeviceState, GeekMagicDevice, SpaceInfo
@@ -668,12 +667,12 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             next_screen = (self._current_screen + 1) % len(self._layouts)
             await self.async_set_screen(next_screen)
 
-            # For Pro devices, also trigger device navigation to help refresh
-            if self.device.model == MODEL_PRO:
+            # For devices that support hardware navigation, trigger it too.
+            if self.device.supports_navigation:
                 try:
                     await self.device.navigate_next()
                 except Exception as err:
-                    _LOGGER.debug("Pro navigate_next failed (non-fatal): %s", err)
+                    _LOGGER.debug("navigate_next failed (non-fatal): %s", err)
 
     async def async_previous_screen(self) -> None:
         """Switch to the previous screen."""
@@ -681,12 +680,12 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             prev_screen = (self._current_screen - 1) % len(self._layouts)
             await self.async_set_screen(prev_screen)
 
-            # For Pro devices, also trigger device navigation to help refresh
-            if self.device.model == MODEL_PRO:
+            # For devices that support hardware navigation, trigger it too.
+            if self.device.supports_navigation:
                 try:
                     await self.device.navigate_previous()
                 except Exception as err:
-                    _LOGGER.debug("Pro navigate_previous failed (non-fatal): %s", err)
+                    _LOGGER.debug("navigate_previous failed (non-fatal): %s", err)
 
     def update_options(self, options: dict[str, Any]) -> None:
         """Update coordinator options.
@@ -1067,7 +1066,10 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                 # If device is in a built-in theme, respect that
                 if self._device_state and self._device_state.theme is not None:
                     device_theme = self._device_state.theme
-                    if device_theme < 3 and self._display_mode == "custom":
+                    if (
+                        not self.device.is_custom_image_theme(device_theme)
+                        and self._display_mode == "custom"
+                    ):
                         # Device is in built-in mode but we thought we were in custom
                         # This can happen on startup - sync to device state
                         _LOGGER.debug(

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -1,55 +1,41 @@
-"""GeekMagic device HTTP API client."""
+"""GeekMagic device HTTP client — thin facade over a firmware-specific driver."""
 
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from typing import Literal
 from urllib.parse import urlparse
 
 import aiohttp
 
-from .const import MODEL_PRO, MODEL_ULTRA, MODEL_UNKNOWN
+from .const import MODEL_UNKNOWN
+from .drivers import (
+    ConnectionResult,
+    DeviceDriver,
+    DeviceState,
+    SpaceInfo,
+    detect_driver,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 TIMEOUT = aiohttp.ClientTimeout(total=30)
 
-
-@dataclass
-class ConnectionResult:
-    """Result of a connection test."""
-
-    success: bool
-    error: Literal[
-        "none", "timeout", "connection_refused", "dns_error", "http_error", "unknown"
-    ] = "none"
-    message: str | None = None
-
-    def __bool__(self) -> bool:
-        """Allow using ConnectionResult in boolean context."""
-        return self.success
-
-
-@dataclass
-class DeviceState:
-    """Represents the current device state."""
-
-    theme: int
-    brightness: int | None
-    current_image: str | None
-
-
-@dataclass
-class SpaceInfo:
-    """Represents device storage info."""
-
-    total: int
-    free: int
+__all__ = [
+    "ConnectionResult",
+    "DeviceState",
+    "GeekMagicDevice",
+    "SpaceInfo",
+]
 
 
 class GeekMagicDevice:
-    """HTTP client for GeekMagic display devices."""
+    """HTTP facade for a GeekMagic display.
+
+    Detects the firmware (Stock Pro, Stock Ultra, SD_PRO) at setup time and
+    delegates every call to the corresponding `DeviceDriver`. Public method
+    names are preserved so callers in `coordinator.py`, `config_flow.py`,
+    `__init__.py`, and the entity modules don't need to know about drivers.
+    """
 
     def __init__(
         self,
@@ -57,348 +43,172 @@ class GeekMagicDevice:
         session: aiohttp.ClientSession | None = None,
         model: str = MODEL_UNKNOWN,
     ) -> None:
-        """Initialize the device client.
-
-        Args:
-            host: IP address, hostname, or URL of the device
-            session: Optional aiohttp session (created if not provided)
-            model: Device model (MODEL_PRO, MODEL_ULTRA, or MODEL_UNKNOWN)
-        """
-        # Parse and normalize the host input to handle URLs
         if host.startswith(("http://", "https://")):
             parsed = urlparse(host)
-            self.host = parsed.netloc  # e.g., "192.168.1.1" or "192.168.1.1:8080"
+            self.host = parsed.netloc
             self.base_url = f"{parsed.scheme}://{parsed.netloc}"
         else:
             self.host = host
             self.base_url = f"http://{host}"
+
         self._session = session
         self._owns_session = session is None
         self.model = model
+        self.sw_version: str | None = None
+        self._driver: DeviceDriver | None = None
+
+    # ----- driver wiring -----
+
+    @property
+    def driver(self) -> DeviceDriver:
+        if self._driver is None:
+            raise RuntimeError(
+                "GeekMagicDevice driver not initialised; "
+                "call detect_model() or test_connection() first"
+            )
+        return self._driver
+
+    @property
+    def supports_navigation(self) -> bool:
+        """True if the device's firmware honours `/set?page=`/`/set?enter=`."""
+        return bool(self._driver and self._driver.supports_navigation)
+
+    def is_custom_image_theme(self, theme: int) -> bool:
+        """True if `theme` is the firmware's custom-image display mode."""
+        if self._driver is None:
+            # Conservative default: stock Ultra (3). Used only before detection.
+            return theme == 3
+        return self._driver.is_custom_image_theme(theme)
 
     async def _get_session(self) -> aiohttp.ClientSession:
-        """Get or create the aiohttp session."""
         if self._session is None:
             self._session = aiohttp.ClientSession(timeout=TIMEOUT)
         return self._session
 
     async def close(self) -> None:
-        """Close the session if we own it."""
         if self._owns_session and self._session is not None:
             await self._session.close()
             self._session = None
 
-    async def get_state(self) -> DeviceState:
-        """Get current device state.
-
-        Returns:
-            DeviceState with theme, brightness, and current image
-        """
-        _LOGGER.debug("Getting device state from %s", self.host)
+    async def detect_model(self) -> str:
+        """Probe the device and pick the right driver."""
         session = await self._get_session()
-        async with session.get(f"{self.base_url}/app.json") as response:
-            response.raise_for_status()
-            # Device returns text/plain content type, so we need to accept any
-            data = await response.json(content_type=None)
-            state = DeviceState(
-                theme=data.get("theme", 0),
-                brightness=data.get("brt"),
-                current_image=data.get("img"),
-            )
-            _LOGGER.debug(
-                "Device state: theme=%d, brightness=%s, image=%s",
-                state.theme,
-                state.brightness,
-                state.current_image,
-            )
-            return state
+        driver = await detect_driver(self.base_url, session)
+        if driver is None:
+            self.model = MODEL_UNKNOWN
+            self.sw_version = None
+            self._driver = None
+            return self.model
+        self._driver = driver
+        self.model = driver.model
+        self.sw_version = driver.sw_version
+        return self.model
+
+    # ----- delegated device API -----
+
+    async def get_state(self) -> DeviceState:
+        return await self.driver.get_state()
 
     async def get_space(self) -> SpaceInfo:
-        """Get device storage information.
-
-        Returns:
-            SpaceInfo with total and free bytes
-        """
-        _LOGGER.debug("Getting storage info from %s", self.host)
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/space.json") as response:
-            response.raise_for_status()
-            # Device returns text/plain content type, so we need to accept any
-            data = await response.json(content_type=None)
-            space = SpaceInfo(
-                total=data.get("total", 0),
-                free=data.get("free", 0),
-            )
-            _LOGGER.debug(
-                "Storage info: total=%d, free=%d (%.1f%% free)",
-                space.total,
-                space.free,
-                (space.free / space.total * 100) if space.total > 0 else 0,
-            )
-            return space
+        return await self.driver.get_space()
 
     async def get_brightness(self) -> int:
-        """Get current brightness from device.
-
-        Returns:
-            Brightness level 0-100
-        """
-        _LOGGER.debug("Getting brightness from %s", self.host)
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/brt.json") as response:
-            response.raise_for_status()
-            data = await response.json(content_type=None)
-            # API returns brightness as string: {"brt": "71"}
-            brightness = int(data.get("brt", 0))
-            _LOGGER.debug("Device brightness: %d", brightness)
-            return brightness
+        return await self.driver.get_brightness()
 
     async def set_brightness(self, value: int) -> None:
-        """Set display brightness.
-
-        Args:
-            value: Brightness level 0-100
-        """
-        value = max(0, min(100, value))
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?brt={value}") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Set brightness to %d", value)
+        await self.driver.set_brightness(value)
 
     async def set_theme(self, theme: int) -> None:
-        """Set device theme.
-
-        Args:
-            theme: Theme number (3 = custom image on Ultra, 4 = custom image on Pro)
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?theme={theme}") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Set theme to %d", theme)
+        await self.driver.set_theme(theme)
 
     async def set_theme_custom(self) -> None:
-        """Set device to custom image mode with the correct theme number.
-
-        Ultra devices use theme 3, Pro devices use theme 4.
-        Uses the model detected at startup via detect_model().
-        """
-        theme = 4 if self.model == MODEL_PRO else 3
-        await self.set_theme(theme)
+        await self.driver.set_theme_custom()
 
     async def set_image(self, filename: str) -> None:
-        """Set the displayed image.
-
-        Args:
-            filename: Image filename (without path)
-        """
-        # Ensure we're in custom image mode
-        await self.set_theme_custom()
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?img=/image/{filename}") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Set image to %s", filename)
+        await self.driver.set_image(filename)
 
     async def upload(self, image_data: bytes, filename: str) -> None:
-        """Upload an image to the device.
-
-        Args:
-            image_data: Raw image bytes (JPEG or PNG)
-            filename: Filename to save as
-        """
-        # Determine content type from filename
-        if filename.lower().endswith(".png"):
-            content_type = "image/png"
-        elif filename.lower().endswith(".gif"):
-            content_type = "image/gif"
-        else:
-            content_type = "image/jpeg"
-
-        # Create multipart form data
-        form = aiohttp.FormData()
-        form.add_field(
-            "file",
-            image_data,
-            filename=filename,
-            content_type=content_type,
-        )
-
-        session = await self._get_session()
-        try:
-            async with session.post(
-                f"{self.base_url}/doUpload?dir=/image/",
-                data=form,
-            ) as response:
-                response.raise_for_status()
-        except aiohttp.ClientResponseError as e:
-            # Device firmware returns malformed HTTP responses, but upload succeeds.
-            # Known issues:
-            # - SmallTV-Ultra: Duplicate Content-Length headers
-            # - SmallTV-Pro: "Data after Connection: close" (sends OK + new response)
-            if e.status == 400:
-                msg = str(e.message) if e.message else ""
-                if "Duplicate Content-Length" in msg or "Data after" in msg:
-                    _LOGGER.debug("Ignoring malformed HTTP response from device: %s", msg)
-                    return
-            raise
-
-        _LOGGER.debug("Uploaded %s (%d bytes)", filename, len(image_data))
+        await self.driver.upload(image_data, filename)
 
     async def upload_and_display(self, image_data: bytes, filename: str) -> None:
-        """Upload an image and immediately display it.
-
-        Args:
-            image_data: Raw image bytes
-            filename: Filename to save as
-        """
         _LOGGER.debug(
             "Uploading and displaying %s (%d bytes) to %s",
             filename,
             len(image_data),
             self.host,
         )
-        await self.upload(image_data, filename)
-        await self.set_image(filename)
-        _LOGGER.debug("Upload and display completed for %s", filename)
+        await self.driver.upload_and_display(image_data, filename)
 
     async def delete_file(self, path: str) -> None:
-        """Delete a file from the device.
-
-        Args:
-            path: Full path to the file
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/delete?file={path}") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Deleted %s", path)
+        await self.driver.delete_file(path)
 
     async def clear_images(self) -> None:
-        """Clear all images from the device."""
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?clear=image") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Cleared all images")
+        await self.driver.clear_images()
 
-    async def test_connection(self) -> ConnectionResult:
-        """Test if the device is reachable.
+    async def reboot(self) -> None:
+        await self.driver.reboot()
 
-        Returns:
-            ConnectionResult with success status and error details if failed.
-            Can be used in boolean context (truthy if successful).
+    async def navigate_next(self) -> None:
+        await self.driver.navigate_next()
+
+    async def navigate_previous(self) -> None:
+        await self.driver.navigate_previous()
+
+    async def navigate_enter(self) -> None:
+        await self.driver.navigate_enter()
+
+    async def test_connection(self) -> ConnectionResult:  # noqa: PLR0911
+        """Confirm the device is reachable and pick its firmware driver.
+
+        Pings the device once first so we can return precise network-level
+        errors (timeout, DNS, connection refused). If the ping succeeds,
+        detection runs to wire the right driver — failure there becomes a
+        generic `http_error` because the device responded but didn't match
+        any known firmware.
         """
-        _LOGGER.debug("Testing connection to %s", self.host)
+        session = await self._get_session()
         try:
-            # use space.json as it's more widely supported across firmware versions
-            await self.get_space()
+            async with session.get(
+                f"{self.base_url}/v.json",
+                timeout=aiohttp.ClientTimeout(total=10),
+            ):
+                pass
         except TimeoutError:
-            _LOGGER.warning("Connection test timed out for %s", self.host)
             return ConnectionResult(
                 success=False,
                 error="timeout",
-                message="Connection timed out after 30 seconds",
+                message="Connection timed out after 10 seconds",
             )
-        except aiohttp.ClientConnectorDNSError as e:
-            _LOGGER.warning("DNS resolution failed for %s: %s", self.host, e)
+        except aiohttp.ClientConnectorDNSError as err:
             return ConnectionResult(
                 success=False,
                 error="dns_error",
-                message=f"Could not resolve hostname: {self.host}",
+                message=f"Could not resolve hostname: {err}",
             )
-        except aiohttp.ClientConnectorError as e:
-            _LOGGER.warning("Connection failed for %s: %s", self.host, e)
-            return ConnectionResult(
-                success=False,
-                error="connection_refused",
-                message=str(e),
-            )
-        except aiohttp.ClientResponseError as e:
-            _LOGGER.warning("HTTP error for %s: %s", self.host, e)
+        except aiohttp.ClientConnectorError as err:
+            return ConnectionResult(success=False, error="connection_refused", message=str(err))
+        except aiohttp.ClientResponseError:
+            # An HTTP-level error here is fine — the device responded.
+            pass
+        except aiohttp.ClientError as err:
+            return ConnectionResult(success=False, error="unknown", message=str(err))
+        except Exception as err:
+            # Bare OSError, etc. — surface so the user sees something.
+            return ConnectionResult(success=False, error="unknown", message=str(err))
+
+        try:
+            await self.detect_model()
+        except Exception as err:
+            _LOGGER.warning("Detection failed for %s: %s", self.host, err)
+            return ConnectionResult(success=False, error="unknown", message=str(err))
+
+        if self._driver is None:
             return ConnectionResult(
                 success=False,
                 error="http_error",
-                message=f"HTTP error {e.status}: {e.message}",
+                message=(
+                    "Device did not respond to firmware-detection probes "
+                    "(/v.json, /config, /app.json)."
+                ),
             )
-        except Exception as e:
-            _LOGGER.warning("Connection test failed for %s: %s", self.host, e)
-            return ConnectionResult(
-                success=False,
-                error="unknown",
-                message=str(e),
-            )
-        else:
-            _LOGGER.debug("Connection test successful for %s", self.host)
-            return ConnectionResult(success=True)
-
-    # Pro-specific navigation methods
-    # These simulate the physical button presses on SmallTV Pro devices
-
-    async def navigate_next(self) -> None:
-        """Navigate to next page (Pro devices).
-
-        Simulates pressing the right/next button on the device.
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?page=1") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Navigated to next page")
-
-    async def navigate_previous(self) -> None:
-        """Navigate to previous page (Pro devices).
-
-        Simulates pressing the left/previous button on the device.
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?page=-1") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Navigated to previous page")
-
-    async def navigate_enter(self) -> None:
-        """Press enter/exit button (Pro devices).
-
-        Simulates pressing the enter/menu button on the device.
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?enter=-1") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Pressed enter button")
-
-    async def reboot(self) -> None:
-        """Reboot the device (Pro devices)."""
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?reboot=1") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Rebooting device")
-
-    async def detect_model(self) -> str:
-        """Attempt to detect the device model.
-
-        Pro devices use /.sys/ paths, Ultra devices use root paths.
-        Returns MODEL_PRO, MODEL_ULTRA, or MODEL_UNKNOWN.
-        """
-        session = await self._get_session()
-
-        # Try Pro-specific path first (/.sys/app.json)
-        try:
-            async with session.get(
-                f"{self.base_url}/.sys/app.json", timeout=aiohttp.ClientTimeout(total=5)
-            ) as response:
-                if response.status == 200:
-                    self.model = MODEL_PRO
-                    _LOGGER.info("Detected device model: SmallTV Pro")
-                    return self.model
-        except Exception as err:
-            _LOGGER.debug("Pro path /.sys/app.json not available: %s", err)
-
-        # Fall back to Ultra (standard path works)
-        try:
-            async with session.get(
-                f"{self.base_url}/app.json", timeout=aiohttp.ClientTimeout(total=5)
-            ) as response:
-                if response.status == 200:
-                    self.model = MODEL_ULTRA
-                    _LOGGER.info("Detected device model: SmallTV Ultra")
-                    return self.model
-        except Exception as err:
-            _LOGGER.debug("Ultra path /app.json not available: %s", err)
-
-        _LOGGER.warning("Could not detect device model for %s", self.host)
-        return MODEL_UNKNOWN
+        return await self._driver.test_connection()

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -157,6 +157,27 @@ class GeekMagicDevice:
     async def navigate_enter(self) -> None:
         await self.driver.navigate_enter()
 
+    async def list_themes(self) -> list[dict]:
+        """Return the device's built-in themes (SD_PRO only)."""
+        driver = self.driver
+        if not hasattr(driver, "list_themes"):
+            return []
+        return await driver.list_themes()
+
+    async def disable_other_themes(self) -> list[str]:
+        """Disable every built-in theme except the one we render into.
+
+        Currently only meaningful for SD_PRO firmware, whose device-side
+        theme rotation would otherwise switch away from the integration's
+        rendered photo. Returns the list of disabled theme names; an empty
+        list means nothing needed changing (or the firmware doesn't support
+        this concept).
+        """
+        driver = self.driver
+        if not hasattr(driver, "disable_other_themes"):
+            return []
+        return await driver.disable_other_themes()
+
     async def test_connection(self) -> ConnectionResult:  # noqa: PLR0911
         """Confirm the device is reachable and pick its firmware driver.
 

--- a/custom_components/geekmagic/drivers/__init__.py
+++ b/custom_components/geekmagic/drivers/__init__.py
@@ -1,0 +1,85 @@
+"""Driver factory + detection for GeekMagic firmwares."""
+
+from __future__ import annotations
+
+import logging
+
+import aiohttp
+
+from .base import (
+    DETECT_TIMEOUT,
+    ConnectionResult,
+    DeviceDriver,
+    DeviceState,
+    SpaceInfo,
+)
+from .sdpro import SDProDriver
+from .stock import STOCK_PRO_PROFILE, STOCK_ULTRA_PROFILE, StockDriver
+
+__all__ = [
+    "ConnectionResult",
+    "DeviceDriver",
+    "DeviceState",
+    "SDProDriver",
+    "SpaceInfo",
+    "StockDriver",
+    "detect_driver",
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def detect_driver(base_url: str, session: aiohttp.ClientSession) -> DeviceDriver | None:
+    """Probe the device and return the right driver, or `None` if unreachable.
+
+    Probe order, picked so the cheapest most-specific signal wins:
+
+      1. `GET /v.json` — stock firmwares (Pro and recent Ultra) identify
+         themselves with `{"m": "<model>", "v": "<version>"}`.
+      2. `GET /config` — SD_PRO community firmware exposes all settings
+         here; presence of `brightness` + `freespace` is the fingerprint.
+      3. `GET /app.json` — legacy stock Ultra firmwares pre-`/v.json`.
+    """
+    # 1. /v.json — stock firmwares
+    try:
+        async with session.get(f"{base_url}/v.json", timeout=DETECT_TIMEOUT) as response:
+            if response.status == 200:
+                data = await response.json(content_type=None)
+                model_str = str(data.get("m", ""))
+                version = data.get("v")
+                if "PRO" in model_str.upper():
+                    _LOGGER.info("Detected stock SmallTV Pro firmware (%s)", version)
+                    return StockDriver(base_url, session, STOCK_PRO_PROFILE, sw_version=version)
+                if "ULTRA" in model_str.upper():
+                    _LOGGER.info("Detected stock SmallTV Ultra firmware (%s)", version)
+                    return StockDriver(base_url, session, STOCK_ULTRA_PROFILE, sw_version=version)
+                _LOGGER.warning(
+                    "Unknown /v.json model %r; defaulting to Ultra driver",
+                    model_str,
+                )
+                return StockDriver(base_url, session, STOCK_ULTRA_PROFILE, sw_version=version)
+    except Exception as err:
+        _LOGGER.debug("/v.json probe failed: %s", err)
+
+    # 2. /config — SD_PRO community firmware
+    try:
+        async with session.get(f"{base_url}/config", timeout=DETECT_TIMEOUT) as response:
+            if response.status == 200:
+                data = await response.json(content_type=None)
+                if "brightness" in data and "freespace" in data:
+                    _LOGGER.info("Detected SD_PRO community firmware")
+                    return SDProDriver(base_url, session)
+    except Exception as err:
+        _LOGGER.debug("/config probe failed: %s", err)
+
+    # 3. /app.json — legacy stock Ultra
+    try:
+        async with session.get(f"{base_url}/app.json", timeout=DETECT_TIMEOUT) as response:
+            if response.status == 200:
+                _LOGGER.info("Detected legacy stock SmallTV Ultra firmware via /app.json")
+                return StockDriver(base_url, session, STOCK_ULTRA_PROFILE, sw_version=None)
+    except Exception as err:
+        _LOGGER.debug("/app.json probe failed: %s", err)
+
+    _LOGGER.warning("Could not detect firmware at %s", base_url)
+    return None

--- a/custom_components/geekmagic/drivers/base.py
+++ b/custom_components/geekmagic/drivers/base.py
@@ -1,0 +1,151 @@
+"""Driver base class and shared dataclasses for GeekMagic firmwares."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Literal
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+TIMEOUT = aiohttp.ClientTimeout(total=30)
+DETECT_TIMEOUT = aiohttp.ClientTimeout(total=5)
+
+
+@dataclass
+class ConnectionResult:
+    """Result of a connection test."""
+
+    success: bool
+    error: Literal[
+        "none", "timeout", "connection_refused", "dns_error", "http_error", "unknown"
+    ] = "none"
+    message: str | None = None
+
+    def __bool__(self) -> bool:
+        return self.success
+
+
+@dataclass
+class DeviceState:
+    """Current device display state."""
+
+    theme: int
+    brightness: int | None
+    current_image: str | None
+
+
+@dataclass
+class SpaceInfo:
+    """Device storage info, bytes."""
+
+    total: int
+    free: int
+
+
+class DeviceDriver(ABC):
+    """Firmware-specific HTTP behaviour for a GeekMagic device.
+
+    Subclasses implement endpoint URLs and quirks. Capability flags
+    (`supports_navigation`, `supports_on_demand_image`, `brightness_range`,
+    `custom_image_theme`) let the coordinator branch without sniffing the
+    model name.
+    """
+
+    model: str
+    sw_version: str | None = None
+    custom_image_theme: int
+    brightness_range: tuple[int, int] = (0, 100)
+    supports_navigation: bool = False
+    supports_on_demand_image: bool = True
+
+    def __init__(self, base_url: str, session: aiohttp.ClientSession) -> None:
+        self.base_url = base_url
+        self._session = session
+
+    def is_custom_image_theme(self, theme: int) -> bool:
+        """Return True when `theme` is this firmware's custom-image mode."""
+        return theme == self.custom_image_theme
+
+    def clamp_brightness(self, value: int) -> int:
+        lo, hi = self.brightness_range
+        return max(lo, min(hi, value))
+
+    @abstractmethod
+    async def get_state(self) -> DeviceState: ...
+
+    @abstractmethod
+    async def get_space(self) -> SpaceInfo: ...
+
+    @abstractmethod
+    async def get_brightness(self) -> int: ...
+
+    @abstractmethod
+    async def set_brightness(self, value: int) -> None: ...
+
+    @abstractmethod
+    async def set_theme(self, theme: int) -> None: ...
+
+    async def set_theme_custom(self) -> None:
+        """Switch the device to its custom-image display mode."""
+        await self.set_theme(self.custom_image_theme)
+
+    @abstractmethod
+    async def set_image(self, filename: str) -> None: ...
+
+    @abstractmethod
+    async def upload(self, image_data: bytes, filename: str) -> None: ...
+
+    async def upload_and_display(self, image_data: bytes, filename: str) -> None:
+        """Upload `image_data` then make the device display it."""
+        await self.upload(image_data, filename)
+        await self.set_image(filename)
+
+    @abstractmethod
+    async def delete_file(self, path: str) -> None: ...
+
+    @abstractmethod
+    async def clear_images(self) -> None: ...
+
+    @abstractmethod
+    async def reboot(self) -> None: ...
+
+    async def navigate_next(self) -> None:
+        _LOGGER.debug("navigate_next not supported on %s", self.model)
+
+    async def navigate_previous(self) -> None:
+        _LOGGER.debug("navigate_previous not supported on %s", self.model)
+
+    async def navigate_enter(self) -> None:
+        _LOGGER.debug("navigate_enter not supported on %s", self.model)
+
+    async def test_connection(self) -> ConnectionResult:
+        """Probe the device with a cheap GET to confirm reachability."""
+        try:
+            await self.get_space()
+        except TimeoutError:
+            return ConnectionResult(
+                success=False,
+                error="timeout",
+                message="Connection timed out after 30 seconds",
+            )
+        except aiohttp.ClientConnectorDNSError as e:
+            return ConnectionResult(
+                success=False,
+                error="dns_error",
+                message=f"Could not resolve hostname: {e}",
+            )
+        except aiohttp.ClientConnectorError as e:
+            return ConnectionResult(success=False, error="connection_refused", message=str(e))
+        except aiohttp.ClientResponseError as e:
+            return ConnectionResult(
+                success=False,
+                error="http_error",
+                message=f"HTTP error {e.status}: {e.message}",
+            )
+        except Exception as e:
+            return ConnectionResult(success=False, error="unknown", message=str(e))
+        return ConnectionResult(success=True)

--- a/custom_components/geekmagic/drivers/sdpro.py
+++ b/custom_components/geekmagic/drivers/sdpro.py
@@ -127,6 +127,49 @@ class SDProDriver(DeviceDriver):
         await self._ensure_only_photo_enabled(name)
         await self._ensure_photo_theme()
 
+    async def list_themes(self) -> list[dict]:
+        """Return the device's built-in theme list.
+
+        Each entry has `{id: int, name: str, enabled: bool}`. Used by the
+        config flow to show the user which themes will be disabled.
+        """
+        async with self._session.get(f"{self.base_url}/theme/list") as r:
+            r.raise_for_status()
+            data = await r.json(content_type=None)
+            return list(data.get("themes", []))
+
+    async def disable_other_themes(self) -> list[str]:
+        """Disable every built-in theme except Photo (the integration's slot).
+
+        Returns the list of theme names that were toggled off, so the caller
+        can confirm to the user what changed. Idempotent — themes already
+        disabled are left alone.
+        """
+        disabled: list[str] = []
+        try:
+            themes = await self.list_themes()
+        except Exception as err:
+            _LOGGER.warning("SD_PRO /theme/list failed: %s", err)
+            return disabled
+        for theme in themes:
+            theme_id = theme.get("id")
+            if theme_id is None or int(theme_id) == self.custom_image_theme:
+                continue
+            if not theme.get("enabled"):
+                continue
+            try:
+                await self._theme_toggle(int(theme_id), False)
+                disabled.append(str(theme.get("name", f"theme {theme_id}")))
+            except Exception as err:
+                _LOGGER.debug("SD_PRO disable theme %s failed: %s", theme_id, err)
+        return disabled
+
+    async def _theme_toggle(self, theme_id: int, enabled: bool) -> None:
+        state = 1 if enabled else 0
+        url = f"{self.base_url}/theme/toggle?id={theme_id}&state={state}"
+        async with self._session.get(url) as r:
+            r.raise_for_status()
+
     async def _ensure_only_photo_enabled(self, keep_name: str) -> None:
         try:
             async with self._session.get(f"{self.base_url}/photo/list") as r:

--- a/custom_components/geekmagic/drivers/sdpro.py
+++ b/custom_components/geekmagic/drivers/sdpro.py
@@ -1,0 +1,220 @@
+"""Driver for the SD_PRO community firmware.
+
+The SD_PRO firmware (https://github.com/JUZIPi-tech/SD_PRO) exposes a
+completely different HTTP surface from stock GeekMagic firmware:
+
+  - all settings live in `GET /config`
+  - writes go through `GET /api/set?key=&value=`
+  - photos are uploaded to `POST /photo/upload` (multipart field `file`)
+  - photos can be enabled/disabled in the slideshow individually
+  - there is *no* "display this image now" endpoint
+
+To approximate the integration's "render and display" pipeline we upload
+the rendered image as `dashboard.jpg`, disable every other photo in the
+slideshow, and switch the device to the Photo theme (id=2). Re-uploading
+the same filename overwrites the previous frame.
+
+Caveats (see docs/devices/new-ultra-sdpro/report.md):
+
+  - Other user-uploaded photos in the slideshow will be disabled.
+  - Other built-in themes (Classic, Weather, Clock, ...) should also be
+    disabled out-of-band so the device doesn't rotate away from Photo.
+  - The reboot endpoint drops the HTTP connection before responding;
+    treat any connection error as success.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import quote
+
+import aiohttp
+
+from ..const import (
+    BRIGHTNESS_RANGE_SDPRO,
+    MODEL_SDPRO,
+    THEME_CUSTOM_IMAGE_SDPRO,
+)
+from .base import ConnectionResult, DeviceDriver, DeviceState, SpaceInfo
+
+_LOGGER = logging.getLogger(__name__)
+
+DASHBOARD_FILENAME = "dashboard.jpg"
+
+
+class SDProDriver(DeviceDriver):
+    """HTTP driver for SD_PRO community firmware."""
+
+    model = MODEL_SDPRO
+    custom_image_theme = THEME_CUSTOM_IMAGE_SDPRO
+    brightness_range = BRIGHTNESS_RANGE_SDPRO
+    supports_navigation = False
+    supports_on_demand_image = False
+
+    def __init__(
+        self,
+        base_url: str,
+        session: aiohttp.ClientSession,
+        sw_version: str | None = "SD_PRO",
+    ) -> None:
+        super().__init__(base_url, session)
+        self.sw_version = sw_version
+        self._cached_total: int | None = None
+
+    async def _get_config(self) -> dict:
+        async with self._session.get(f"{self.base_url}/config") as r:
+            r.raise_for_status()
+            return await r.json(content_type=None)
+
+    async def _api_set(self, key: str, value: str | int) -> None:
+        url = f"{self.base_url}/api/set?key={quote(str(key))}&value={quote(str(value))}"
+        async with self._session.get(url) as r:
+            r.raise_for_status()
+
+    async def get_state(self) -> DeviceState:
+        config = await self._get_config()
+        return DeviceState(
+            theme=int(config.get("theme", 0)),
+            brightness=int(config["brightness"]) if "brightness" in config else None,
+            current_image=None,  # no on-demand image concept
+        )
+
+    async def get_space(self) -> SpaceInfo:
+        config = await self._get_config()
+        free = int(config.get("freespace", 0))
+        if self._cached_total is None:
+            try:
+                async with self._session.get(f"{self.base_url}/photo/list") as r:
+                    r.raise_for_status()
+                    data = await r.json(content_type=None)
+                    self._cached_total = int(data.get("total", 0))
+            except Exception as err:
+                _LOGGER.debug("SD_PRO /photo/list unavailable: %s", err)
+                self._cached_total = 0
+        return SpaceInfo(total=self._cached_total or 0, free=free)
+
+    async def get_brightness(self) -> int:
+        config = await self._get_config()
+        return int(config.get("brightness", 0))
+
+    async def set_brightness(self, value: int) -> None:
+        value = self.clamp_brightness(value)
+        await self._api_set("lcd_brightness", value)
+
+    async def set_theme(self, theme: int) -> None:
+        await self._api_set("theme", int(theme))
+
+    async def set_image(self, filename: str) -> None:
+        # The SD_PRO firmware has no "show this image" endpoint. The only way
+        # to display a specific image is the photo-slideshow workaround in
+        # `upload_and_display`. Calling `set_image` directly without an upload
+        # is not meaningful here.
+        raise NotImplementedError(
+            "SD_PRO firmware does not support on-demand image display; "
+            "use upload_and_display() instead."
+        )
+
+    async def upload(self, image_data: bytes, filename: str) -> None:
+        form = aiohttp.FormData()
+        form.add_field("file", image_data, filename=filename, content_type="image/jpeg")
+        async with self._session.post(f"{self.base_url}/photo/upload", data=form) as r:
+            r.raise_for_status()
+
+    async def upload_and_display(self, image_data: bytes, filename: str) -> None:
+        # Force the canonical filename so re-uploads overwrite the same slot.
+        name = DASHBOARD_FILENAME
+        await self.upload(image_data, name)
+        await self._ensure_only_photo_enabled(name)
+        await self._ensure_photo_theme()
+
+    async def _ensure_only_photo_enabled(self, keep_name: str) -> None:
+        try:
+            async with self._session.get(f"{self.base_url}/photo/list") as r:
+                r.raise_for_status()
+                data = await r.json(content_type=None)
+        except Exception as err:
+            _LOGGER.debug("SD_PRO /photo/list failed: %s", err)
+            return
+
+        for entry in data.get("files", []):
+            name = entry.get("name")
+            enabled = bool(entry.get("enabled"))
+            if name == keep_name:
+                if not enabled:
+                    await self._photo_toggle(name, True)
+            elif enabled:
+                await self._photo_toggle(name, False)
+
+    async def _photo_toggle(self, name: str, enabled: bool) -> None:
+        state = 1 if enabled else 0
+        url = f"{self.base_url}/photo/toggle?name={quote(name)}&state={state}"
+        async with self._session.get(url) as r:
+            r.raise_for_status()
+
+    async def _ensure_photo_theme(self) -> None:
+        try:
+            config = await self._get_config()
+        except Exception as err:
+            _LOGGER.debug("SD_PRO /config failed during theme check: %s", err)
+            await self.set_theme(self.custom_image_theme)
+            return
+        if int(config.get("theme", -1)) != self.custom_image_theme:
+            await self.set_theme(self.custom_image_theme)
+
+    async def delete_file(self, path: str) -> None:
+        # Accept either "name" or "/photo/name"; the firmware wants basename.
+        name = path.rsplit("/", 1)[-1]
+        async with self._session.get(f"{self.base_url}/photo/delete?name={quote(name)}") as r:
+            r.raise_for_status()
+
+    async def clear_images(self) -> None:
+        try:
+            async with self._session.get(f"{self.base_url}/photo/list") as r:
+                r.raise_for_status()
+                data = await r.json(content_type=None)
+        except Exception as err:
+            _LOGGER.debug("SD_PRO /photo/list failed during clear: %s", err)
+            return
+        for entry in data.get("files", []):
+            name = entry.get("name")
+            if name:
+                try:
+                    await self.delete_file(name)
+                except Exception as err:
+                    _LOGGER.debug("SD_PRO delete %s failed: %s", name, err)
+
+    async def reboot(self) -> None:
+        # /restart drops the connection before responding; treat connection
+        # errors as success.
+        try:
+            async with self._session.get(f"{self.base_url}/restart") as r:
+                r.raise_for_status()
+        except aiohttp.ClientError as err:
+            _LOGGER.debug("SD_PRO reboot connection dropped (expected): %s", err)
+
+    async def test_connection(self) -> ConnectionResult:
+        try:
+            await self._get_config()
+        except TimeoutError:
+            return ConnectionResult(
+                success=False,
+                error="timeout",
+                message="Connection timed out after 30 seconds",
+            )
+        except aiohttp.ClientConnectorDNSError as e:
+            return ConnectionResult(
+                success=False,
+                error="dns_error",
+                message=f"Could not resolve hostname: {e}",
+            )
+        except aiohttp.ClientConnectorError as e:
+            return ConnectionResult(success=False, error="connection_refused", message=str(e))
+        except aiohttp.ClientResponseError as e:
+            return ConnectionResult(
+                success=False,
+                error="http_error",
+                message=f"HTTP error {e.status}: {e.message}",
+            )
+        except Exception as e:
+            return ConnectionResult(success=False, error="unknown", message=str(e))
+        return ConnectionResult(success=True)

--- a/custom_components/geekmagic/drivers/stock.py
+++ b/custom_components/geekmagic/drivers/stock.py
@@ -1,0 +1,180 @@
+"""Driver for stock GeekMagic firmware (SmallTV Pro and Ultra families).
+
+The Pro and Ultra share the same `/set?...` write surface and the same
+upload endpoint; they only differ in:
+
+- the path that returns current brightness (`/.sys/brt.json` vs `/brt.json`)
+- the theme number used for custom-image display (4=Picture vs 3=Photo Album)
+- whether `/app.json` is exposed (Ultra: yes, returns only `{theme}`; Pro: 404)
+- whether navigation endpoints (`/set?page=`, `/set?enter=`) are honoured
+
+These are captured in `StockProfile` so a single class handles both.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import aiohttp
+
+from ..const import (
+    MODEL_PRO,
+    MODEL_ULTRA,
+    THEME_CUSTOM_IMAGE_PRO,
+    THEME_CUSTOM_IMAGE_ULTRA,
+)
+from .base import DeviceDriver, DeviceState, SpaceInfo
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StockProfile:
+    """Per-firmware configuration for `StockDriver`."""
+
+    model: str
+    brightness_path: str
+    custom_image_theme: int
+    has_app_json: bool
+    supports_navigation: bool
+
+
+STOCK_PRO_PROFILE = StockProfile(
+    model=MODEL_PRO,
+    brightness_path="/.sys/brt.json",
+    custom_image_theme=THEME_CUSTOM_IMAGE_PRO,
+    has_app_json=False,
+    supports_navigation=True,
+)
+
+STOCK_ULTRA_PROFILE = StockProfile(
+    model=MODEL_ULTRA,
+    brightness_path="/brt.json",
+    custom_image_theme=THEME_CUSTOM_IMAGE_ULTRA,
+    has_app_json=True,
+    supports_navigation=False,
+)
+
+
+class StockDriver(DeviceDriver):
+    """HTTP driver for stock GeekMagic firmwares (Pro + Ultra)."""
+
+    def __init__(
+        self,
+        base_url: str,
+        session: aiohttp.ClientSession,
+        profile: StockProfile,
+        sw_version: str | None = None,
+    ) -> None:
+        super().__init__(base_url, session)
+        self._profile = profile
+        self.model = profile.model
+        self.custom_image_theme = profile.custom_image_theme
+        self.supports_navigation = profile.supports_navigation
+        self.sw_version = sw_version
+        # Cache last theme written by the integration; used as a fallback when
+        # the firmware doesn't expose /app.json (Pro).
+        self._last_known_theme: int = profile.custom_image_theme
+
+    async def get_state(self) -> DeviceState:
+        if not self._profile.has_app_json:
+            # Pro firmware: no /app.json — return our best guess.
+            return DeviceState(theme=self._last_known_theme, brightness=None, current_image=None)
+        async with self._session.get(f"{self.base_url}/app.json") as r:
+            r.raise_for_status()
+            data = await r.json(content_type=None)
+            theme = data.get("theme", 0)
+            self._last_known_theme = theme
+            return DeviceState(
+                theme=theme,
+                brightness=data.get("brt"),
+                current_image=data.get("img"),
+            )
+
+    async def get_space(self) -> SpaceInfo:
+        async with self._session.get(f"{self.base_url}/space.json") as r:
+            r.raise_for_status()
+            data = await r.json(content_type=None)
+            return SpaceInfo(total=data.get("total", 0), free=data.get("free", 0))
+
+    async def get_brightness(self) -> int:
+        async with self._session.get(f"{self.base_url}{self._profile.brightness_path}") as r:
+            r.raise_for_status()
+            data = await r.json(content_type=None)
+            # Firmware returns brightness as a string: {"brt": "71"}
+            return int(data.get("brt", 0))
+
+    async def set_brightness(self, value: int) -> None:
+        value = self.clamp_brightness(value)
+        async with self._session.get(f"{self.base_url}/set?brt={value}") as r:
+            r.raise_for_status()
+
+    async def set_theme(self, theme: int) -> None:
+        async with self._session.get(f"{self.base_url}/set?theme={theme}") as r:
+            r.raise_for_status()
+        self._last_known_theme = theme
+
+    async def set_image(self, filename: str) -> None:
+        await self.set_theme_custom()
+        async with self._session.get(f"{self.base_url}/set?img=/image/{filename}") as r:
+            r.raise_for_status()
+
+    async def upload(self, image_data: bytes, filename: str) -> None:
+        if filename.lower().endswith(".png"):
+            content_type = "image/png"
+        elif filename.lower().endswith(".gif"):
+            content_type = "image/gif"
+        else:
+            content_type = "image/jpeg"
+
+        form = aiohttp.FormData()
+        form.add_field("file", image_data, filename=filename, content_type=content_type)
+
+        try:
+            async with self._session.post(f"{self.base_url}/doUpload?dir=/image/", data=form) as r:
+                r.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            # Stock firmware returns malformed HTTP responses after a successful
+            # upload — swallow the known signatures.
+            # Ultra: "Duplicate Content-Length header"
+            # Pro:   "Data after `Connection: close`"
+            if e.status == 400:
+                msg = str(e.message) if e.message else ""
+                if "Duplicate Content-Length" in msg or "Data after" in msg:
+                    _LOGGER.debug("Ignoring malformed HTTP response from device: %s", msg)
+                    return
+            raise
+
+    async def delete_file(self, path: str) -> None:
+        async with self._session.get(f"{self.base_url}/delete?file={path}") as r:
+            r.raise_for_status()
+
+    async def clear_images(self) -> None:
+        async with self._session.get(f"{self.base_url}/set?clear=image") as r:
+            r.raise_for_status()
+
+    async def reboot(self) -> None:
+        async with self._session.get(f"{self.base_url}/set?reboot=1") as r:
+            r.raise_for_status()
+
+    async def navigate_next(self) -> None:
+        if not self._profile.supports_navigation:
+            await super().navigate_next()
+            return
+        async with self._session.get(f"{self.base_url}/set?page=1") as r:
+            r.raise_for_status()
+
+    async def navigate_previous(self) -> None:
+        if not self._profile.supports_navigation:
+            await super().navigate_previous()
+            return
+        async with self._session.get(f"{self.base_url}/set?page=-1") as r:
+            r.raise_for_status()
+
+    async def navigate_enter(self) -> None:
+        if not self._profile.supports_navigation:
+            await super().navigate_enter()
+            return
+        async with self._session.get(f"{self.base_url}/set?enter=-1") as r:
+            r.raise_for_status()

--- a/custom_components/geekmagic/entities/base.py
+++ b/custom_components/geekmagic/entities/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ..const import DOMAIN, MODEL_PRO, MODEL_ULTRA
+from ..const import DOMAIN, MODEL_DISPLAY_NAMES, MODEL_UNKNOWN
 
 if TYPE_CHECKING:
     from ..coordinator import GeekMagicCoordinator
@@ -32,11 +32,7 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
     def _device_model_name(self) -> str:
         """Return human-readable device model name."""
         model = self.coordinator.device.model
-        if model == MODEL_PRO:
-            return "SmallTV Pro"
-        if model == MODEL_ULTRA:
-            return "SmallTV Ultra"
-        return "SmallTV"
+        return MODEL_DISPLAY_NAMES.get(model, MODEL_DISPLAY_NAMES[MODEL_UNKNOWN])
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -46,4 +42,5 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
             name=self.coordinator.entry.title,
             manufacturer="GeekMagic",
             model=self._device_model_name,
+            sw_version=self.coordinator.device.sw_version,
         )

--- a/custom_components/geekmagic/strings.json
+++ b/custom_components/geekmagic/strings.json
@@ -79,6 +79,13 @@
           "host": "Host (IP, hostname, or URL)",
           "name": "Display name"
         }
+      },
+      "sdpro_confirm": {
+        "title": "SD_PRO firmware setup",
+        "description": "This device runs the SD_PRO community firmware, which rotates through built-in themes (Classic, Weather, Clock, etc.) by default. To keep the integration's rendered image on screen, those built-in themes need to be disabled.\n\nCurrently enabled built-in themes that will be disabled: {themes}\n\nYou can re-enable them later from the device's web UI. Other photos in the slideshow are left alone here, but will be disabled per render so only the integration's image shows.",
+        "data": {
+          "disable_other_themes": "Disable other built-in themes now"
+        }
       }
     },
     "error": {

--- a/tests/drivers/test_detection.py
+++ b/tests/drivers/test_detection.py
@@ -1,0 +1,103 @@
+"""Tests for the firmware detection factory."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from custom_components.geekmagic.const import (
+    MODEL_PRO,
+    MODEL_SDPRO,
+    MODEL_ULTRA,
+)
+from custom_components.geekmagic.drivers import detect_driver
+from custom_components.geekmagic.drivers.sdpro import SDProDriver
+from custom_components.geekmagic.drivers.stock import StockDriver
+
+
+def _make_response(*, status=200, json_data=None):
+    response = MagicMock()
+    response.status = status
+    if json_data is not None:
+        response.json = AsyncMock(return_value=json_data)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+    return response
+
+
+def _make_session(handlers):
+    """`handlers` maps URL substring -> a pre-built response (MagicMock)."""
+
+    session = MagicMock()
+
+    def _get(url, **_kwargs):
+        for needle, response in handlers.items():
+            if needle in url:
+                return response
+        return _make_response(status=404)
+
+    session.get = _get
+    return session
+
+
+@pytest.mark.asyncio
+async def test_detects_stock_pro_from_v_json():
+    session = _make_session(
+        {"/v.json": _make_response(json_data={"m": "GeekMagic SmallTV-PRO", "v": "V3.3.76EN"})}
+    )
+    driver = await detect_driver("http://10.0.0.1", session)
+    assert isinstance(driver, StockDriver)
+    assert driver.model == MODEL_PRO
+    assert driver.sw_version == "V3.3.76EN"
+    assert driver.custom_image_theme == 4
+    assert driver.supports_navigation is True
+
+
+@pytest.mark.asyncio
+async def test_detects_stock_ultra_from_v_json():
+    session = _make_session(
+        {"/v.json": _make_response(json_data={"m": "SmallTV-Ultra", "v": "Ultra-V9.0.40"})}
+    )
+    driver = await detect_driver("http://10.0.0.1", session)
+    assert isinstance(driver, StockDriver)
+    assert driver.model == MODEL_ULTRA
+    assert driver.sw_version == "Ultra-V9.0.40"
+    assert driver.custom_image_theme == 3
+    assert driver.supports_navigation is False
+
+
+@pytest.mark.asyncio
+async def test_detects_sdpro_when_v_json_missing():
+    session = _make_session(
+        {"/config": _make_response(json_data={"brightness": 50, "freespace": 1024, "theme": 0})}
+    )
+    driver = await detect_driver("http://10.0.0.1", session)
+    assert isinstance(driver, SDProDriver)
+    assert driver.model == MODEL_SDPRO
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_legacy_app_json():
+    session = _make_session({"/app.json": _make_response(json_data={"theme": 3})})
+    driver = await detect_driver("http://10.0.0.1", session)
+    assert isinstance(driver, StockDriver)
+    assert driver.model == MODEL_ULTRA
+    assert driver.sw_version is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_all_probes_fail():
+    session = _make_session({})  # everything 404s
+    driver = await detect_driver("http://10.0.0.1", session)
+    assert driver is None
+
+
+@pytest.mark.asyncio
+async def test_config_without_sdpro_fingerprint_is_ignored():
+    """A /config endpoint that doesn't look like SD_PRO falls through."""
+    session = _make_session({"/config": _make_response(json_data={"something_else": True})})
+    driver = await detect_driver("http://10.0.0.1", session)
+    assert driver is None

--- a/tests/drivers/test_sdpro.py
+++ b/tests/drivers/test_sdpro.py
@@ -222,6 +222,62 @@ async def test_reboot_swallows_connection_drop(driver, session):
 
 
 @pytest.mark.asyncio
+async def test_list_themes(driver, session):
+    session.queue_get(
+        "/theme/list",
+        json={
+            "interval": 10,
+            "themes": [
+                {"id": 0, "name": "Classic", "enabled": True},
+                {"id": 1, "name": "Weather", "enabled": False},
+                {"id": 2, "name": "Photo", "enabled": True},
+            ],
+        },
+    )
+    themes = await driver.list_themes()
+    assert len(themes) == 3
+    assert themes[0]["name"] == "Classic"
+
+
+@pytest.mark.asyncio
+async def test_disable_other_themes(driver, session):
+    session.queue_get(
+        "/theme/list",
+        json={
+            "themes": [
+                {"id": 0, "name": "Classic", "enabled": True},
+                {"id": 1, "name": "Weather", "enabled": True},
+                {"id": 2, "name": "Photo", "enabled": True},
+                {"id": 3, "name": "Dial", "enabled": False},
+            ],
+        },
+    )
+
+    disabled = await driver.disable_other_themes()
+
+    # Photo (id=2, custom_image_theme) is kept enabled; Dial was already off
+    assert sorted(disabled) == ["Classic", "Weather"]
+    # Verify the toggle calls were the right ones
+    assert any("/theme/toggle?id=0&state=0" in url for url in session.get_log)
+    assert any("/theme/toggle?id=1&state=0" in url for url in session.get_log)
+    # Photo theme was NOT touched
+    assert not any("/theme/toggle?id=2" in url for url in session.get_log)
+
+
+@pytest.mark.asyncio
+async def test_disable_other_themes_handles_missing_endpoint(driver, session):
+    session.queue_get(
+        "/theme/list",
+        raise_for_status_error=aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=404, message="not found"
+        ),
+    )
+    # Should not raise; returns empty list.
+    disabled = await driver.disable_other_themes()
+    assert disabled == []
+
+
+@pytest.mark.asyncio
 async def test_test_connection_success(driver, session):
     session.queue_get("/config", json={"brightness": 50, "freespace": 1024})
     result = await driver.test_connection()

--- a/tests/drivers/test_sdpro.py
+++ b/tests/drivers/test_sdpro.py
@@ -1,0 +1,241 @@
+"""Tests for SDProDriver (SD_PRO community firmware)."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from custom_components.geekmagic.const import (
+    BRIGHTNESS_RANGE_SDPRO,
+    MODEL_SDPRO,
+    THEME_CUSTOM_IMAGE_SDPRO,
+)
+from custom_components.geekmagic.drivers.sdpro import SDProDriver
+
+
+class FakeSession:
+    """Tiny session double that returns a queued response per URL prefix."""
+
+    def __init__(self):
+        self.get_log: list[str] = []
+        self.post_log: list[str] = []
+        self._get_handlers: list[tuple[str, dict]] = []
+        self._post_handlers: list[tuple[str, dict]] = []
+
+    def queue_get(
+        self,
+        url_contains: str,
+        json: dict | None = None,
+        status: int = 200,
+        raise_for_status_error: Exception | None = None,
+    ) -> None:
+        self._get_handlers.append(
+            (url_contains, {"json": json, "status": status, "error": raise_for_status_error})
+        )
+
+    def queue_post(self, url_contains: str, status: int = 200) -> None:
+        self._post_handlers.append((url_contains, {"status": status}))
+
+    def _build_response(self, spec: dict):
+        response = MagicMock()
+        response.status = spec.get("status", 200)
+        if spec.get("error"):
+            response.raise_for_status = MagicMock(side_effect=spec["error"])
+        else:
+            response.raise_for_status = MagicMock()
+        if spec.get("json") is not None:
+            response.json = AsyncMock(return_value=spec["json"])
+        response.__aenter__ = AsyncMock(return_value=response)
+        response.__aexit__ = AsyncMock(return_value=False)
+        return response
+
+    def get(self, url, **_kwargs):
+        self.get_log.append(url)
+        for needle, spec in self._get_handlers:
+            if needle in url:
+                return self._build_response(spec)
+        return self._build_response({"json": {}})
+
+    def post(self, url, **_kwargs):
+        self.post_log.append(url)
+        for needle, spec in self._post_handlers:
+            if needle in url:
+                return self._build_response(spec)
+        return self._build_response({})
+
+
+@pytest.fixture
+def session():
+    return FakeSession()
+
+
+@pytest.fixture
+def driver(session):
+    return SDProDriver("http://192.168.1.100", session)
+
+
+def test_capabilities(driver):
+    assert driver.model == MODEL_SDPRO
+    assert driver.custom_image_theme == THEME_CUSTOM_IMAGE_SDPRO
+    assert driver.brightness_range == BRIGHTNESS_RANGE_SDPRO
+    assert driver.supports_navigation is False
+    assert driver.supports_on_demand_image is False
+
+
+def test_is_custom_image_theme(driver):
+    assert driver.is_custom_image_theme(2) is True
+    assert driver.is_custom_image_theme(3) is False
+
+
+@pytest.mark.asyncio
+async def test_get_state(driver, session):
+    session.queue_get("/config", json={"theme": 2, "brightness": 50, "freespace": 1024})
+    state = await driver.get_state()
+    assert state.theme == 2
+    assert state.brightness == 50
+    assert state.current_image is None
+
+
+@pytest.mark.asyncio
+async def test_get_brightness(driver, session):
+    session.queue_get("/config", json={"brightness": 33})
+    assert await driver.get_brightness() == 33
+
+
+@pytest.mark.asyncio
+async def test_set_brightness_uses_api_set(driver, session):
+    await driver.set_brightness(50)
+    assert any("/api/set?key=lcd_brightness&value=50" in url for url in session.get_log)
+
+
+@pytest.mark.asyncio
+async def test_set_brightness_clamps_to_sdpro_range(driver, session):
+    await driver.set_brightness(150)
+    assert any("value=99" in url for url in session.get_log)
+    await driver.set_brightness(-5)
+    assert any("value=2" in url for url in session.get_log)
+
+
+@pytest.mark.asyncio
+async def test_set_theme_uses_api_set(driver, session):
+    await driver.set_theme(2)
+    assert any("/api/set?key=theme&value=2" in url for url in session.get_log)
+
+
+@pytest.mark.asyncio
+async def test_set_image_not_supported(driver):
+    with pytest.raises(NotImplementedError):
+        await driver.set_image("dashboard.jpg")
+
+
+@pytest.mark.asyncio
+async def test_upload_uses_photo_upload(driver, session):
+    await driver.upload(b"\xff\xd8\xff\xe0" + b"x" * 100, "dashboard.jpg")
+    assert any("/photo/upload" in url for url in session.post_log)
+
+
+@pytest.mark.asyncio
+async def test_upload_and_display_workaround(driver, session):
+    """Upload, disable other photos, enable ours, switch to Photo theme."""
+    session.queue_get(
+        "/photo/list",
+        json={
+            "files": [
+                {"name": "dashboard.jpg", "enabled": False, "size": 1000},
+                {"name": "vacation.jpg", "enabled": True, "size": 5000},
+                {"name": "cat.gif", "enabled": True, "size": 3000},
+            ],
+            "total": 1_000_000,
+            "used": 9000,
+            "interval": 10,
+        },
+    )
+    session.queue_get("/config", json={"theme": 0})
+
+    await driver.upload_and_display(b"x" * 64, "dashboard.jpg")
+
+    # Uploaded as canonical dashboard.jpg
+    assert any("/photo/upload" in url for url in session.post_log)
+    # Disabled the two other enabled photos
+    assert any(
+        "/photo/toggle" in u and "vacation.jpg" in u and "state=0" in u for u in session.get_log
+    )
+    assert any("/photo/toggle" in u and "cat.gif" in u and "state=0" in u for u in session.get_log)
+    # Enabled dashboard.jpg
+    assert any(
+        "/photo/toggle" in u and "dashboard.jpg" in u and "state=1" in u for u in session.get_log
+    )
+    # Switched to Photo theme (2)
+    assert any("/api/set?key=theme&value=2" in u for u in session.get_log)
+
+
+@pytest.mark.asyncio
+async def test_upload_and_display_skips_theme_when_already_set(driver, session):
+    session.queue_get(
+        "/photo/list",
+        json={
+            "files": [{"name": "dashboard.jpg", "enabled": True}],
+            "total": 0,
+            "used": 0,
+            "interval": 10,
+        },
+    )
+    session.queue_get("/config", json={"theme": 2})
+
+    await driver.upload_and_display(b"x" * 64, "dashboard.jpg")
+
+    # No theme write because device is already on theme 2
+    assert not any("/api/set?key=theme" in u for u in session.get_log)
+
+
+@pytest.mark.asyncio
+async def test_delete_file_extracts_basename(driver, session):
+    await driver.delete_file("/photo/vacation.jpg")
+    assert any("/photo/delete?name=vacation.jpg" in u for u in session.get_log)
+    await driver.delete_file("plainname.jpg")
+    assert any("/photo/delete?name=plainname.jpg" in u for u in session.get_log)
+
+
+@pytest.mark.asyncio
+async def test_clear_images_deletes_each(driver, session):
+    session.queue_get(
+        "/photo/list",
+        json={"files": [{"name": "a.jpg"}, {"name": "b.jpg"}]},
+    )
+    await driver.clear_images()
+    assert any("/photo/delete?name=a.jpg" in u for u in session.get_log)
+    assert any("/photo/delete?name=b.jpg" in u for u in session.get_log)
+
+
+@pytest.mark.asyncio
+async def test_reboot_swallows_connection_drop(driver, session):
+    session.queue_get(
+        "/restart",
+        raise_for_status_error=aiohttp.ClientError("connection reset"),
+    )
+    # Must not raise.
+    await driver.reboot()
+
+
+@pytest.mark.asyncio
+async def test_test_connection_success(driver, session):
+    session.queue_get("/config", json={"brightness": 50, "freespace": 1024})
+    result = await driver.test_connection()
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_test_connection_404(driver, session):
+    session.queue_get(
+        "/config",
+        raise_for_status_error=aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=404, message="not found"
+        ),
+    )
+    result = await driver.test_connection()
+    assert result.success is False
+    assert result.error == "http_error"

--- a/tests/drivers/test_stock.py
+++ b/tests/drivers/test_stock.py
@@ -1,0 +1,266 @@
+"""Tests for the StockDriver (Pro + Ultra families)."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from custom_components.geekmagic.drivers.stock import (
+    STOCK_PRO_PROFILE,
+    STOCK_ULTRA_PROFILE,
+    StockDriver,
+)
+
+
+@pytest.fixture
+def mock_response():
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.status = 200
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+    return response
+
+
+@pytest.fixture
+def mock_session(mock_response):
+    session = MagicMock()
+    session.get = MagicMock(return_value=mock_response)
+    session.post = MagicMock(return_value=mock_response)
+    session.close = AsyncMock()
+    return session
+
+
+def _ultra(session):
+    return StockDriver(
+        "http://192.168.1.100", session, STOCK_ULTRA_PROFILE, sw_version="Ultra-V9.0.40"
+    )
+
+
+def _pro(session):
+    return StockDriver("http://192.168.1.100", session, STOCK_PRO_PROFILE, sw_version="V3.3.76EN")
+
+
+class TestStockUltra:
+    """Ultra firmware behaviour — regression coverage for the historical default."""
+
+    @pytest.mark.asyncio
+    async def test_get_state(self, mock_session, mock_response):
+        mock_response.json = AsyncMock(
+            return_value={"theme": 3, "brt": 75, "img": "/image/dashboard.jpg"}
+        )
+        driver = _ultra(mock_session)
+        state = await driver.get_state()
+        assert state.theme == 3
+        assert state.brightness == 75
+        assert state.current_image == "/image/dashboard.jpg"
+        mock_session.get.assert_called_once_with("http://192.168.1.100/app.json")
+
+    @pytest.mark.asyncio
+    async def test_get_state_partial(self, mock_session, mock_response):
+        """Old-ultra firmware returns only {theme}; brightness/image stay None."""
+        mock_response.json = AsyncMock(return_value={"theme": 3})
+        driver = _ultra(mock_session)
+        state = await driver.get_state()
+        assert state.theme == 3
+        assert state.brightness is None
+        assert state.current_image is None
+
+    @pytest.mark.asyncio
+    async def test_get_space(self, mock_session, mock_response):
+        mock_response.json = AsyncMock(return_value={"total": 1048576, "free": 524288})
+        driver = _ultra(mock_session)
+        space = await driver.get_space()
+        assert space.total == 1048576
+        assert space.free == 524288
+        mock_session.get.assert_called_once_with("http://192.168.1.100/space.json")
+
+    @pytest.mark.asyncio
+    async def test_get_brightness(self, mock_session, mock_response):
+        mock_response.json = AsyncMock(return_value={"brt": "71"})
+        driver = _ultra(mock_session)
+        assert await driver.get_brightness() == 71
+        mock_session.get.assert_called_once_with("http://192.168.1.100/brt.json")
+
+    @pytest.mark.asyncio
+    async def test_set_brightness(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.set_brightness(80)
+        mock_session.get.assert_called_with("http://192.168.1.100/set?brt=80")
+
+    @pytest.mark.asyncio
+    async def test_set_brightness_clamps(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.set_brightness(150)
+        mock_session.get.assert_called_with("http://192.168.1.100/set?brt=100")
+        await driver.set_brightness(-10)
+        mock_session.get.assert_called_with("http://192.168.1.100/set?brt=0")
+
+    @pytest.mark.asyncio
+    async def test_set_theme(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.set_theme(3)
+        mock_session.get.assert_called_with("http://192.168.1.100/set?theme=3")
+
+    @pytest.mark.asyncio
+    async def test_set_theme_custom_uses_3_for_ultra(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.set_theme_custom()
+        mock_session.get.assert_called_with("http://192.168.1.100/set?theme=3")
+
+    @pytest.mark.asyncio
+    async def test_set_image_sets_theme_then_image(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.set_image("dashboard.jpg")
+        calls = mock_session.get.call_args_list
+        assert len(calls) == 2
+        assert "theme=3" in str(calls[0])
+        assert "img=/image/dashboard.jpg" in str(calls[1])
+
+    @pytest.mark.asyncio
+    async def test_upload_jpeg(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.upload(b"\xff\xd8\xff\xe0" + b"\x00" * 100, "test.jpg")
+        mock_session.post.assert_called_once()
+        url = mock_session.post.call_args[0][0]
+        assert "doUpload" in url
+        assert "dir=/image/" in url
+
+    @pytest.mark.asyncio
+    async def test_upload_png(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.upload(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100, "test.png")
+        mock_session.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_upload_swallows_duplicate_content_length(self, mock_session):
+        driver = _ultra(mock_session)
+        error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=400,
+            message="Duplicate Content-Length header",
+        )
+        mock_session.post.return_value.__aenter__.side_effect = error
+        # Must not raise.
+        await driver.upload(b"x" * 64, "test.jpg")
+
+    @pytest.mark.asyncio
+    async def test_upload_swallows_data_after_close(self, mock_session):
+        driver = _ultra(mock_session)
+        error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=400,
+            message="Data after `Connection: close`",
+        )
+        mock_session.post.return_value.__aenter__.side_effect = error
+        await driver.upload(b"x" * 64, "test.jpg")
+
+    @pytest.mark.asyncio
+    async def test_delete_file(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.delete_file("/image/old.jpg")
+        mock_session.get.assert_called_with("http://192.168.1.100/delete?file=/image/old.jpg")
+
+    @pytest.mark.asyncio
+    async def test_clear_images(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.clear_images()
+        mock_session.get.assert_called_with("http://192.168.1.100/set?clear=image")
+
+    @pytest.mark.asyncio
+    async def test_reboot(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.reboot()
+        mock_session.get.assert_called_with("http://192.168.1.100/set?reboot=1")
+
+    @pytest.mark.asyncio
+    async def test_navigation_is_noop_on_ultra(self, mock_session, mock_response):
+        driver = _ultra(mock_session)
+        await driver.navigate_next()
+        await driver.navigate_previous()
+        await driver.navigate_enter()
+        # No HTTP calls because Ultra firmware doesn't have these endpoints.
+        assert not mock_session.get.called
+
+    def test_is_custom_image_theme(self, mock_session):
+        driver = _ultra(mock_session)
+        assert driver.is_custom_image_theme(3) is True
+        assert driver.is_custom_image_theme(4) is False
+
+    def test_supports_navigation_false(self, mock_session):
+        assert _ultra(mock_session).supports_navigation is False
+
+
+class TestStockPro:
+    """Pro firmware differences: brightness path, custom-image theme=4, navigation."""
+
+    @pytest.mark.asyncio
+    async def test_get_state_no_app_json(self, mock_session, mock_response):
+        """Pro firmware has no /app.json; return cached theme without hitting HTTP."""
+        driver = _pro(mock_session)
+        state = await driver.get_state()
+        assert state.theme == 4  # default cache = custom_image_theme
+        assert state.brightness is None
+        assert state.current_image is None
+        # Importantly, no request was made.
+        assert not mock_session.get.called
+
+    @pytest.mark.asyncio
+    async def test_set_theme_updates_cached_theme(self, mock_session, mock_response):
+        driver = _pro(mock_session)
+        await driver.set_theme(6)
+        state = await driver.get_state()
+        assert state.theme == 6
+
+    @pytest.mark.asyncio
+    async def test_get_brightness_uses_sys_path(self, mock_session, mock_response):
+        mock_response.json = AsyncMock(return_value={"brt": "85"})
+        driver = _pro(mock_session)
+        assert await driver.get_brightness() == 85
+        mock_session.get.assert_called_once_with("http://192.168.1.100/.sys/brt.json")
+
+    @pytest.mark.asyncio
+    async def test_set_theme_custom_uses_4_for_pro(self, mock_session, mock_response):
+        driver = _pro(mock_session)
+        await driver.set_theme_custom()
+        mock_session.get.assert_called_with("http://192.168.1.100/set?theme=4")
+
+    @pytest.mark.asyncio
+    async def test_set_image_uses_picture_theme(self, mock_session, mock_response):
+        driver = _pro(mock_session)
+        await driver.set_image("dashboard.jpg")
+        calls = mock_session.get.call_args_list
+        assert "theme=4" in str(calls[0])
+        assert "img=/image/dashboard.jpg" in str(calls[1])
+
+    @pytest.mark.asyncio
+    async def test_navigate_next(self, mock_session, mock_response):
+        driver = _pro(mock_session)
+        await driver.navigate_next()
+        mock_session.get.assert_called_with("http://192.168.1.100/set?page=1")
+
+    @pytest.mark.asyncio
+    async def test_navigate_previous(self, mock_session, mock_response):
+        driver = _pro(mock_session)
+        await driver.navigate_previous()
+        mock_session.get.assert_called_with("http://192.168.1.100/set?page=-1")
+
+    @pytest.mark.asyncio
+    async def test_navigate_enter(self, mock_session, mock_response):
+        driver = _pro(mock_session)
+        await driver.navigate_enter()
+        mock_session.get.assert_called_with("http://192.168.1.100/set?enter=-1")
+
+    def test_is_custom_image_theme(self, mock_session):
+        driver = _pro(mock_session)
+        assert driver.is_custom_image_theme(4) is True
+        assert driver.is_custom_image_theme(3) is False
+
+    def test_supports_navigation_true(self, mock_session):
+        assert _pro(mock_session).supports_navigation is True

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -110,6 +110,101 @@ class TestConfigFlowUser:
         assert errors is not None
         assert errors["base"] in ("connection_refused", "unknown")
 
+    async def test_sdpro_flow_shows_confirm_step_and_disables_themes(
+        self, hass: HomeAssistant, aioclient_mock
+    ):
+        """SD_PRO firmware setup pauses to confirm + disable built-in themes."""
+        base = f"http://{DEVICE_HOST}"
+        # /v.json 404 so detection falls through to /config (SD_PRO fingerprint)
+        aioclient_mock.get(f"{base}/v.json", status=404)
+        aioclient_mock.get(
+            f"{base}/config",
+            json={"theme": 0, "brightness": 50, "freespace": 1024 * 1024},
+        )
+        # Confirm-step preview of currently-enabled themes
+        aioclient_mock.get(
+            f"{base}/theme/list",
+            json={
+                "interval": 10,
+                "themes": [
+                    {"id": 0, "name": "Classic", "enabled": True},
+                    {"id": 1, "name": "Weather", "enabled": True},
+                    {"id": 2, "name": "Photo", "enabled": True},
+                ],
+            },
+        )
+        # Toggle endpoint (matches anything under /theme/toggle)
+        aioclient_mock.get(re.compile(rf"^{re.escape(base)}/theme/toggle\?"), status=200)
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"host": DEVICE_HOST, "name": "SD_PRO Display"},
+        )
+
+        # Should show the SD_PRO confirmation form, not create the entry yet.
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "sdpro_confirm"
+
+        # Confirm with default (disable themes)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"disable_other_themes": True},
+        )
+        await hass.async_block_till_done()
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == "SD_PRO Display"
+
+        # Confirm the two non-Photo themes were disabled via /theme/toggle
+        toggle_urls = [
+            str(call[1]) for call in aioclient_mock.mock_calls if "/theme/toggle" in str(call[1])
+        ]
+        assert any("id=0" in url and "state=0" in url for url in toggle_urls)
+        assert any("id=1" in url and "state=0" in url for url in toggle_urls)
+        # Photo theme (id=2) must NOT be disabled
+        assert not any("id=2" in url and "state=0" in url for url in toggle_urls)
+
+    async def test_sdpro_flow_skips_theme_disable_when_unchecked(
+        self, hass: HomeAssistant, aioclient_mock
+    ):
+        """If the user unchecks the box, no /theme/toggle calls are made."""
+        base = f"http://{DEVICE_HOST}"
+        aioclient_mock.get(f"{base}/v.json", status=404)
+        aioclient_mock.get(
+            f"{base}/config",
+            json={"theme": 0, "brightness": 50, "freespace": 1024 * 1024},
+        )
+        aioclient_mock.get(
+            f"{base}/theme/list",
+            json={
+                "themes": [
+                    {"id": 0, "name": "Classic", "enabled": True},
+                    {"id": 2, "name": "Photo", "enabled": True},
+                ],
+            },
+        )
+        aioclient_mock.get(re.compile(rf"^{re.escape(base)}/theme/toggle\?"), status=200)
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"host": DEVICE_HOST, "name": "SD_PRO Display"},
+        )
+        assert result["step_id"] == "sdpro_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"disable_other_themes": False},
+        )
+        await hass.async_block_till_done()
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+
+        toggle_urls = [
+            str(call[1]) for call in aioclient_mock.mock_calls if "/theme/toggle" in str(call[1])
+        ]
+        assert toggle_urls == []
+
     async def test_user_flow_success(self, hass: HomeAssistant, aioclient_mock):
         """Test successful user flow creates entry with default options."""
         _mock_device_success(aioclient_mock)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -31,15 +31,16 @@ BASE_URL = f"http://{DEVICE_HOST}"
 
 
 def _mock_device_success(aioclient_mock, host: str = DEVICE_HOST):
-    """Mock HTTP endpoints for a successful device connection."""
+    """Mock HTTP endpoints for a successful device connection (stock Ultra)."""
     base = f"http://{host}"
-    # test_connection calls get_space
+    # Firmware identification — drives detect_driver
+    aioclient_mock.get(f"{base}/v.json", json={"m": "SmallTV-Ultra", "v": "Ultra-V9.0.40"})
+    # Connection probe and storage info
     aioclient_mock.get(f"{base}/space.json", json={"total": 1048576, "free": 524288})
-    # Model detection
-    aioclient_mock.get(f"{base}/.sys/app.json", status=404)
+    # Device state, brightness
     aioclient_mock.get(f"{base}/app.json", json={"theme": 0, "brt": 50, "img": None})
-    # Brightness, upload, set commands (for full setup after entry creation)
     aioclient_mock.get(f"{base}/brt.json", json={"brt": "50"})
+    # Upload + /set?... commands (for full setup after entry creation)
     aioclient_mock.post(f"{base}/doUpload?dir=/image/", status=200)
     aioclient_mock.get(re.compile(rf"^{re.escape(base)}/set\?"), status=200)
 
@@ -77,7 +78,7 @@ class TestConfigFlowUser:
     async def test_user_flow_connection_timeout(self, hass: HomeAssistant, aioclient_mock):
         """Test user flow shows timeout error when device times out."""
         aioclient_mock.get(
-            f"{BASE_URL}/space.json",
+            f"{BASE_URL}/v.json",
             exc=TimeoutError("Connection timed out"),
         )
 
@@ -93,7 +94,7 @@ class TestConfigFlowUser:
     async def test_user_flow_connection_refused(self, hass: HomeAssistant, aioclient_mock):
         """Test user flow shows connection refused error."""
         aioclient_mock.get(
-            f"{BASE_URL}/space.json",
+            f"{BASE_URL}/v.json",
             exc=OSError("Connection refused"),
         )
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,4 +1,10 @@
-"""Tests for GeekMagic device client."""
+"""Tests for the GeekMagicDevice facade.
+
+Endpoint-level behaviour for each firmware family lives in
+`tests/drivers/test_stock.py` and `tests/drivers/test_sdpro.py`. This file
+covers facade concerns: URL parsing, session lifecycle, driver detection
+wiring, and delegation.
+"""
 
 import sys
 from pathlib import Path
@@ -7,9 +13,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import aiohttp
 import pytest
 
+from custom_components.geekmagic.const import (
+    MODEL_PRO,
+    MODEL_SDPRO,
+    MODEL_ULTRA,
+    MODEL_UNKNOWN,
+)
 from custom_components.geekmagic.device import (
     DeviceState,
     GeekMagicDevice,
@@ -17,491 +28,240 @@ from custom_components.geekmagic.device import (
 )
 
 
-@pytest.fixture
-def mock_response():
-    """Create a mock aiohttp response."""
+def _make_response(*, status=200, json_data=None):
     response = MagicMock()
+    response.status = status
     response.raise_for_status = MagicMock()
+    if json_data is not None:
+        response.json = AsyncMock(return_value=json_data)
     response.__aenter__ = AsyncMock(return_value=response)
-    response.__aexit__ = AsyncMock()
+    response.__aexit__ = AsyncMock(return_value=False)
     return response
 
 
-@pytest.fixture
-def mock_session(mock_response):
-    """Create a mock aiohttp session."""
+def _make_session(handlers=None):
+    """`handlers` maps URL substring -> a pre-built response (MagicMock)."""
+    handlers = handlers or {}
     session = MagicMock()
-    session.get = MagicMock(return_value=mock_response)
-    session.post = MagicMock(return_value=mock_response)
+
+    def _get(url, **_kwargs):
+        for needle, response in handlers.items():
+            if needle in url:
+                return response
+        return _make_response(status=404)
+
+    def _post(url, **_kwargs):
+        return _make_response()
+
+    session.get = _get
+    session.post = _post
     session.close = AsyncMock()
     return session
 
 
 class TestDeviceState:
-    """Tests for DeviceState dataclass."""
-
-    def test_create_state(self):
-        """Test creating a device state."""
-        state = DeviceState(theme=3, brightness=50, current_image="/image/test.jpg")
+    def test_create(self):
+        state = DeviceState(theme=3, brightness=50, current_image="/image/x.jpg")
         assert state.theme == 3
         assert state.brightness == 50
-        assert state.current_image == "/image/test.jpg"
+        assert state.current_image == "/image/x.jpg"
 
-    def test_state_with_none_values(self):
-        """Test creating a state with None values."""
+    def test_with_none(self):
         state = DeviceState(theme=0, brightness=None, current_image=None)
-        assert state.theme == 0
         assert state.brightness is None
         assert state.current_image is None
 
 
 class TestSpaceInfo:
-    """Tests for SpaceInfo dataclass."""
-
-    def test_create_space_info(self):
-        """Test creating space info."""
-        info = SpaceInfo(total=1048576, free=524288)
-        assert info.total == 1048576
-        assert info.free == 524288
+    def test_create(self):
+        info = SpaceInfo(total=1024, free=512)
+        assert info.total == 1024
+        assert info.free == 512
 
 
-class TestGeekMagicDevice:
-    """Tests for GeekMagicDevice client."""
-
-    def test_init(self):
-        """Test device initialization."""
+class TestGeekMagicDeviceInit:
+    def test_bare_ip(self):
         device = GeekMagicDevice("192.168.1.100")
         assert device.host == "192.168.1.100"
         assert device.base_url == "http://192.168.1.100"
 
-    def test_init_with_http_url(self):
-        """Test device initialization with http:// URL."""
+    def test_http_url(self):
         device = GeekMagicDevice("http://192.168.1.100")
         assert device.host == "192.168.1.100"
         assert device.base_url == "http://192.168.1.100"
 
-    def test_init_with_https_url(self):
-        """Test device initialization with https:// URL preserves scheme."""
+    def test_https_url_preserved(self):
         device = GeekMagicDevice("https://192.168.1.100")
-        assert device.host == "192.168.1.100"
         assert device.base_url == "https://192.168.1.100"
 
-    def test_init_with_port(self):
-        """Test device initialization with port number."""
+    def test_port(self):
         device = GeekMagicDevice("http://192.168.1.100:8080")
         assert device.host == "192.168.1.100:8080"
         assert device.base_url == "http://192.168.1.100:8080"
 
-    def test_init_with_hostname(self):
-        """Test device initialization with hostname."""
+    def test_hostname(self):
         device = GeekMagicDevice("geekmagic.local")
         assert device.host == "geekmagic.local"
         assert device.base_url == "http://geekmagic.local"
 
-    def test_init_with_session(self, mock_session):
-        """Test device initialization with provided session."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        assert device._session == mock_session
+    def test_default_model_unknown(self):
+        assert GeekMagicDevice("192.168.1.100").model == MODEL_UNKNOWN
+
+    def test_external_session(self):
+        sess = _make_session()
+        device = GeekMagicDevice("192.168.1.100", session=sess)
+        assert device._session is sess
         assert device._owns_session is False
 
-    @pytest.mark.asyncio
-    async def test_get_state(self, mock_session, mock_response):
-        """Test getting device state."""
-        mock_response.json = AsyncMock(
-            return_value={"theme": 3, "brt": 75, "img": "/image/dashboard.jpg"}
-        )
+    def test_driver_property_raises_before_detection(self):
+        device = GeekMagicDevice("192.168.1.100")
+        with pytest.raises(RuntimeError):
+            _ = device.driver
 
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        state = await device.get_state()
 
-        assert state.theme == 3
-        assert state.brightness == 75
-        assert state.current_image == "/image/dashboard.jpg"
-        mock_session.get.assert_called_once_with("http://192.168.1.100/app.json")
-
-    @pytest.mark.asyncio
-    async def test_get_space(self, mock_session, mock_response):
-        """Test getting storage info."""
-        mock_response.json = AsyncMock(return_value={"total": 1048576, "free": 524288})
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        space = await device.get_space()
-
-        assert space.total == 1048576
-        assert space.free == 524288
-
-    @pytest.mark.asyncio
-    async def test_get_brightness(self, mock_session, mock_response):
-        """Test getting brightness."""
-        # API returns brightness as string
-        mock_response.json = AsyncMock(return_value={"brt": "71"})
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        brightness = await device.get_brightness()
-
-        assert brightness == 71
-        mock_session.get.assert_called_once_with("http://192.168.1.100/brt.json")
-
-    @pytest.mark.asyncio
-    async def test_set_brightness(self, mock_session, mock_response):
-        """Test setting brightness."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        await device.set_brightness(80)
-
-        mock_session.get.assert_called_with("http://192.168.1.100/set?brt=80")
-
-    @pytest.mark.asyncio
-    async def test_set_brightness_clamps_values(self, mock_session, mock_response):
-        """Test brightness values are clamped to 0-100."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-
-        await device.set_brightness(150)
-        mock_session.get.assert_called_with("http://192.168.1.100/set?brt=100")
-
-        await device.set_brightness(-10)
-        mock_session.get.assert_called_with("http://192.168.1.100/set?brt=0")
-
-    @pytest.mark.asyncio
-    async def test_set_theme(self, mock_session, mock_response):
-        """Test setting theme."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        await device.set_theme(3)
-
-        mock_session.get.assert_called_with("http://192.168.1.100/set?theme=3")
-
-    @pytest.mark.asyncio
-    async def test_set_image(self, mock_session, mock_response):
-        """Test setting displayed image."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        await device.set_image("dashboard.jpg")
-
-        # Should set theme first, then image
-        calls = mock_session.get.call_args_list
-        assert len(calls) == 2
-        assert "theme=3" in str(calls[0])
-        assert "img=/image/dashboard.jpg" in str(calls[1])
-
-    @pytest.mark.asyncio
-    async def test_upload(self, mock_session, mock_response):
-        """Test uploading an image."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        image_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100  # Fake JPEG
-
-        await device.upload(image_data, "test.jpg")
-
-        mock_session.post.assert_called_once()
-        call_args = mock_session.post.call_args
-        assert "doUpload" in call_args[0][0]
-
-    @pytest.mark.asyncio
-    async def test_upload_png(self, mock_session, mock_response):
-        """Test uploading a PNG image."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        image_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-
-        await device.upload(image_data, "test.png")
-
-        mock_session.post.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_upload_ignores_duplicate_content_length_error(self, mock_session):
-        """Test upload ignores malformed HTTP with duplicate Content-Length."""
-        import aiohttp
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        image_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
-
-        # Simulate the error from SmallTV-Ultra firmware
-        error = aiohttp.ClientResponseError(
-            request_info=MagicMock(),
-            history=(),
-            status=400,
-            message="Duplicate Content-Length header",
-        )
-        mock_session.post.return_value.__aenter__.side_effect = error
-
-        # Should not raise - error is ignored
-        await device.upload(image_data, "test.jpg")
-
-    @pytest.mark.asyncio
-    async def test_upload_ignores_data_after_close_error(self, mock_session):
-        """Test upload ignores malformed HTTP with data after Connection: close."""
-        import aiohttp
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        image_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
-
-        # Simulate the error from SmallTV-Pro firmware
-        error = aiohttp.ClientResponseError(
-            request_info=MagicMock(),
-            history=(),
-            status=400,
-            message="Data after `Connection: close`",
-        )
-        mock_session.post.return_value.__aenter__.side_effect = error
-
-        # Should not raise - error is ignored
-        await device.upload(image_data, "test.jpg")
-
-    @pytest.mark.asyncio
-    async def test_upload_and_display(self, mock_session, mock_response):
-        """Test uploading and displaying an image."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        image_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
-
-        await device.upload_and_display(image_data, "dashboard.jpg")
-
-        # Should call post for upload, then get for set_image
-        assert mock_session.post.called
-        assert mock_session.get.called
-
-    @pytest.mark.asyncio
-    async def test_delete_file(self, mock_session, mock_response):
-        """Test deleting a file."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        await device.delete_file("/image/old.jpg")
-
-        mock_session.get.assert_called_with("http://192.168.1.100/delete?file=/image/old.jpg")
-
-    @pytest.mark.asyncio
-    async def test_clear_images(self, mock_session, mock_response):
-        """Test clearing all images."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        await device.clear_images()
-
-        mock_session.get.assert_called_with("http://192.168.1.100/set?clear=image")
-
-    @pytest.mark.asyncio
-    async def test_test_connection_success(self, mock_session, mock_response):
-        """Test connection test succeeds."""
-        # Connection test uses /space.json endpoint (wider firmware support)
-        mock_response.json = AsyncMock(return_value={"total": 1048576, "free": 524288})
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        result = await device.test_connection()
-
-        assert result.success is True
-        assert result.error == "none"
-        # ConnectionResult should be truthy when successful
-        assert result
-        mock_session.get.assert_called_once_with("http://192.168.1.100/space.json")
-
-    @pytest.mark.asyncio
-    async def test_test_connection_failure(self, mock_session, mock_response):
-        """Test connection test fails gracefully with generic error."""
-        mock_session.get.side_effect = aiohttp.ClientError("Connection refused")
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        result = await device.test_connection()
-
-        assert result.success is False
-        # ClientError (base class) maps to unknown
-        assert result.error == "unknown"
-        # ConnectionResult should be falsy when failed
-        assert not result
-
-    @pytest.mark.asyncio
-    async def test_test_connection_timeout(self, mock_session, mock_response):
-        """Test connection test returns timeout error."""
-        mock_session.get.side_effect = TimeoutError()
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        result = await device.test_connection()
-
-        assert result.success is False
-        assert result.error == "timeout"
-        assert result.message is not None
-        assert "timed out" in result.message.lower()
-
-    @pytest.mark.asyncio
-    async def test_test_connection_dns_error(self, mock_session, mock_response):
-        """Test connection test returns DNS error."""
-        # Create a DNS error with proper arguments
-        mock_session.get.side_effect = aiohttp.ClientConnectorDNSError(
-            MagicMock(), OSError("DNS lookup failed")
-        )
-
-        device = GeekMagicDevice("invalid.hostname.local", session=mock_session)
-        result = await device.test_connection()
-
-        assert result.success is False
-        assert result.error == "dns_error"
-        assert result.message is not None
-        assert "resolve" in result.message.lower()
-
-    @pytest.mark.asyncio
-    async def test_test_connection_refused(self, mock_session, mock_response):
-        """Test connection test returns connection refused error."""
-        mock_session.get.side_effect = aiohttp.ClientConnectorError(
-            MagicMock(), OSError("Connection refused")
-        )
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        result = await device.test_connection()
-
-        assert result.success is False
-        assert result.error == "connection_refused"
-
-    @pytest.mark.asyncio
-    async def test_test_connection_http_error(self, mock_session, mock_response):
-        """Test connection test returns HTTP error."""
-        mock_session.get.side_effect = aiohttp.ClientResponseError(
-            MagicMock(), (), status=500, message="Internal Server Error"
-        )
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        result = await device.test_connection()
-
-        assert result.success is False
-        assert result.error == "http_error"
-        assert result.message is not None
-        assert "500" in result.message
-
+class TestSessionLifecycle:
     @pytest.mark.asyncio
     async def test_close_owned_session(self):
-        """Test closing owned session."""
         with patch("aiohttp.ClientSession") as mock_cls:
-            mock_session = MagicMock()
-            mock_session.close = AsyncMock()
-            mock_cls.return_value = mock_session
-
+            session = MagicMock()
+            session.close = AsyncMock()
+            mock_cls.return_value = session
             device = GeekMagicDevice("192.168.1.100")
-            device._session = mock_session
+            device._session = session
             await device.close()
-
-            mock_session.close.assert_called_once()
+            session.close.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_close_external_session(self, mock_session):
-        """Test not closing external session."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
+    async def test_close_external_session(self):
+        sess = _make_session()
+        device = GeekMagicDevice("192.168.1.100", session=sess)
         await device.close()
+        sess.close.assert_not_called()
 
-        mock_session.close.assert_not_called()
 
-
-class TestDeviceModelDetection:
-    """Tests for device model detection."""
-
-    @pytest.fixture
-    def mock_session(self):
-        """Create a mock aiohttp session."""
-        session = MagicMock()
-        session.close = AsyncMock()
-        return session
-
-    def test_init_with_model(self):
-        """Test device initialization with explicit model."""
-        from custom_components.geekmagic.const import MODEL_PRO
-
-        device = GeekMagicDevice("192.168.1.100", model=MODEL_PRO)
-        assert device.model == MODEL_PRO
-
-    def test_init_default_model(self):
-        """Test device initialization has unknown model by default."""
-        from custom_components.geekmagic.const import MODEL_UNKNOWN
-
-        device = GeekMagicDevice("192.168.1.100")
-        assert device.model == MODEL_UNKNOWN
+class TestDetection:
+    @pytest.mark.asyncio
+    async def test_detect_stock_pro(self):
+        session = _make_session(
+            {"/v.json": _make_response(json_data={"m": "GeekMagic SmallTV-PRO", "v": "V3"})}
+        )
+        device = GeekMagicDevice("192.168.1.100", session=session)
+        assert await device.detect_model() == MODEL_PRO
+        assert device.sw_version == "V3"
+        assert device.supports_navigation is True
 
     @pytest.mark.asyncio
-    async def test_detect_model_pro(self, mock_session):
-        """Test detecting Pro model via /.sys/app.json."""
-        from custom_components.geekmagic.const import MODEL_PRO
-
-        # Create mock response for Pro path
-        mock_response = MagicMock()
-        mock_response.status = 200
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
-        mock_session.get = MagicMock(return_value=mock_response)
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        result = await device.detect_model()
-
-        assert result == MODEL_PRO
-        assert device.model == MODEL_PRO
-        # Should have tried Pro path first
-        mock_session.get.assert_called()
-        call_url = mock_session.get.call_args[0][0]
-        assert "/.sys/app.json" in call_url
+    async def test_detect_stock_ultra(self):
+        session = _make_session(
+            {"/v.json": _make_response(json_data={"m": "SmallTV-Ultra", "v": "Ultra-V9"})}
+        )
+        device = GeekMagicDevice("192.168.1.100", session=session)
+        assert await device.detect_model() == MODEL_ULTRA
+        assert device.sw_version == "Ultra-V9"
+        assert device.supports_navigation is False
 
     @pytest.mark.asyncio
-    async def test_detect_model_ultra(self, mock_session):
-        """Test detecting Ultra model when Pro path fails."""
-        from custom_components.geekmagic.const import MODEL_ULTRA
+    async def test_detect_sdpro(self):
+        session = _make_session(
+            {"/config": _make_response(json_data={"brightness": 50, "freespace": 1024})}
+        )
+        device = GeekMagicDevice("192.168.1.100", session=session)
+        assert await device.detect_model() == MODEL_SDPRO
 
-        # First call (Pro path) fails, second call (Ultra path) succeeds
-        mock_response_fail = MagicMock()
-        mock_response_fail.status = 404
-        mock_response_fail.__aenter__ = AsyncMock(return_value=mock_response_fail)
-        mock_response_fail.__aexit__ = AsyncMock()
+    @pytest.mark.asyncio
+    async def test_detect_returns_unknown_when_all_fail(self):
+        session = _make_session({})
+        device = GeekMagicDevice("192.168.1.100", session=session)
+        assert await device.detect_model() == MODEL_UNKNOWN
+        assert device.sw_version is None
 
-        mock_response_ok = MagicMock()
-        mock_response_ok.status = 200
-        mock_response_ok.__aenter__ = AsyncMock(return_value=mock_response_ok)
-        mock_response_ok.__aexit__ = AsyncMock()
 
-        mock_session.get = MagicMock(side_effect=[mock_response_fail, mock_response_ok])
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        result = await device.detect_model()
-
-        assert result == MODEL_ULTRA
+class TestConnectionTest:
+    @pytest.mark.asyncio
+    async def test_success_runs_detection(self):
+        session = _make_session(
+            {
+                "/v.json": _make_response(json_data={"m": "SmallTV-Ultra", "v": "Ultra-V9.0.40"}),
+                "/space.json": _make_response(json_data={"total": 1024, "free": 512}),
+            }
+        )
+        device = GeekMagicDevice("192.168.1.100", session=session)
+        result = await device.test_connection()
+        assert result.success is True
         assert device.model == MODEL_ULTRA
 
     @pytest.mark.asyncio
-    async def test_navigate_next(self, mock_session):
-        """Test Pro navigate next."""
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
-        mock_session.get = MagicMock(return_value=mock_response)
+    async def test_failure_when_undetectable(self):
+        session = _make_session({})
+        device = GeekMagicDevice("192.168.1.100", session=session)
+        result = await device.test_connection()
+        assert result.success is False
+        assert result.error == "http_error"
 
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
+
+class TestDelegation:
+    """The facade must forward calls to the underlying driver."""
+
+    @pytest.fixture
+    def detected_device(self):
+        session = _make_session(
+            {"/v.json": _make_response(json_data={"m": "SmallTV-Ultra", "v": "Ultra-V9.0.40"})}
+        )
+        return GeekMagicDevice("192.168.1.100", session=session)
+
+    @pytest.mark.asyncio
+    async def test_each_method_calls_driver(self, detected_device):
+        device = detected_device
+        await device.detect_model()
+        driver = device.driver
+        driver.get_state = AsyncMock(return_value="STATE")
+        driver.get_space = AsyncMock(return_value="SPACE")
+        driver.get_brightness = AsyncMock(return_value=42)
+        driver.set_brightness = AsyncMock()
+        driver.set_theme = AsyncMock()
+        driver.set_theme_custom = AsyncMock()
+        driver.set_image = AsyncMock()
+        driver.upload = AsyncMock()
+        driver.upload_and_display = AsyncMock()
+        driver.delete_file = AsyncMock()
+        driver.clear_images = AsyncMock()
+        driver.reboot = AsyncMock()
+        driver.navigate_next = AsyncMock()
+        driver.navigate_previous = AsyncMock()
+        driver.navigate_enter = AsyncMock()
+
+        assert await device.get_state() == "STATE"
+        assert await device.get_space() == "SPACE"
+        assert await device.get_brightness() == 42
+        await device.set_brightness(50)
+        await device.set_theme(3)
+        await device.set_theme_custom()
+        await device.set_image("x.jpg")
+        await device.upload(b"x", "x.jpg")
+        await device.upload_and_display(b"x", "x.jpg")
+        await device.delete_file("/image/x.jpg")
+        await device.clear_images()
+        await device.reboot()
         await device.navigate_next()
-
-        mock_session.get.assert_called_with("http://192.168.1.100/set?page=1")
-
-    @pytest.mark.asyncio
-    async def test_navigate_previous(self, mock_session):
-        """Test Pro navigate previous."""
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
-        mock_session.get = MagicMock(return_value=mock_response)
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
         await device.navigate_previous()
-
-        mock_session.get.assert_called_with("http://192.168.1.100/set?page=-1")
-
-    @pytest.mark.asyncio
-    async def test_navigate_enter(self, mock_session):
-        """Test Pro navigate enter."""
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
-        mock_session.get = MagicMock(return_value=mock_response)
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
         await device.navigate_enter()
 
-        mock_session.get.assert_called_with("http://192.168.1.100/set?enter=-1")
+        driver.set_brightness.assert_awaited_once_with(50)
+        driver.set_theme.assert_awaited_once_with(3)
+        driver.set_theme_custom.assert_awaited_once()
+        driver.set_image.assert_awaited_once_with("x.jpg")
+        driver.upload.assert_awaited_once_with(b"x", "x.jpg")
+        driver.upload_and_display.assert_awaited_once_with(b"x", "x.jpg")
+        driver.delete_file.assert_awaited_once_with("/image/x.jpg")
+        driver.clear_images.assert_awaited_once()
+        driver.reboot.assert_awaited_once()
+        driver.navigate_next.assert_awaited_once()
+        driver.navigate_previous.assert_awaited_once()
+        driver.navigate_enter.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_reboot(self, mock_session):
-        """Test Pro reboot."""
-        mock_response = MagicMock()
-        mock_response.raise_for_status = MagicMock()
-        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
-        mock_response.__aexit__ = AsyncMock()
-        mock_session.get = MagicMock(return_value=mock_response)
-
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
-        await device.reboot()
-
-        mock_session.get.assert_called_with("http://192.168.1.100/set?reboot=1")
+    async def test_is_custom_image_theme_before_detection(self):
+        device = GeekMagicDevice("192.168.1.100")
+        # Conservative pre-detection fallback (Ultra: theme 3).
+        assert device.is_custom_image_theme(3) is True
+        assert device.is_custom_image_theme(4) is False

--- a/tests/test_ha_integration.py
+++ b/tests/test_ha_integration.py
@@ -46,29 +46,36 @@ def setup_device_http_mocks(
     """
     base = f"http://{host}"
 
-    # Connection test (test_connection → get_space)
+    # Firmware identification (drives detect_driver)
+    if model == "pro":
+        aioclient_mock.get(
+            f"{base}/v.json",
+            json={"m": "GeekMagic SmallTV-PRO", "v": "V3.3.76EN"},
+        )
+        # Pro firmware: brightness lives at /.sys/brt.json, /app.json is 404
+        aioclient_mock.get(f"{base}/.sys/brt.json", json={"brt": str(brightness)})
+        aioclient_mock.get(f"{base}/app.json", status=404)
+    else:
+        aioclient_mock.get(
+            f"{base}/v.json",
+            json={"m": "SmallTV-Ultra", "v": "Ultra-V9.0.40"},
+        )
+        # Ultra firmware: brightness at /brt.json, /app.json returns theme
+        aioclient_mock.get(f"{base}/brt.json", json={"brt": str(brightness)})
+        aioclient_mock.get(
+            f"{base}/app.json",
+            json={
+                "theme": theme,
+                "brt": brightness,
+                "img": "/image/dashboard.jpg",
+            },
+        )
+
+    # Storage (both stock variants)
     aioclient_mock.get(
         f"{base}/space.json",
         json={"total": total_storage, "free": free_storage},
     )
-
-    # Model detection
-    if model == "pro":
-        aioclient_mock.get(
-            f"{base}/.sys/app.json",
-            json={"theme": theme, "brt": brightness, "img": None},
-        )
-    else:
-        aioclient_mock.get(f"{base}/.sys/app.json", status=404)
-
-    # Device state
-    aioclient_mock.get(
-        f"{base}/app.json",
-        json={"theme": theme, "brt": brightness, "img": "/image/dashboard.jpg"},
-    )
-
-    # Brightness poll
-    aioclient_mock.get(f"{base}/brt.json", json={"brt": str(brightness)})
 
     # Upload image (POST)
     aioclient_mock.post(f"{base}/doUpload?dir=/image/", status=200)
@@ -134,7 +141,7 @@ class TestSetupLifecycle:
         """Test that connection failure results in ConfigEntryNotReady."""
         base = f"http://{DEVICE_HOST}"
         aioclient_mock.get(
-            f"{base}/space.json",
+            f"{base}/v.json",
             exc=TimeoutError("Connection timed out"),
         )
 


### PR DESCRIPTION
The reverse-engineering reports in docs/devices/ document three real
firmware families. The single hardcoded HTTP client only worked
reliably for one of them:

  - Stock SmallTV-Ultra (V9.0.40): mostly worked (with silent partial
    state because /app.json only returns {theme}).
  - Stock SmallTV-PRO (V3.3.76EN): silently misdetected. /.sys/app.json
    404s on this firmware, so detect_model() returned UNKNOWN and
    set_theme_custom() sent theme=3 (Weather) instead of the correct
    theme=4 (Picture) — the rendered image never displayed. Brightness
    polling also hit the wrong path (/brt.json vs /.sys/brt.json).
  - SD_PRO community firmware: setup failed entirely. Connection test
    404s on /space.json; the entire API surface is different
    (/config + /api/set?key=&value=, /photo/upload, no on-demand image).

Refactor into a DeviceDriver strategy with two implementations:

  - StockDriver parameterised by StockProfile (Pro vs Ultra differ only
    in brightness path, custom-image theme number, /app.json presence,
    and navigation support).
  - SDProDriver speaks the community firmware's API. Live image display
    uses a photo-slideshow workaround: upload as dashboard.jpg, disable
    other photos, force theme=Photo.

Detection now probes /v.json first (returns model + version on stock
firmwares), falls back to /config (SD_PRO fingerprint), then legacy
/app.json. Capability flags (supports_navigation, custom_image_theme,
brightness_range) let the coordinator branch without sniffing the model
string. Firmware version captured from /v.json is surfaced as
sw_version on the HA device card.

Tests reorganised:
  - tests/drivers/{test_stock,test_sdpro,test_detection}.py: endpoint
    coverage per firmware family + detection routing.
  - tests/test_device.py: facade concerns only (URL parsing, detection
    wiring, delegation).
  - tests/test_config_flow.py + tests/test_ha_integration.py: switched
    HTTP mocks from /.sys/app.json to /v.json.