### PR TITLE
refactor: extract firmware drivers and support SD_PRO community firmware

### DIFF
--- a/custom_components/geekmagic/__init__.py
+++ b/custom_components/geekmagic/__init__.py
@@ -112,6 +112,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = async_get_clientsession(hass)
     device = GeekMagicDevice(host, session=session)
 
+    # Detect firmware first so the connection test uses the right endpoint
+    # (SD_PRO has no /space.json; it is probed via /config instead).
+    await device.detect_model()
+
     # Test connection - raise ConfigEntryNotReady if device is offline
     # This allows HA to automatically retry instead of showing a "Setup Error"
     result = await device.test_connection()
@@ -121,9 +125,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     _LOGGER.debug("Successfully connected to GeekMagic device at %s", host)
-
-    # Detect device model (Pro vs Ultra)
-    await device.detect_model()
 
     # Create coordinator
     coordinator = GeekMagicCoordinator(

--- a/custom_components/geekmagic/const.py
+++ b/custom_components/geekmagic/const.py
@@ -5,6 +5,7 @@ DOMAIN = "geekmagic"
 # Device models
 MODEL_ULTRA = "ultra"
 MODEL_PRO = "pro"
+MODEL_SDPRO = "sdpro"  # SmallTV-Ultra running the JUZIPi-tech SD_PRO community firmware
 MODEL_UNKNOWN = "unknown"
 
 # Display dimensions

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -1066,17 +1066,17 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                 self._device_state = await self.device.get_state()
                 self._space_info = await self.device.get_space()
 
-                # Sync display mode with device state on first poll
-                # If device is in a built-in theme, respect that. The threshold
-                # is firmware-specific (None disables the sync entirely).
-                threshold = self.device.capabilities.builtin_theme_threshold
-                if (
-                    threshold is not None
-                    and self._device_state
-                    and self._device_state.theme is not None
-                ):
+                # Sync display mode with device state on first poll.
+                # If the device was manually switched to one of its built-in
+                # themes, respect that. We match against the firmware's explicit
+                # set of built-in theme numbers (not a "< N" heuristic): the
+                # custom-image theme differs per firmware (Ultra 3, Pro 4) and
+                # built-ins sit on both sides of it on Pro.
+                caps = self.device.capabilities
+                builtin_themes = set(caps.builtin_modes.values())
+                if builtin_themes and self._device_state and self._device_state.theme is not None:
                     device_theme = self._device_state.theme
-                    if device_theme < threshold and self._display_mode == "custom":
+                    if device_theme in builtin_themes and self._display_mode == "custom":
                         # Device is in built-in mode but we thought we were in custom
                         # This can happen on startup - sync to device state
                         _LOGGER.debug(

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -53,7 +53,6 @@ from .const import (
     LAYOUT_THREE_COLUMN,
     LAYOUT_THREE_ROW,
     MAX_BACKOFF_MULTIPLIER,
-    MODEL_PRO,
     THEME_WATCHOS,
 )
 from .device import DeviceState, GeekMagicDevice, SpaceInfo
@@ -668,12 +667,13 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             next_screen = (self._current_screen + 1) % len(self._layouts)
             await self.async_set_screen(next_screen)
 
-            # For Pro devices, also trigger device navigation to help refresh
-            if self.device.model == MODEL_PRO:
+            # On devices with hardware navigation, also nudge the device to
+            # help refresh the display.
+            if self.device.capabilities.supports_navigation:
                 try:
                     await self.device.navigate_next()
                 except Exception as err:
-                    _LOGGER.debug("Pro navigate_next failed (non-fatal): %s", err)
+                    _LOGGER.debug("Device navigate_next failed (non-fatal): %s", err)
 
     async def async_previous_screen(self) -> None:
         """Switch to the previous screen."""
@@ -681,12 +681,13 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             prev_screen = (self._current_screen - 1) % len(self._layouts)
             await self.async_set_screen(prev_screen)
 
-            # For Pro devices, also trigger device navigation to help refresh
-            if self.device.model == MODEL_PRO:
+            # On devices with hardware navigation, also nudge the device to
+            # help refresh the display.
+            if self.device.capabilities.supports_navigation:
                 try:
                     await self.device.navigate_previous()
                 except Exception as err:
-                    _LOGGER.debug("Pro navigate_previous failed (non-fatal): %s", err)
+                    _LOGGER.debug("Device navigate_previous failed (non-fatal): %s", err)
 
     def update_options(self, options: dict[str, Any]) -> None:
         """Update coordinator options.
@@ -1052,9 +1053,11 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                 or now - self._last_brightness_poll >= self._brightness_poll_interval
             ):
                 try:
-                    self._device_brightness = await self.device.get_brightness()
+                    brightness = await self.device.get_brightness()
                     self._last_brightness_poll = now
-                    _LOGGER.debug("Polled device brightness: %d", self._device_brightness)
+                    if brightness is not None:
+                        self._device_brightness = brightness
+                        _LOGGER.debug("Polled device brightness: %d", brightness)
                 except Exception as e:
                     _LOGGER.debug("Failed to poll device brightness: %s", e)
 
@@ -1064,10 +1067,16 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                 self._space_info = await self.device.get_space()
 
                 # Sync display mode with device state on first poll
-                # If device is in a built-in theme, respect that
-                if self._device_state and self._device_state.theme is not None:
+                # If device is in a built-in theme, respect that. The threshold
+                # is firmware-specific (None disables the sync entirely).
+                threshold = self.device.capabilities.builtin_theme_threshold
+                if (
+                    threshold is not None
+                    and self._device_state
+                    and self._device_state.theme is not None
+                ):
                     device_theme = self._device_state.theme
-                    if device_theme < 3 and self._display_mode == "custom":
+                    if device_theme < threshold and self._display_mode == "custom":
                         # Device is in built-in mode but we thought we were in custom
                         # This can happen on startup - sync to device state
                         _LOGGER.debug(

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -87,8 +87,8 @@ class GeekMagicDevice:
         return DriverCapabilities(
             supports_navigation=False,
             supports_on_demand_image=False,
-            supports_builtin_themes=False,
-            builtin_theme_threshold=None,
+            custom_theme=None,
+            builtin_modes={},
         )
 
     @property

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -1,68 +1,57 @@
-"""GeekMagic device HTTP API client."""
+"""GeekMagic device HTTP API client.
+
+``GeekMagicDevice`` is a thin facade. It owns the aiohttp session and the
+host/URL parsing, then delegates every operation to a :class:`FirmwareDriver`
+chosen by :func:`detect_driver`. The public method surface is unchanged so the
+coordinator and entities need not know which firmware is in use.
+"""
 
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from typing import Literal
 from urllib.parse import urlparse
 
 import aiohttp
 
-from .const import MODEL_PRO, MODEL_ULTRA, MODEL_UNKNOWN
+from .const import MODEL_UNKNOWN
+from .drivers import (
+    ConnectionResult,
+    DeviceState,
+    DriverCapabilities,
+    FirmwareDriver,
+    SpaceInfo,
+    detect_driver,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 TIMEOUT = aiohttp.ClientTimeout(total=30)
 
-
-@dataclass
-class ConnectionResult:
-    """Result of a connection test."""
-
-    success: bool
-    error: Literal[
-        "none", "timeout", "connection_refused", "dns_error", "http_error", "unknown"
-    ] = "none"
-    message: str | None = None
-
-    def __bool__(self) -> bool:
-        """Allow using ConnectionResult in boolean context."""
-        return self.success
-
-
-@dataclass
-class DeviceState:
-    """Represents the current device state."""
-
-    theme: int
-    brightness: int | None
-    current_image: str | None
-
-
-@dataclass
-class SpaceInfo:
-    """Represents device storage info."""
-
-    total: int
-    free: int
+# Re-exported for backward compatibility (``from .device import DeviceState``).
+__all__ = [
+    "ConnectionResult",
+    "DeviceState",
+    "GeekMagicDevice",
+    "SpaceInfo",
+]
 
 
 class GeekMagicDevice:
-    """HTTP client for GeekMagic display devices."""
+    """HTTP client facade for GeekMagic display devices."""
 
     def __init__(
         self,
         host: str,
         session: aiohttp.ClientSession | None = None,
-        model: str = MODEL_UNKNOWN,
+        model: str | None = None,
     ) -> None:
         """Initialize the device client.
 
         Args:
-            host: IP address, hostname, or URL of the device
-            session: Optional aiohttp session (created if not provided)
-            model: Device model (MODEL_PRO, MODEL_ULTRA, or MODEL_UNKNOWN)
+            host: IP address, hostname, or URL of the device.
+            session: Optional aiohttp session (created if not provided).
+            model: Deprecated/ignored — the model is determined by firmware
+                detection (:meth:`detect_model`). Accepted for compatibility.
         """
         # Parse and normalize the host input to handle URLs
         if host.startswith(("http://", "https://")):
@@ -74,7 +63,41 @@ class GeekMagicDevice:
             self.base_url = f"http://{host}"
         self._session = session
         self._owns_session = session is None
-        self.model = model
+        self._driver: FirmwareDriver | None = None
+
+    @property
+    def model(self) -> str:
+        """Return the detected model, or MODEL_UNKNOWN before detection."""
+        return self._driver.model if self._driver else MODEL_UNKNOWN
+
+    @property
+    def model_name(self) -> str:
+        """Return the human-readable model name for the detected firmware."""
+        return self._driver.model_name if self._driver else "SmallTV"
+
+    @property
+    def capabilities(self) -> DriverCapabilities:
+        """Return the detected firmware's capabilities.
+
+        Before detection, returns conservative defaults (no navigation, no
+        builtin-theme sync) so callers never crash on an undetected device.
+        """
+        if self._driver:
+            return self._driver.capabilities
+        return DriverCapabilities(
+            supports_navigation=False,
+            supports_on_demand_image=False,
+            supports_builtin_themes=False,
+            builtin_theme_threshold=None,
+        )
+
+    @property
+    def firmware_version(self) -> str | None:
+        """Return the firmware version string, if known."""
+        return self._driver.firmware_version if self._driver else None
+
+    # ``sw_version`` is the Home Assistant DeviceInfo field name.
+    sw_version = firmware_version
 
     async def _get_session(self) -> aiohttp.ClientSession:
         """Get or create the aiohttp session."""
@@ -82,323 +105,105 @@ class GeekMagicDevice:
             self._session = aiohttp.ClientSession(timeout=TIMEOUT)
         return self._session
 
+    async def _require_driver(self) -> FirmwareDriver:
+        """Return the driver, detecting it on first use."""
+        if self._driver is None:
+            await self.detect_model()
+        assert self._driver is not None
+        return self._driver
+
     async def close(self) -> None:
         """Close the session if we own it."""
         if self._owns_session and self._session is not None:
             await self._session.close()
             self._session = None
 
-    async def get_state(self) -> DeviceState:
-        """Get current device state.
+    async def detect_model(self) -> str:
+        """Detect the firmware and bind the matching driver.
 
-        Returns:
-            DeviceState with theme, brightness, and current image
+        Returns the detected model string (MODEL_PRO/MODEL_ULTRA/MODEL_SDPRO).
         """
-        _LOGGER.debug("Getting device state from %s", self.host)
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/app.json") as response:
-            response.raise_for_status()
-            # Device returns text/plain content type, so we need to accept any
-            data = await response.json(content_type=None)
-            state = DeviceState(
-                theme=data.get("theme", 0),
-                brightness=data.get("brt"),
-                current_image=data.get("img"),
-            )
-            _LOGGER.debug(
-                "Device state: theme=%d, brightness=%s, image=%s",
-                state.theme,
-                state.brightness,
-                state.current_image,
-            )
-            return state
+        self._driver = await detect_driver(self.host, self.base_url, self._get_session)
+        return self._driver.model
+
+    # -- delegated API surface ------------------------------------------------
+
+    async def test_connection(self) -> ConnectionResult:
+        """Test if the device is reachable (detects firmware if needed)."""
+        driver = await self._require_driver()
+        return await driver.test_connection()
+
+    async def get_state(self) -> DeviceState:
+        """Get current device state."""
+        driver = await self._require_driver()
+        return await driver.get_state()
 
     async def get_space(self) -> SpaceInfo:
-        """Get device storage information.
+        """Get device storage information."""
+        driver = await self._require_driver()
+        return await driver.get_space()
 
-        Returns:
-            SpaceInfo with total and free bytes
-        """
-        _LOGGER.debug("Getting storage info from %s", self.host)
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/space.json") as response:
-            response.raise_for_status()
-            # Device returns text/plain content type, so we need to accept any
-            data = await response.json(content_type=None)
-            space = SpaceInfo(
-                total=data.get("total", 0),
-                free=data.get("free", 0),
-            )
-            _LOGGER.debug(
-                "Storage info: total=%d, free=%d (%.1f%% free)",
-                space.total,
-                space.free,
-                (space.free / space.total * 100) if space.total > 0 else 0,
-            )
-            return space
-
-    async def get_brightness(self) -> int:
-        """Get current brightness from device.
-
-        Returns:
-            Brightness level 0-100
-        """
-        _LOGGER.debug("Getting brightness from %s", self.host)
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/brt.json") as response:
-            response.raise_for_status()
-            data = await response.json(content_type=None)
-            # API returns brightness as string: {"brt": "71"}
-            brightness = int(data.get("brt", 0))
-            _LOGGER.debug("Device brightness: %d", brightness)
-            return brightness
+    async def get_brightness(self) -> int | None:
+        """Get current brightness from device."""
+        driver = await self._require_driver()
+        return await driver.get_brightness()
 
     async def set_brightness(self, value: int) -> None:
-        """Set display brightness.
-
-        Args:
-            value: Brightness level 0-100
-        """
-        value = max(0, min(100, value))
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?brt={value}") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Set brightness to %d", value)
+        """Set display brightness."""
+        driver = await self._require_driver()
+        await driver.set_brightness(value)
 
     async def set_theme(self, theme: int) -> None:
-        """Set device theme.
-
-        Args:
-            theme: Theme number (3 = custom image on Ultra, 4 = custom image on Pro)
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?theme={theme}") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Set theme to %d", theme)
+        """Set device theme."""
+        driver = await self._require_driver()
+        await driver.set_theme(theme)
 
     async def set_theme_custom(self) -> None:
-        """Set device to custom image mode with the correct theme number.
-
-        Ultra devices use theme 3, Pro devices use theme 4.
-        Uses the model detected at startup via detect_model().
-        """
-        theme = 4 if self.model == MODEL_PRO else 3
-        await self.set_theme(theme)
+        """Set device to custom-image / dashboard mode."""
+        driver = await self._require_driver()
+        await driver.set_theme_custom()
 
     async def set_image(self, filename: str) -> None:
-        """Set the displayed image.
-
-        Args:
-            filename: Image filename (without path)
-        """
-        # Ensure we're in custom image mode
-        await self.set_theme_custom()
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?img=/image/{filename}") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Set image to %s", filename)
+        """Set the displayed image."""
+        driver = await self._require_driver()
+        await driver.set_image(filename)
 
     async def upload(self, image_data: bytes, filename: str) -> None:
-        """Upload an image to the device.
-
-        Args:
-            image_data: Raw image bytes (JPEG or PNG)
-            filename: Filename to save as
-        """
-        # Determine content type from filename
-        if filename.lower().endswith(".png"):
-            content_type = "image/png"
-        elif filename.lower().endswith(".gif"):
-            content_type = "image/gif"
-        else:
-            content_type = "image/jpeg"
-
-        # Create multipart form data
-        form = aiohttp.FormData()
-        form.add_field(
-            "file",
-            image_data,
-            filename=filename,
-            content_type=content_type,
-        )
-
-        session = await self._get_session()
-        try:
-            async with session.post(
-                f"{self.base_url}/doUpload?dir=/image/",
-                data=form,
-            ) as response:
-                response.raise_for_status()
-        except aiohttp.ClientResponseError as e:
-            # Device firmware returns malformed HTTP responses, but upload succeeds.
-            # Known issues:
-            # - SmallTV-Ultra: Duplicate Content-Length headers
-            # - SmallTV-Pro: "Data after Connection: close" (sends OK + new response)
-            if e.status == 400:
-                msg = str(e.message) if e.message else ""
-                if "Duplicate Content-Length" in msg or "Data after" in msg:
-                    _LOGGER.debug("Ignoring malformed HTTP response from device: %s", msg)
-                    return
-            raise
-
-        _LOGGER.debug("Uploaded %s (%d bytes)", filename, len(image_data))
+        """Upload an image to the device."""
+        driver = await self._require_driver()
+        await driver.upload(image_data, filename)
 
     async def upload_and_display(self, image_data: bytes, filename: str) -> None:
-        """Upload an image and immediately display it.
-
-        Args:
-            image_data: Raw image bytes
-            filename: Filename to save as
-        """
-        _LOGGER.debug(
-            "Uploading and displaying %s (%d bytes) to %s",
-            filename,
-            len(image_data),
-            self.host,
-        )
-        await self.upload(image_data, filename)
-        await self.set_image(filename)
-        _LOGGER.debug("Upload and display completed for %s", filename)
+        """Upload an image and immediately display it."""
+        driver = await self._require_driver()
+        await driver.upload_and_display(image_data, filename)
 
     async def delete_file(self, path: str) -> None:
-        """Delete a file from the device.
-
-        Args:
-            path: Full path to the file
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/delete?file={path}") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Deleted %s", path)
+        """Delete a file from the device."""
+        driver = await self._require_driver()
+        await driver.delete_file(path)
 
     async def clear_images(self) -> None:
         """Clear all images from the device."""
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?clear=image") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Cleared all images")
-
-    async def test_connection(self) -> ConnectionResult:
-        """Test if the device is reachable.
-
-        Returns:
-            ConnectionResult with success status and error details if failed.
-            Can be used in boolean context (truthy if successful).
-        """
-        _LOGGER.debug("Testing connection to %s", self.host)
-        try:
-            # use space.json as it's more widely supported across firmware versions
-            await self.get_space()
-        except TimeoutError:
-            _LOGGER.warning("Connection test timed out for %s", self.host)
-            return ConnectionResult(
-                success=False,
-                error="timeout",
-                message="Connection timed out after 30 seconds",
-            )
-        except aiohttp.ClientConnectorDNSError as e:
-            _LOGGER.warning("DNS resolution failed for %s: %s", self.host, e)
-            return ConnectionResult(
-                success=False,
-                error="dns_error",
-                message=f"Could not resolve hostname: {self.host}",
-            )
-        except aiohttp.ClientConnectorError as e:
-            _LOGGER.warning("Connection failed for %s: %s", self.host, e)
-            return ConnectionResult(
-                success=False,
-                error="connection_refused",
-                message=str(e),
-            )
-        except aiohttp.ClientResponseError as e:
-            _LOGGER.warning("HTTP error for %s: %s", self.host, e)
-            return ConnectionResult(
-                success=False,
-                error="http_error",
-                message=f"HTTP error {e.status}: {e.message}",
-            )
-        except Exception as e:
-            _LOGGER.warning("Connection test failed for %s: %s", self.host, e)
-            return ConnectionResult(
-                success=False,
-                error="unknown",
-                message=str(e),
-            )
-        else:
-            _LOGGER.debug("Connection test successful for %s", self.host)
-            return ConnectionResult(success=True)
-
-    # Pro-specific navigation methods
-    # These simulate the physical button presses on SmallTV Pro devices
+        driver = await self._require_driver()
+        await driver.clear_images()
 
     async def navigate_next(self) -> None:
-        """Navigate to next page (Pro devices).
-
-        Simulates pressing the right/next button on the device.
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?page=1") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Navigated to next page")
+        """Navigate to next page (Pro devices)."""
+        driver = await self._require_driver()
+        await driver.navigate_next()
 
     async def navigate_previous(self) -> None:
-        """Navigate to previous page (Pro devices).
-
-        Simulates pressing the left/previous button on the device.
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?page=-1") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Navigated to previous page")
+        """Navigate to previous page (Pro devices)."""
+        driver = await self._require_driver()
+        await driver.navigate_previous()
 
     async def navigate_enter(self) -> None:
-        """Press enter/exit button (Pro devices).
-
-        Simulates pressing the enter/menu button on the device.
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?enter=-1") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Pressed enter button")
+        """Press enter/exit button (Pro devices)."""
+        driver = await self._require_driver()
+        await driver.navigate_enter()
 
     async def reboot(self) -> None:
-        """Reboot the device (Pro devices)."""
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?reboot=1") as response:
-            response.raise_for_status()
-        _LOGGER.debug("Rebooting device")
-
-    async def detect_model(self) -> str:
-        """Attempt to detect the device model.
-
-        Pro devices use /.sys/ paths, Ultra devices use root paths.
-        Returns MODEL_PRO, MODEL_ULTRA, or MODEL_UNKNOWN.
-        """
-        session = await self._get_session()
-
-        # Try Pro-specific path first (/.sys/app.json)
-        try:
-            async with session.get(
-                f"{self.base_url}/.sys/app.json", timeout=aiohttp.ClientTimeout(total=5)
-            ) as response:
-                if response.status == 200:
-                    self.model = MODEL_PRO
-                    _LOGGER.info("Detected device model: SmallTV Pro")
-                    return self.model
-        except Exception as err:
-            _LOGGER.debug("Pro path /.sys/app.json not available: %s", err)
-
-        # Fall back to Ultra (standard path works)
-        try:
-            async with session.get(
-                f"{self.base_url}/app.json", timeout=aiohttp.ClientTimeout(total=5)
-            ) as response:
-                if response.status == 200:
-                    self.model = MODEL_ULTRA
-                    _LOGGER.info("Detected device model: SmallTV Ultra")
-                    return self.model
-        except Exception as err:
-            _LOGGER.debug("Ultra path /app.json not available: %s", err)
-
-        _LOGGER.warning("Could not detect device model for %s", self.host)
-        return MODEL_UNKNOWN
+        """Reboot the device."""
+        driver = await self._require_driver()
+        await driver.reboot()

--- a/custom_components/geekmagic/drivers/__init__.py
+++ b/custom_components/geekmagic/drivers/__init__.py
@@ -23,9 +23,6 @@ from .stock import PRO, ULTRA, StockDriver
 
 _LOGGER = logging.getLogger(__name__)
 
-# Detection probes use a short timeout so an absent endpoint fails fast.
-_DETECT_TIMEOUT = aiohttp.ClientTimeout(total=5)
-
 __all__ = [
     "ConnectionResult",
     "DeviceState",
@@ -36,6 +33,94 @@ __all__ = [
     "StockDriver",
     "detect_driver",
 ]
+
+# Detection probes use a short timeout so an absent endpoint fails fast.
+_DETECT_TIMEOUT = aiohttp.ClientTimeout(total=5)
+
+# Errors that mean the host itself is unreachable. When a probe hits one of
+# these, the remaining probes would fail identically, so we stop early instead
+# of burning a full timeout per probe (relevant for offline-host setup retries).
+_HOST_UNREACHABLE = (
+    aiohttp.ClientConnectorError,
+    aiohttp.ClientConnectorDNSError,
+    TimeoutError,
+)
+
+
+class _HostUnreachableError(Exception):
+    """Raised internally to abort detection when the host is unreachable."""
+
+
+async def _probe_status_json(session: aiohttp.ClientSession, url: str) -> dict | None:
+    """GET ``url``; return parsed JSON on HTTP 200, else None.
+
+    Raises :class:`_HostUnreachableError` if the host is unreachable so the
+    caller can stop probing early.
+    """
+    try:
+        async with session.get(url, timeout=_DETECT_TIMEOUT) as response:
+            if response.status == 200:
+                return await response.json(content_type=None)
+    except _HOST_UNREACHABLE as err:
+        raise _HostUnreachableError(str(err)) from err
+    except (aiohttp.ClientError, ValueError) as err:
+        # A missing endpoint (404) or non-JSON body is expected during probing.
+        _LOGGER.debug("Probe %s failed for detection: %s", url, err)
+    return None
+
+
+async def _probe_exists(session: aiohttp.ClientSession, url: str) -> bool:
+    """Return True if ``url`` responds with HTTP 200 (body ignored).
+
+    Used for legacy probes that only check endpoint presence. Raises
+    :class:`_HostUnreachableError` if the host is unreachable.
+    """
+    try:
+        async with session.get(url, timeout=_DETECT_TIMEOUT) as response:
+            return response.status == 200
+    except _HOST_UNREACHABLE as err:
+        raise _HostUnreachableError(str(err)) from err
+    except aiohttp.ClientError as err:
+        _LOGGER.debug("Probe %s failed for detection: %s", url, err)
+    return False
+
+
+async def _identify_driver(
+    session: aiohttp.ClientSession,
+    host: str,
+    base_url: str,
+    session_provider: SessionProvider,
+) -> FirmwareDriver | None:
+    """Run the probe sequence; return a driver if identified, else None."""
+    # 1. Stock identification via /v.json.
+    data = await _probe_status_json(session, f"{base_url}/v.json")
+    if data is not None:
+        model_str = str(data.get("m", ""))
+        version = data.get("v")
+        upper = model_str.upper()
+        if "PRO" in upper:
+            _LOGGER.info("Detected SmallTV Pro (%s) at %s", model_str, host)
+            return StockDriver(PRO, host, base_url, session_provider, version)
+        if "ULTRA" in upper:
+            _LOGGER.info("Detected SmallTV Ultra (%s) at %s", model_str, host)
+            return StockDriver(ULTRA, host, base_url, session_provider, version)
+
+    # 2. SD_PRO community firmware via /config.
+    data = await _probe_status_json(session, f"{base_url}/config")
+    if isinstance(data, dict) and "theme" in data and "brightness" in data:
+        _LOGGER.info("Detected SD_PRO community firmware at %s", host)
+        return SdProDriver(host, base_url, session_provider)
+
+    # 3. Legacy fallback for old stock firmware without /v.json. These are
+    #    presence checks only — the body is not used.
+    if await _probe_exists(session, f"{base_url}/.sys/app.json"):
+        _LOGGER.info("Detected SmallTV Pro (legacy /.sys/app.json) at %s", host)
+        return StockDriver(PRO, host, base_url, session_provider)
+    if await _probe_exists(session, f"{base_url}/app.json"):
+        _LOGGER.info("Detected SmallTV Ultra (legacy /app.json) at %s", host)
+        return StockDriver(ULTRA, host, base_url, session_provider)
+
+    return None
 
 
 async def detect_driver(
@@ -49,54 +134,32 @@ async def detect_driver(
       3. Legacy probe of ``/.sys/app.json`` / ``/app.json`` for old stock
          firmware that predates ``/v.json``.
       4. Default to the Ultra stock driver with a warning.
+
+    If the host is unreachable, probing stops after the first probe and the
+    default driver is returned; the subsequent ``test_connection()`` then
+    reports the failure as retryable rather than every probe timing out.
     """
     session = await session_provider()
 
-    # 1. Stock identification via /v.json.
+    # Detection is best-effort: it must never crash setup. The subsequent
+    # test_connection() is the authority on whether the host is reachable.
     try:
-        async with session.get(f"{base_url}/v.json", timeout=_DETECT_TIMEOUT) as response:
-            if response.status == 200:
-                data = await response.json(content_type=None)
-                model_str = str(data.get("m", ""))
-                version = data.get("v")
-                upper = model_str.upper()
-                if "PRO" in upper:
-                    _LOGGER.info("Detected SmallTV Pro (%s) at %s", model_str, host)
-                    return StockDriver(PRO, host, base_url, session_provider, version)
-                if "ULTRA" in upper:
-                    _LOGGER.info("Detected SmallTV Ultra (%s) at %s", model_str, host)
-                    return StockDriver(ULTRA, host, base_url, session_provider, version)
+        driver = await _identify_driver(session, host, base_url, session_provider)
+    except _HostUnreachableError as err:
+        _LOGGER.debug(
+            "Host %s unreachable during detection (%s); deferring to connection test",
+            host,
+            err,
+        )
+        return StockDriver(ULTRA, host, base_url, session_provider)
     except Exception as err:
-        _LOGGER.debug("/v.json detection failed for %s: %s", host, err)
+        # Detection must not break setup; default and let test_connection decide.
+        _LOGGER.debug("Firmware detection error for %s (%s); defaulting", host, err)
+        return StockDriver(ULTRA, host, base_url, session_provider)
 
-    # 2. SD_PRO community firmware via /config.
-    try:
-        async with session.get(f"{base_url}/config", timeout=_DETECT_TIMEOUT) as response:
-            if response.status == 200:
-                data = await response.json(content_type=None)
-                if isinstance(data, dict) and "theme" in data and "brightness" in data:
-                    _LOGGER.info("Detected SD_PRO community firmware at %s", host)
-                    return SdProDriver(host, base_url, session_provider)
-    except Exception as err:
-        _LOGGER.debug("/config detection failed for %s: %s", host, err)
+    if driver is not None:
+        return driver
 
-    # 3. Legacy fallback for old stock firmware without /v.json.
-    try:
-        async with session.get(f"{base_url}/.sys/app.json", timeout=_DETECT_TIMEOUT) as response:
-            if response.status == 200:
-                _LOGGER.info("Detected SmallTV Pro (legacy /.sys/app.json) at %s", host)
-                return StockDriver(PRO, host, base_url, session_provider)
-    except Exception as err:
-        _LOGGER.debug("Legacy Pro probe failed for %s: %s", host, err)
-
-    try:
-        async with session.get(f"{base_url}/app.json", timeout=_DETECT_TIMEOUT) as response:
-            if response.status == 200:
-                _LOGGER.info("Detected SmallTV Ultra (legacy /app.json) at %s", host)
-                return StockDriver(ULTRA, host, base_url, session_provider)
-    except Exception as err:
-        _LOGGER.debug("Legacy Ultra probe failed for %s: %s", host, err)
-
-    # 4. Default: assume stock Ultra (matches the historic UNKNOWN->theme-3 path).
+    # Default: assume stock Ultra (matches the historic UNKNOWN->theme-3 path).
     _LOGGER.warning("Could not detect firmware for %s; defaulting to SmallTV Ultra", host)
     return StockDriver(ULTRA, host, base_url, session_provider)

--- a/custom_components/geekmagic/drivers/__init__.py
+++ b/custom_components/geekmagic/drivers/__init__.py
@@ -1,0 +1,102 @@
+"""Firmware drivers for GeekMagic displays.
+
+``detect_driver`` fingerprints a device and returns the matching
+:class:`FirmwareDriver`. ``GeekMagicDevice`` delegates to it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiohttp
+
+from .base import (
+    ConnectionResult,
+    DeviceState,
+    DriverCapabilities,
+    FirmwareDriver,
+    SessionProvider,
+    SpaceInfo,
+)
+from .sdpro import SdProDriver
+from .stock import PRO, ULTRA, StockDriver
+
+_LOGGER = logging.getLogger(__name__)
+
+# Detection probes use a short timeout so an absent endpoint fails fast.
+_DETECT_TIMEOUT = aiohttp.ClientTimeout(total=5)
+
+__all__ = [
+    "ConnectionResult",
+    "DeviceState",
+    "DriverCapabilities",
+    "FirmwareDriver",
+    "SdProDriver",
+    "SpaceInfo",
+    "StockDriver",
+    "detect_driver",
+]
+
+
+async def detect_driver(
+    host: str, base_url: str, session_provider: SessionProvider
+) -> FirmwareDriver:
+    """Detect the firmware at ``base_url`` and return its driver.
+
+    Detection order matters:
+      1. ``/v.json`` — stock firmware identification (distinguishes Pro/Ultra).
+      2. ``/config`` — SD_PRO community firmware (has no ``/v.json``).
+      3. Legacy probe of ``/.sys/app.json`` / ``/app.json`` for old stock
+         firmware that predates ``/v.json``.
+      4. Default to the Ultra stock driver with a warning.
+    """
+    session = await session_provider()
+
+    # 1. Stock identification via /v.json.
+    try:
+        async with session.get(f"{base_url}/v.json", timeout=_DETECT_TIMEOUT) as response:
+            if response.status == 200:
+                data = await response.json(content_type=None)
+                model_str = str(data.get("m", ""))
+                version = data.get("v")
+                upper = model_str.upper()
+                if "PRO" in upper:
+                    _LOGGER.info("Detected SmallTV Pro (%s) at %s", model_str, host)
+                    return StockDriver(PRO, host, base_url, session_provider, version)
+                if "ULTRA" in upper:
+                    _LOGGER.info("Detected SmallTV Ultra (%s) at %s", model_str, host)
+                    return StockDriver(ULTRA, host, base_url, session_provider, version)
+    except Exception as err:
+        _LOGGER.debug("/v.json detection failed for %s: %s", host, err)
+
+    # 2. SD_PRO community firmware via /config.
+    try:
+        async with session.get(f"{base_url}/config", timeout=_DETECT_TIMEOUT) as response:
+            if response.status == 200:
+                data = await response.json(content_type=None)
+                if isinstance(data, dict) and "theme" in data and "brightness" in data:
+                    _LOGGER.info("Detected SD_PRO community firmware at %s", host)
+                    return SdProDriver(host, base_url, session_provider)
+    except Exception as err:
+        _LOGGER.debug("/config detection failed for %s: %s", host, err)
+
+    # 3. Legacy fallback for old stock firmware without /v.json.
+    try:
+        async with session.get(f"{base_url}/.sys/app.json", timeout=_DETECT_TIMEOUT) as response:
+            if response.status == 200:
+                _LOGGER.info("Detected SmallTV Pro (legacy /.sys/app.json) at %s", host)
+                return StockDriver(PRO, host, base_url, session_provider)
+    except Exception as err:
+        _LOGGER.debug("Legacy Pro probe failed for %s: %s", host, err)
+
+    try:
+        async with session.get(f"{base_url}/app.json", timeout=_DETECT_TIMEOUT) as response:
+            if response.status == 200:
+                _LOGGER.info("Detected SmallTV Ultra (legacy /app.json) at %s", host)
+                return StockDriver(ULTRA, host, base_url, session_provider)
+    except Exception as err:
+        _LOGGER.debug("Legacy Ultra probe failed for %s: %s", host, err)
+
+    # 4. Default: assume stock Ultra (matches the historic UNKNOWN->theme-3 path).
+    _LOGGER.warning("Could not detect firmware for %s; defaulting to SmallTV Ultra", host)
+    return StockDriver(ULTRA, host, base_url, session_provider)

--- a/custom_components/geekmagic/drivers/base.py
+++ b/custom_components/geekmagic/drivers/base.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 import aiohttp
@@ -75,12 +75,14 @@ class DriverCapabilities:
     # Device can be told to display a specific named image on demand. False for
     # firmwares whose display is a device-managed slideshow (SD_PRO).
     supports_on_demand_image: bool = True
-    # Device has the stock built-in theme set (Weather/Time/etc.) selectable by
-    # number. False when the theme set differs (SD_PRO).
-    supports_builtin_themes: bool = True
-    # Themes numbered below this threshold are device-managed "built-in" modes;
-    # the coordinator syncs display mode to them. None disables the sync.
-    builtin_theme_threshold: int | None = 3
+    # The theme number that means "show the integration's rendered image"
+    # (Ultra 3 = Photo Album, Pro 4 = Picture). None when the firmware has no
+    # such concept (SD_PRO, where the dashboard is faked via the slideshow).
+    custom_theme: int | None = None
+    # Selectable device built-in modes, mapped display-name -> theme number.
+    # Firmware-specific: Ultra and Pro number their themes differently, so this
+    # cannot be a single global table. Empty means "no built-in modes to offer".
+    builtin_modes: dict[str, int] = field(default_factory=dict)
 
 
 async def classify_connection(

--- a/custom_components/geekmagic/drivers/base.py
+++ b/custom_components/geekmagic/drivers/base.py
@@ -1,0 +1,267 @@
+"""Firmware driver abstraction for GeekMagic displays.
+
+Different GeekMagic firmwares expose very different HTTP APIs. Rather than
+branching on ``device.model`` throughout the codebase, each firmware is
+implemented as a :class:`FirmwareDriver`. ``GeekMagicDevice`` is a thin facade
+that detects the firmware once and delegates every call to the matching driver.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Literal
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+# Shared HTTP timeout for normal requests. Detection uses a shorter timeout.
+TIMEOUT = aiohttp.ClientTimeout(total=30)
+
+# Async callable returning the shared aiohttp session. The facade owns the
+# session lifecycle; drivers never create or close sessions themselves.
+SessionProvider = Callable[[], Awaitable[aiohttp.ClientSession]]
+
+
+@dataclass
+class ConnectionResult:
+    """Result of a connection test."""
+
+    success: bool
+    error: Literal[
+        "none", "timeout", "connection_refused", "dns_error", "http_error", "unknown"
+    ] = "none"
+    message: str | None = None
+
+    def __bool__(self) -> bool:
+        """Allow using ConnectionResult in boolean context."""
+        return self.success
+
+
+@dataclass
+class DeviceState:
+    """Represents the current device state.
+
+    ``theme`` is ``None`` when the firmware does not expose the active theme
+    (e.g. SmallTV-PRO V3.3.76 has no ``/app.json``).
+    """
+
+    theme: int | None
+    brightness: int | None
+    current_image: str | None
+
+
+@dataclass
+class SpaceInfo:
+    """Represents device storage info."""
+
+    total: int
+    free: int
+
+
+@dataclass(frozen=True)
+class DriverCapabilities:
+    """Feature flags describing what a firmware supports.
+
+    These let the coordinator and entities adapt behaviour without knowing the
+    concrete firmware.
+    """
+
+    # Device supports /set?page= and /set?enter= navigation (Pro only).
+    supports_navigation: bool = False
+    # Device can be told to display a specific named image on demand. False for
+    # firmwares whose display is a device-managed slideshow (SD_PRO).
+    supports_on_demand_image: bool = True
+    # Device has the stock built-in theme set (Weather/Time/etc.) selectable by
+    # number. False when the theme set differs (SD_PRO).
+    supports_builtin_themes: bool = True
+    # Themes numbered below this threshold are device-managed "built-in" modes;
+    # the coordinator syncs display mode to them. None disables the sync.
+    builtin_theme_threshold: int | None = 3
+
+
+async def classify_connection(
+    host: str, probe: Callable[[], Awaitable[object]]
+) -> ConnectionResult:
+    """Run ``probe`` and translate exceptions into a :class:`ConnectionResult`.
+
+    Shared by all drivers so connection-test error handling stays consistent.
+    """
+    try:
+        await probe()
+    except TimeoutError:
+        _LOGGER.warning("Connection test timed out for %s", host)
+        return ConnectionResult(
+            success=False, error="timeout", message="Connection timed out after 30 seconds"
+        )
+    except aiohttp.ClientConnectorDNSError as e:
+        _LOGGER.warning("DNS resolution failed for %s: %s", host, e)
+        return ConnectionResult(
+            success=False, error="dns_error", message=f"Could not resolve hostname: {host}"
+        )
+    except aiohttp.ClientConnectorError as e:
+        _LOGGER.warning("Connection failed for %s: %s", host, e)
+        return ConnectionResult(success=False, error="connection_refused", message=str(e))
+    except aiohttp.ClientResponseError as e:
+        _LOGGER.warning("HTTP error for %s: %s", host, e)
+        return ConnectionResult(
+            success=False, error="http_error", message=f"HTTP error {e.status}: {e.message}"
+        )
+    except Exception as e:
+        _LOGGER.warning("Connection test failed for %s: %s", host, e)
+        return ConnectionResult(success=False, error="unknown", message=str(e))
+    else:
+        _LOGGER.debug("Connection test successful for %s", host)
+        return ConnectionResult(success=True)
+
+
+class FirmwareDriver(ABC):
+    """Abstract HTTP driver for a specific GeekMagic firmware family."""
+
+    # Subclasses set these (instances may override firmware_version at detection).
+    model: str = "unknown"
+    model_name: str = "SmallTV"
+    capabilities: DriverCapabilities = DriverCapabilities()
+
+    def __init__(
+        self,
+        host: str,
+        base_url: str,
+        session_provider: SessionProvider,
+        firmware_version: str | None = None,
+    ) -> None:
+        """Initialize the driver.
+
+        Args:
+            host: Device host (``ip`` or ``ip:port``).
+            base_url: Fully-qualified base URL (e.g. ``http://192.168.1.5``).
+            session_provider: Async callable returning the shared session.
+            firmware_version: Firmware version string, if known from detection.
+        """
+        self.host = host
+        self.base_url = base_url
+        self._session_provider = session_provider
+        self.firmware_version = firmware_version
+
+    async def _session(self) -> aiohttp.ClientSession:
+        """Return the shared aiohttp session."""
+        return await self._session_provider()
+
+    # -- abstract API surface (mirrors what the coordinator/entities call) ----
+
+    @abstractmethod
+    async def test_connection(self) -> ConnectionResult:
+        """Test whether the device is reachable and speaks this firmware."""
+
+    @abstractmethod
+    async def get_state(self) -> DeviceState:
+        """Return current theme / brightness / image."""
+
+    @abstractmethod
+    async def get_space(self) -> SpaceInfo:
+        """Return storage info in bytes."""
+
+    @abstractmethod
+    async def get_brightness(self) -> int | None:
+        """Return current brightness (0-100), or None if unavailable."""
+
+    @abstractmethod
+    async def set_brightness(self, value: int) -> None:
+        """Set display brightness."""
+
+    @abstractmethod
+    async def set_theme(self, theme: int) -> None:
+        """Switch to a specific theme number."""
+
+    @abstractmethod
+    async def set_theme_custom(self) -> None:
+        """Switch to the firmware's custom-image / dashboard mode."""
+
+    @abstractmethod
+    async def set_image(self, filename: str) -> None:
+        """Display a previously uploaded image by name."""
+
+    @abstractmethod
+    async def upload(self, image_data: bytes, filename: str) -> None:
+        """Upload an image to the device."""
+
+    @abstractmethod
+    async def upload_and_display(self, image_data: bytes, filename: str) -> None:
+        """Upload an image and immediately display it."""
+
+    @abstractmethod
+    async def delete_file(self, path: str) -> None:
+        """Delete a file from the device."""
+
+    @abstractmethod
+    async def clear_images(self) -> None:
+        """Remove all uploaded images."""
+
+    @abstractmethod
+    async def reboot(self) -> None:
+        """Reboot the device."""
+
+    # Navigation defaults to no-op so non-Pro firmwares inherit it for free.
+
+    async def navigate_next(self) -> None:
+        """Navigate to next page (Pro devices)."""
+        return
+
+    async def navigate_previous(self) -> None:
+        """Navigate to previous page (Pro devices)."""
+        return
+
+    async def navigate_enter(self) -> None:
+        """Press enter/menu (Pro devices)."""
+        return
+
+    # -- shared helpers -------------------------------------------------------
+
+    async def _get_json(self, path: str) -> dict:
+        """GET ``path`` and parse the JSON body (device sends text/plain)."""
+        session = await self._session()
+        async with session.get(f"{self.base_url}{path}") as response:
+            response.raise_for_status()
+            return await response.json(content_type=None)
+
+    async def _get(self, path: str) -> None:
+        """GET ``path`` expecting no body, raising on HTTP error."""
+        session = await self._session()
+        async with session.get(f"{self.base_url}{path}") as response:
+            response.raise_for_status()
+
+    async def _post_multipart_image(
+        self, path: str, image_data: bytes, filename: str, field: str = "file"
+    ) -> None:
+        """POST a multipart image upload, tolerating known malformed responses.
+
+        GeekMagic firmwares return malformed HTTP responses on a successful
+        upload:
+          - SmallTV-Ultra: duplicate Content-Length headers
+          - SmallTV-Pro: "Data after Connection: close" (OK + a new response)
+        These are swallowed because the upload itself succeeds.
+        """
+        if filename.lower().endswith(".png"):
+            content_type = "image/png"
+        elif filename.lower().endswith(".gif"):
+            content_type = "image/gif"
+        else:
+            content_type = "image/jpeg"
+
+        form = aiohttp.FormData()
+        form.add_field(field, image_data, filename=filename, content_type=content_type)
+
+        session = await self._session()
+        try:
+            async with session.post(f"{self.base_url}{path}", data=form) as response:
+                response.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            if e.status == 400:
+                msg = str(e.message) if e.message else ""
+                if "Duplicate Content-Length" in msg or "Data after" in msg:
+                    _LOGGER.debug("Ignoring malformed HTTP response from device: %s", msg)
+                    return
+            raise

--- a/custom_components/geekmagic/drivers/sdpro.py
+++ b/custom_components/geekmagic/drivers/sdpro.py
@@ -52,8 +52,10 @@ class SdProDriver(FirmwareDriver):
     capabilities = DriverCapabilities(
         supports_navigation=False,
         supports_on_demand_image=False,
-        supports_builtin_themes=False,
-        builtin_theme_threshold=None,
+        # No stock built-in theme set, and the dashboard is faked via the
+        # slideshow rather than a dedicated "custom image" theme.
+        custom_theme=None,
+        builtin_modes={},
     )
 
     def __init__(
@@ -136,24 +138,75 @@ class SdProDriver(FirmwareDriver):
 
         ``filename`` from the coordinator is ignored; we alternate between two
         internal names so the new frame exists before the old is removed.
+
+        To keep the dashboard actually visible, we isolate it from the device's
+        own slideshow/theme rotation: only the Photo theme stays enabled, and
+        only our dashboard frame stays enabled in the photo pool. Otherwise the
+        device would rotate to other themes/photos and the dashboard would only
+        flash by intermittently.
         """
         new_frame = self._next_frame_name()
 
         # 1. Upload the new frame.
         await self.upload(image_data, new_frame)
-        # 2. Ensure the device is showing the photo slideshow.
+        # 2. Make Photo the only enabled theme so rotation can't switch away.
         await self.set_theme(PHOTO_THEME)
-        # 3. Enable only the new frame and keep rotation short.
+        await self._isolate_photo_theme()
+        # 3. Enable only the new frame; disable any competing photos.
         await self.set_image(new_frame)
+        await self._isolate_dashboard_photo(keep=new_frame)
         try:
             await self._get(f"/photo/interval?val={DASHBOARD_INTERVAL_SECONDS}")
         except aiohttp.ClientError as err:
             _LOGGER.debug("Failed to set photo interval (non-fatal): %s", err)
-        # 4. Retire the previous frame.
+        # 4. Retire the previous frame (our own alternate name only).
         if self._last_frame and self._last_frame != new_frame:
             await self._retire_frame(self._last_frame)
         self._last_frame = new_frame
         _LOGGER.debug("Displayed dashboard frame %s", new_frame)
+
+    async def _isolate_photo_theme(self) -> None:
+        """Disable every built-in theme except Photo so rotation can't switch.
+
+        Best-effort: if ``/theme/list`` or a toggle fails we keep going, since
+        the dashboard is still likely visible if Photo was already the active
+        theme.
+        """
+        try:
+            data = await self._get_json("/theme/list")
+        except (aiohttp.ClientError, ValueError) as err:
+            _LOGGER.debug("Could not read theme list to isolate dashboard: %s", err)
+            return
+        for theme in data.get("themes", []):
+            theme_id = theme.get("id")
+            if theme_id is None or theme_id == PHOTO_THEME:
+                continue
+            if theme.get("enabled"):
+                try:
+                    await self._get(f"/theme/toggle?id={theme_id}&state=0")
+                except aiohttp.ClientError as err:
+                    _LOGGER.debug("Failed to disable theme %s (non-fatal): %s", theme_id, err)
+
+    async def _isolate_dashboard_photo(self, *, keep: str) -> None:
+        """Disable every enabled photo except ``keep`` (our dashboard frame).
+
+        User photos and our stale alternate frame are toggled off so the
+        slideshow shows only the live dashboard. Non-fatal on error.
+        """
+        try:
+            data = await self._get_json("/photo/list")
+        except (aiohttp.ClientError, ValueError) as err:
+            _LOGGER.debug("Could not read photo list to isolate dashboard: %s", err)
+            return
+        for entry in data.get("files", []):
+            name = entry.get("name")
+            if not name or name == keep:
+                continue
+            if entry.get("enabled"):
+                try:
+                    await self._get(f"/photo/toggle?name={name}&state=0")
+                except aiohttp.ClientError as err:
+                    _LOGGER.debug("Failed to disable photo %s (non-fatal): %s", name, err)
 
     async def delete_file(self, path: str) -> None:
         """Delete a photo by name (``/photo/delete``)."""

--- a/custom_components/geekmagic/drivers/sdpro.py
+++ b/custom_components/geekmagic/drivers/sdpro.py
@@ -1,0 +1,195 @@
+"""Driver for the SD_PRO community firmware (JUZIPi-tech).
+
+This firmware (web title "Smart Weather Clock") shares no endpoints with stock
+GeekMagic firmware. It exposes a unified ``GET /config`` for reads and
+``GET /api/set?key=&value=`` for writes, plus a device-managed photo slideshow
+(``/photo/*``) and built-in theme rotation (``/theme/*``).
+
+Critically, there is **no** "display this named image now" endpoint. To drive a
+live dashboard we use a slideshow workaround: upload each rendered frame as a
+photo, keep only that photo enabled, force the Photo theme, and delete the
+previous frame. Two alternating filenames are used so the new frame always
+exists before the old one is deleted (no blank frame).
+
+Several details could not be confirmed without hardware and are flagged inline:
+the ``/api/set`` response format, the brightness write key (``lcd_brightness``),
+the ``/photo/upload`` field name, and valid ``/photo/interval`` values.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiohttp
+
+from ..const import MODEL_SDPRO
+from .base import (
+    ConnectionResult,
+    DeviceState,
+    DriverCapabilities,
+    FirmwareDriver,
+    SessionProvider,
+    SpaceInfo,
+    classify_connection,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Built-in theme index whose mode renders the photo slideshow.
+PHOTO_THEME = 2
+# Slideshow rotation while we drive a live dashboard. Kept short so a new frame
+# shows promptly; the exact set of allowed values is firmware-specific.
+DASHBOARD_INTERVAL_SECONDS = 5
+# Alternating filenames so the new frame exists before the old is deleted.
+_FRAME_NAMES = ("dashboard_a.jpg", "dashboard_b.jpg")
+
+
+class SdProDriver(FirmwareDriver):
+    """HTTP driver for the SD_PRO community firmware."""
+
+    model = MODEL_SDPRO
+    model_name = "SmallTV Ultra (SD_PRO)"
+    capabilities = DriverCapabilities(
+        supports_navigation=False,
+        supports_on_demand_image=False,
+        supports_builtin_themes=False,
+        builtin_theme_threshold=None,
+    )
+
+    def __init__(
+        self,
+        host: str,
+        base_url: str,
+        session_provider: SessionProvider,
+        firmware_version: str | None = None,
+    ) -> None:
+        """Initialize the SD_PRO driver."""
+        super().__init__(host, base_url, session_provider, firmware_version)
+        # Name of the frame currently shown, so we can delete it next cycle.
+        self._last_frame: str | None = None
+
+    async def test_connection(self) -> ConnectionResult:
+        """Probe ``/config`` (the firmware's single read endpoint)."""
+        return await classify_connection(self.host, self.get_state)
+
+    async def get_state(self) -> DeviceState:
+        """Read theme and brightness from ``/config``."""
+        config = await self._get_json("/config")
+        return DeviceState(
+            theme=config.get("theme"),
+            brightness=config.get("brightness"),
+            current_image=None,
+        )
+
+    async def get_space(self) -> SpaceInfo:
+        """Return photo-partition storage from ``/photo/list``.
+
+        ``total``/``used`` here describe the photo partition, not the whole
+        device. Falls back to ``/config.freespace`` (free only) if unavailable.
+        """
+        try:
+            data = await self._get_json("/photo/list")
+            total = int(data.get("total", 0))
+            used = int(data.get("used", 0))
+            return SpaceInfo(total=total, free=max(total - used, 0))
+        except aiohttp.ClientError:
+            config = await self._get_json("/config")
+            return SpaceInfo(total=0, free=int(config.get("freespace", 0)))
+
+    async def get_brightness(self) -> int | None:
+        """Return brightness from ``/config`` (device range 2-99)."""
+        config = await self._get_json("/config")
+        brightness = config.get("brightness")
+        return int(brightness) if brightness is not None else None
+
+    async def set_brightness(self, value: int) -> None:
+        """Set brightness via ``/api/set`` (clamped to the device's 2-99 range).
+
+        The config read key is ``brightness`` but the write key is
+        ``lcd_brightness`` (per the firmware JS) — verify on hardware.
+        """
+        value = max(2, min(99, value))
+        await self._get(f"/api/set?key=lcd_brightness&value={value}")
+        _LOGGER.debug("Set brightness to %d", value)
+
+    async def set_theme(self, theme: int) -> None:
+        """Switch theme via ``/api/set?key=theme``."""
+        await self._get(f"/api/set?key=theme&value={theme}")
+        _LOGGER.debug("Set theme to %d", theme)
+
+    async def set_theme_custom(self) -> None:
+        """Switch to the Photo theme used for the slideshow dashboard."""
+        await self.set_theme(PHOTO_THEME)
+
+    async def set_image(self, filename: str) -> None:
+        """Enable only ``filename`` in the slideshow (no direct display API)."""
+        await self._get(f"/photo/toggle?name={filename}&state=1")
+        _LOGGER.debug("Enabled photo %s", filename)
+
+    async def upload(self, image_data: bytes, filename: str) -> None:
+        """Upload a photo via ``POST /photo/upload`` (multipart field ``file``)."""
+        await self._post_multipart_image("/photo/upload", image_data, filename)
+        _LOGGER.debug("Uploaded photo %s (%d bytes)", filename, len(image_data))
+
+    async def upload_and_display(self, image_data: bytes, filename: str) -> None:
+        """Render a live dashboard frame via the slideshow workaround.
+
+        ``filename`` from the coordinator is ignored; we alternate between two
+        internal names so the new frame exists before the old is removed.
+        """
+        new_frame = self._next_frame_name()
+
+        # 1. Upload the new frame.
+        await self.upload(image_data, new_frame)
+        # 2. Ensure the device is showing the photo slideshow.
+        await self.set_theme(PHOTO_THEME)
+        # 3. Enable only the new frame and keep rotation short.
+        await self.set_image(new_frame)
+        try:
+            await self._get(f"/photo/interval?val={DASHBOARD_INTERVAL_SECONDS}")
+        except aiohttp.ClientError as err:
+            _LOGGER.debug("Failed to set photo interval (non-fatal): %s", err)
+        # 4. Retire the previous frame.
+        if self._last_frame and self._last_frame != new_frame:
+            await self._retire_frame(self._last_frame)
+        self._last_frame = new_frame
+        _LOGGER.debug("Displayed dashboard frame %s", new_frame)
+
+    async def delete_file(self, path: str) -> None:
+        """Delete a photo by name (``/photo/delete``)."""
+        name = path.rsplit("/", 1)[-1]
+        await self._get(f"/photo/delete?name={name}")
+        _LOGGER.debug("Deleted photo %s", name)
+
+    async def clear_images(self) -> None:
+        """Delete every photo from the slideshow pool."""
+        data = await self._get_json("/photo/list")
+        for entry in data.get("files", []):
+            name = entry.get("name")
+            if name:
+                await self._get(f"/photo/delete?name={name}")
+        self._last_frame = None
+        _LOGGER.debug("Cleared all photos")
+
+    async def reboot(self) -> None:
+        """Reboot via ``/restart``; the device may drop the connection first."""
+        try:
+            await self._get("/restart")
+        except (aiohttp.ClientError, TimeoutError) as err:
+            # The device reboots before responding; treat any error as success.
+            _LOGGER.debug("Restart request errored as expected (device rebooting): %s", err)
+        _LOGGER.debug("Rebooting device")
+
+    def _next_frame_name(self) -> str:
+        """Return the alternate frame name to the one currently shown."""
+        if self._last_frame == _FRAME_NAMES[0]:
+            return _FRAME_NAMES[1]
+        return _FRAME_NAMES[0]
+
+    async def _retire_frame(self, name: str) -> None:
+        """Disable and delete a previous frame, tolerating errors."""
+        try:
+            await self._get(f"/photo/toggle?name={name}&state=0")
+            await self._get(f"/photo/delete?name={name}")
+        except aiohttp.ClientError as err:
+            _LOGGER.debug("Failed to retire frame %s (non-fatal): %s", name, err)

--- a/custom_components/geekmagic/drivers/stock.py
+++ b/custom_components/geekmagic/drivers/stock.py
@@ -41,13 +41,42 @@ class StockVariant:
     capabilities: DriverCapabilities
 
 
+# Ultra V9 theme map (from docs/devices/old-ultra): 1=Weather Clock Today,
+# 2=Weather Forecast, 3=Photo Album (custom image), 4-6=Time styles,
+# 7=Simple Weather Clock. Theme 3 is the custom slot, so it is excluded here.
+_ULTRA_BUILTIN_MODES = {
+    "Weather Clock Today": 1,
+    "Weather Forecast": 2,
+    "Time Style 1": 4,
+    "Time Style 2": 5,
+    "Time Style 3": 6,
+    "Simple Weather Clock": 7,
+}
+
+# Pro V3.3.76 theme map (from docs/devices/new-pro): 0=Bitcoin, 1=CoinGecko,
+# 2=Stocks, 3=Weather, 4=Picture (custom image), 5=Monitor, 6=Clock, 7=Ideas.
+# Theme 4 is the custom slot, so it is excluded here.
+_PRO_BUILTIN_MODES = {
+    "Bitcoin": 0,
+    "CoinGecko": 1,
+    "Stocks": 2,
+    "Weather": 3,
+    "Monitor": 5,
+    "Clock": 6,
+    "Ideas": 7,
+}
+
 ULTRA = StockVariant(
     model=MODEL_ULTRA,
     model_name="SmallTV Ultra",
     custom_theme_number=3,
     brightness_path="/brt.json",
     state_path="/app.json",
-    capabilities=DriverCapabilities(supports_navigation=False, builtin_theme_threshold=3),
+    capabilities=DriverCapabilities(
+        supports_navigation=False,
+        custom_theme=3,
+        builtin_modes=_ULTRA_BUILTIN_MODES,
+    ),
 )
 
 PRO = StockVariant(
@@ -57,7 +86,11 @@ PRO = StockVariant(
     # V3.3.76EN exposes brightness under /.sys/, and has no /app.json.
     brightness_path="/.sys/brt.json",
     state_path=None,
-    capabilities=DriverCapabilities(supports_navigation=True, builtin_theme_threshold=3),
+    capabilities=DriverCapabilities(
+        supports_navigation=True,
+        custom_theme=4,
+        builtin_modes=_PRO_BUILTIN_MODES,
+    ),
 )
 
 

--- a/custom_components/geekmagic/drivers/stock.py
+++ b/custom_components/geekmagic/drivers/stock.py
@@ -1,0 +1,168 @@
+"""Driver for stock GeekMagic firmware (SmallTV Pro and Ultra).
+
+Pro and Ultra share ~90% of the same root HTTP API; the differences are
+captured in a small per-variant table:
+
+  - custom-image theme number (Ultra 3 "Photo Album", Pro 4 "Picture")
+  - brightness read path (Ultra ``/brt.json``, Pro ``/.sys/brt.json``)
+  - whether ``/app.json`` exists (Ultra yes, Pro no)
+  - device navigation support (Pro only)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from ..const import MODEL_PRO, MODEL_ULTRA
+from .base import (
+    ConnectionResult,
+    DeviceState,
+    DriverCapabilities,
+    FirmwareDriver,
+    SessionProvider,
+    SpaceInfo,
+    classify_connection,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StockVariant:
+    """Per-model configuration for the stock firmware driver."""
+
+    model: str
+    model_name: str
+    custom_theme_number: int
+    brightness_path: str
+    # Path returning {"theme": N}, or None if the firmware has no such endpoint.
+    state_path: str | None
+    capabilities: DriverCapabilities
+
+
+ULTRA = StockVariant(
+    model=MODEL_ULTRA,
+    model_name="SmallTV Ultra",
+    custom_theme_number=3,
+    brightness_path="/brt.json",
+    state_path="/app.json",
+    capabilities=DriverCapabilities(supports_navigation=False, builtin_theme_threshold=3),
+)
+
+PRO = StockVariant(
+    model=MODEL_PRO,
+    model_name="SmallTV Pro",
+    custom_theme_number=4,
+    # V3.3.76EN exposes brightness under /.sys/, and has no /app.json.
+    brightness_path="/.sys/brt.json",
+    state_path=None,
+    capabilities=DriverCapabilities(supports_navigation=True, builtin_theme_threshold=3),
+)
+
+
+class StockDriver(FirmwareDriver):
+    """HTTP driver for stock GeekMagic firmware."""
+
+    def __init__(
+        self,
+        variant: StockVariant,
+        host: str,
+        base_url: str,
+        session_provider: SessionProvider,
+        firmware_version: str | None = None,
+    ) -> None:
+        """Initialize from a :class:`StockVariant`."""
+        super().__init__(host, base_url, session_provider, firmware_version)
+        self._variant = variant
+        self.model = variant.model
+        self.model_name = variant.model_name
+        self.capabilities = variant.capabilities
+
+    async def test_connection(self) -> ConnectionResult:
+        """Probe ``/space.json`` (supported across stock firmware versions)."""
+        return await classify_connection(self.host, self.get_space)
+
+    async def get_state(self) -> DeviceState:
+        """Return device state, degrading gracefully when /app.json is absent."""
+        if self._variant.state_path is None:
+            # Pro V3.3.76 has no state endpoint; avoid a guaranteed 404.
+            return DeviceState(theme=None, brightness=None, current_image=None)
+        data = await self._get_json(self._variant.state_path)
+        return DeviceState(
+            theme=data.get("theme", 0),
+            brightness=data.get("brt"),
+            current_image=data.get("img"),
+        )
+
+    async def get_space(self) -> SpaceInfo:
+        """Return storage info from ``/space.json``."""
+        data = await self._get_json("/space.json")
+        return SpaceInfo(total=data.get("total", 0), free=data.get("free", 0))
+
+    async def get_brightness(self) -> int | None:
+        """Return brightness from the variant's brightness path."""
+        data = await self._get_json(self._variant.brightness_path)
+        return int(data.get("brt", 0))
+
+    async def set_brightness(self, value: int) -> None:
+        """Set brightness (clamped 0-100)."""
+        value = max(0, min(100, value))
+        await self._get(f"/set?brt={value}")
+        _LOGGER.debug("Set brightness to %d", value)
+
+    async def set_theme(self, theme: int) -> None:
+        """Switch to a specific theme number."""
+        await self._get(f"/set?theme={theme}")
+        _LOGGER.debug("Set theme to %d", theme)
+
+    async def set_theme_custom(self) -> None:
+        """Switch to the variant's custom-image theme (Ultra 3, Pro 4)."""
+        await self.set_theme(self._variant.custom_theme_number)
+
+    async def set_image(self, filename: str) -> None:
+        """Switch to custom mode and display the named image."""
+        await self.set_theme_custom()
+        await self._get(f"/set?img=/image/{filename}")
+        _LOGGER.debug("Set image to %s", filename)
+
+    async def upload(self, image_data: bytes, filename: str) -> None:
+        """Upload an image to ``/image/``."""
+        await self._post_multipart_image("/doUpload?dir=/image/", image_data, filename)
+        _LOGGER.debug("Uploaded %s (%d bytes)", filename, len(image_data))
+
+    async def upload_and_display(self, image_data: bytes, filename: str) -> None:
+        """Upload an image and immediately display it."""
+        await self.upload(image_data, filename)
+        await self.set_image(filename)
+        _LOGGER.debug("Upload and display completed for %s", filename)
+
+    async def delete_file(self, path: str) -> None:
+        """Delete a file by full path."""
+        await self._get(f"/delete?file={path}")
+        _LOGGER.debug("Deleted %s", path)
+
+    async def clear_images(self) -> None:
+        """Clear all images."""
+        await self._get("/set?clear=image")
+        _LOGGER.debug("Cleared all images")
+
+    async def navigate_next(self) -> None:
+        """Navigate to next page (Pro devices)."""
+        await self._get("/set?page=1")
+        _LOGGER.debug("Navigated to next page")
+
+    async def navigate_previous(self) -> None:
+        """Navigate to previous page (Pro devices)."""
+        await self._get("/set?page=-1")
+        _LOGGER.debug("Navigated to previous page")
+
+    async def navigate_enter(self) -> None:
+        """Press enter/menu button (Pro devices)."""
+        await self._get("/set?enter=-1")
+        _LOGGER.debug("Pressed enter button")
+
+    async def reboot(self) -> None:
+        """Reboot the device."""
+        await self._get("/set?reboot=1")
+        _LOGGER.debug("Rebooting device")

--- a/custom_components/geekmagic/entities/base.py
+++ b/custom_components/geekmagic/entities/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ..const import DOMAIN, MODEL_PRO, MODEL_ULTRA
+from ..const import DOMAIN
 
 if TYPE_CHECKING:
     from ..coordinator import GeekMagicCoordinator
@@ -30,13 +30,8 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
 
     @property
     def _device_model_name(self) -> str:
-        """Return human-readable device model name."""
-        model = self.coordinator.device.model
-        if model == MODEL_PRO:
-            return "SmallTV Pro"
-        if model == MODEL_ULTRA:
-            return "SmallTV Ultra"
-        return "SmallTV"
+        """Return human-readable device model name from the detected firmware."""
+        return self.coordinator.device.model_name
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -46,4 +41,5 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
             name=self.coordinator.entry.title,
             manufacturer="GeekMagic",
             model=self._device_model_name,
+            sw_version=self.coordinator.device.sw_version,
         )

--- a/custom_components/geekmagic/entities/select.py
+++ b/custom_components/geekmagic/entities/select.py
@@ -19,17 +19,9 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Built-in device modes with their theme numbers
-# These are handled by the device firmware, not rendered by the integration
-# Theme 3 (Photo Album) is intentionally omitted - used for custom rendered views
-BUILTIN_MODES = {
-    "Weather Clock Today": 1,
-    "Weather Forecast": 2,
-    "Time Style 1": 4,
-    "Time Style 2": 5,
-    "Time Style 3": 6,
-    "Simple Weather Clock": 7,
-}
+# Built-in device modes are firmware-specific (Ultra and Pro number their
+# themes differently), so the name->theme map comes from the active driver's
+# capabilities rather than a global table. See drivers/stock.py.
 
 # Prefix used to identify custom views in the combined select
 CUSTOM_VIEW_PREFIX = ""  # No prefix - views shown by name directly
@@ -73,14 +65,11 @@ class GeekMagicDisplaySelect(GeekMagicEntity, SelectEntity):
         self._last_options: list[str] | None = None
 
     def _builtin_modes(self) -> dict[str, int]:
-        """Return stock built-in modes, or none if the firmware lacks them.
+        """Return the active firmware's built-in modes (name -> theme number).
 
-        SD_PRO uses a different theme set, so its stock built-in entries would
-        be wrong; hide them behind the capability flag.
+        Empty for firmwares with no selectable stock themes (e.g. SD_PRO).
         """
-        if self.coordinator.device.capabilities.supports_builtin_themes:
-            return BUILTIN_MODES
-        return {}
+        return self.coordinator.device.capabilities.builtin_modes
 
     def _get_custom_view_names(self) -> list[str]:
         """Get list of custom view names."""

--- a/custom_components/geekmagic/entities/select.py
+++ b/custom_components/geekmagic/entities/select.py
@@ -72,6 +72,16 @@ class GeekMagicDisplaySelect(GeekMagicEntity, SelectEntity):
         # Track last known options to detect when views are added/removed
         self._last_options: list[str] | None = None
 
+    def _builtin_modes(self) -> dict[str, int]:
+        """Return stock built-in modes, or none if the firmware lacks them.
+
+        SD_PRO uses a different theme set, so its stock built-in entries would
+        be wrong; hide them behind the capability flag.
+        """
+        if self.coordinator.device.capabilities.supports_builtin_themes:
+            return BUILTIN_MODES
+        return {}
+
     def _get_custom_view_names(self) -> list[str]:
         """Get list of custom view names."""
         store = self.coordinator.get_store()
@@ -92,7 +102,7 @@ class GeekMagicDisplaySelect(GeekMagicEntity, SelectEntity):
 
         Built-in modes come first, followed by custom views.
         """
-        options = list(BUILTIN_MODES.keys())
+        options = list(self._builtin_modes().keys())
         options.extend(self._get_custom_view_names())
         return options or ["Clock"]
 
@@ -102,7 +112,7 @@ class GeekMagicDisplaySelect(GeekMagicEntity, SelectEntity):
         # Check if coordinator is in builtin mode
         if self.coordinator.display_mode == "builtin":
             theme = self.coordinator.builtin_theme
-            for mode_name, mode_theme in BUILTIN_MODES.items():
+            for mode_name, mode_theme in self._builtin_modes().items():
                 if mode_theme == theme:
                     return mode_name
             return "Clock"
@@ -121,9 +131,10 @@ class GeekMagicDisplaySelect(GeekMagicEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Handle selection of a display option."""
-        if option in BUILTIN_MODES:
+        builtin_modes = self._builtin_modes()
+        if option in builtin_modes:
             # Built-in mode selected - set device theme and enter builtin mode
-            theme = BUILTIN_MODES[option]
+            theme = builtin_modes[option]
             _LOGGER.debug("Switching to built-in mode: %s (theme=%d)", option, theme)
             await self.coordinator.device.set_theme(theme)
             self.coordinator.set_display_mode("builtin", theme)

--- a/tests/drivers/test_detection.py
+++ b/tests/drivers/test_detection.py
@@ -1,0 +1,122 @@
+"""Tests for firmware driver detection."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from custom_components.geekmagic.const import MODEL_PRO, MODEL_SDPRO, MODEL_ULTRA
+from custom_components.geekmagic.drivers import detect_driver
+from custom_components.geekmagic.drivers.sdpro import SdProDriver
+from custom_components.geekmagic.drivers.stock import StockDriver
+
+BASE_URL = "http://192.168.1.50"
+HOST = "192.168.1.50"
+
+
+def _response(*, status: int = 200, json_value=None):
+    """Build a mock aiohttp response usable as an async context manager."""
+    resp = MagicMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=json_value)
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock()
+    return resp
+
+
+def _session(route_map: dict):
+    """Build a mock session whose .get returns responses keyed by path substring.
+
+    ``route_map`` maps a path fragment to a response (or an Exception to raise).
+    Unmatched paths raise to emulate an absent endpoint.
+    """
+
+    def _get(url, *args, **kwargs):
+        for fragment, result in route_map.items():
+            if fragment in url:
+                if isinstance(result, Exception):
+                    raise result
+                return result
+        raise AssertionError(f"unexpected request: {url}")
+
+    session = MagicMock()
+    session.get = MagicMock(side_effect=_get)
+    return session
+
+
+async def _provider(session):
+    return session
+
+
+@pytest.mark.asyncio
+async def test_detect_pro_via_v_json():
+    """A /v.json with 'PRO' in the model resolves to the Pro stock driver."""
+    session = _session(
+        {"/v.json": _response(json_value={"m": "GeekMagic SmallTV-PRO", "v": "V3.3.76EN"})}
+    )
+    driver = await detect_driver(HOST, BASE_URL, lambda: _provider(session))
+    assert isinstance(driver, StockDriver)
+    assert driver.model == MODEL_PRO
+    assert driver.firmware_version == "V3.3.76EN"
+    assert driver.capabilities.supports_navigation is True
+
+
+@pytest.mark.asyncio
+async def test_detect_ultra_via_v_json():
+    """A /v.json with 'Ultra' in the model resolves to the Ultra stock driver."""
+    session = _session(
+        {"/v.json": _response(json_value={"m": "SmallTV-Ultra", "v": "Ultra-V9.0.40"})}
+    )
+    driver = await detect_driver(HOST, BASE_URL, lambda: _provider(session))
+    assert isinstance(driver, StockDriver)
+    assert driver.model == MODEL_ULTRA
+    assert driver.capabilities.supports_navigation is False
+
+
+@pytest.mark.asyncio
+async def test_detect_sdpro_via_config():
+    """No /v.json but a /config with theme+brightness resolves to SD_PRO."""
+    session = _session(
+        {
+            "/v.json": _response(status=404),
+            "/config": _response(json_value={"theme": 2, "brightness": 50, "freespace": 1000}),
+        }
+    )
+    driver = await detect_driver(HOST, BASE_URL, lambda: _provider(session))
+    assert isinstance(driver, SdProDriver)
+    assert driver.model == MODEL_SDPRO
+    assert driver.capabilities.supports_on_demand_image is False
+
+
+@pytest.mark.asyncio
+async def test_detect_legacy_pro_via_sys_app_json():
+    """Old Pro firmware without /v.json falls back to the /.sys/app.json probe."""
+    session = _session(
+        {
+            "/v.json": _response(status=404),
+            "/config": _response(status=404),
+            "/.sys/app.json": _response(status=200),
+        }
+    )
+    driver = await detect_driver(HOST, BASE_URL, lambda: _provider(session))
+    assert isinstance(driver, StockDriver)
+    assert driver.model == MODEL_PRO
+
+
+@pytest.mark.asyncio
+async def test_detect_defaults_to_ultra():
+    """When nothing is identifiable, default to the Ultra stock driver."""
+    session = _session(
+        {
+            "/v.json": _response(status=404),
+            "/config": _response(status=404),
+            "/.sys/app.json": _response(status=404),
+            "/app.json": _response(status=404),
+        }
+    )
+    driver = await detect_driver(HOST, BASE_URL, lambda: _provider(session))
+    assert isinstance(driver, StockDriver)
+    assert driver.model == MODEL_ULTRA

--- a/tests/drivers/test_sdpro_driver.py
+++ b/tests/drivers/test_sdpro_driver.py
@@ -98,6 +98,57 @@ async def test_upload_and_display_alternates_and_retires(driver, session):
 
 
 @pytest.mark.asyncio
+async def test_upload_and_display_isolates_themes_and_photos():
+    """Dashboard mode disables competing themes and other enabled photos."""
+
+    def _make_response(json_value):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = AsyncMock(return_value=json_value)
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock()
+        return resp
+
+    def _route(url, *args, **kwargs):
+        if "/theme/list" in url:
+            return _make_response(
+                {
+                    "themes": [
+                        {"id": 0, "name": "Classic", "enabled": True},
+                        {"id": 1, "name": "Weather", "enabled": True},
+                        {"id": 2, "name": "Photo", "enabled": True},
+                    ]
+                }
+            )
+        if "/photo/list" in url:
+            return _make_response(
+                {
+                    "files": [
+                        {"name": "vacation.jpg", "enabled": True},
+                        {"name": "dashboard_a.jpg", "enabled": True},
+                    ]
+                }
+            )
+        return _make_response({})
+
+    session = MagicMock()
+    session.get = MagicMock(side_effect=_route)
+    session.post = MagicMock(return_value=_make_response({}))
+    driver = SdProDriver(HOST, BASE_URL, AsyncMock(return_value=session))
+
+    await driver.upload_and_display(b"frame", "dashboard.jpg")
+
+    urls = [call.args[0] for call in session.get.call_args_list]
+    # Competing built-in themes are disabled; Photo is left enabled.
+    assert f"{BASE_URL}/theme/toggle?id=0&state=0" in urls
+    assert f"{BASE_URL}/theme/toggle?id=1&state=0" in urls
+    assert not any("theme/toggle?id=2&state=0" in u for u in urls)
+    # The competing user photo is disabled; the dashboard frame is not.
+    assert f"{BASE_URL}/photo/toggle?name=vacation.jpg&state=0" in urls
+    assert not any("photo/toggle?name=dashboard_a.jpg&state=0" in u for u in urls)
+
+
+@pytest.mark.asyncio
 async def test_reboot_swallows_connection_error(driver, session):
     """The device drops the connection on /restart; that is treated as success."""
     session.get.return_value.__aenter__.side_effect = aiohttp.ClientError("dropped")
@@ -109,5 +160,5 @@ async def test_capabilities(driver):
     caps = driver.capabilities
     assert caps.supports_navigation is False
     assert caps.supports_on_demand_image is False
-    assert caps.supports_builtin_themes is False
-    assert caps.builtin_theme_threshold is None
+    assert caps.custom_theme is None
+    assert caps.builtin_modes == {}

--- a/tests/drivers/test_sdpro_driver.py
+++ b/tests/drivers/test_sdpro_driver.py
@@ -1,0 +1,113 @@
+"""Tests for the SD_PRO community firmware driver."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from custom_components.geekmagic.drivers.sdpro import (
+    DASHBOARD_INTERVAL_SECONDS,
+    PHOTO_THEME,
+    SdProDriver,
+)
+
+BASE_URL = "http://192.168.1.50"
+HOST = "192.168.1.50"
+
+
+@pytest.fixture
+def response():
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = AsyncMock(return_value={})
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock()
+    return resp
+
+
+@pytest.fixture
+def session(response):
+    sess = MagicMock()
+    sess.get = MagicMock(return_value=response)
+    sess.post = MagicMock(return_value=response)
+    return sess
+
+
+@pytest.fixture
+def driver(session):
+    return SdProDriver(HOST, BASE_URL, AsyncMock(return_value=session))
+
+
+def _urls(session):
+    return [call.args[0] for call in session.get.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_get_brightness_from_config(driver, session, response):
+    response.json = AsyncMock(return_value={"theme": 2, "brightness": 60})
+    assert await driver.get_brightness() == 60
+    session.get.assert_called_once_with(f"{BASE_URL}/config")
+
+
+@pytest.mark.asyncio
+async def test_set_brightness_clamps_and_uses_lcd_key(driver, session):
+    await driver.set_brightness(150)
+    session.get.assert_called_with(f"{BASE_URL}/api/set?key=lcd_brightness&value=99")
+    await driver.set_brightness(0)
+    session.get.assert_called_with(f"{BASE_URL}/api/set?key=lcd_brightness&value=2")
+
+
+@pytest.mark.asyncio
+async def test_set_theme_custom_selects_photo(driver, session):
+    await driver.set_theme_custom()
+    session.get.assert_called_with(f"{BASE_URL}/api/set?key=theme&value={PHOTO_THEME}")
+
+
+@pytest.mark.asyncio
+async def test_upload_and_display_slideshow_sequence(driver, session):
+    """First frame: upload, set Photo theme, enable it, set interval; no delete."""
+    await driver.upload_and_display(b"jpegdata", "dashboard.jpg")
+
+    session.post.assert_called_once()
+    assert "/photo/upload" in session.post.call_args.args[0]
+
+    urls = _urls(session)
+    assert f"{BASE_URL}/api/set?key=theme&value={PHOTO_THEME}" in urls
+    assert f"{BASE_URL}/photo/toggle?name=dashboard_a.jpg&state=1" in urls
+    assert f"{BASE_URL}/photo/interval?val={DASHBOARD_INTERVAL_SECONDS}" in urls
+    # No previous frame to retire yet.
+    assert not any("delete" in url for url in urls)
+
+
+@pytest.mark.asyncio
+async def test_upload_and_display_alternates_and_retires(driver, session):
+    """Second frame uses the alternate name and retires the first."""
+    await driver.upload_and_display(b"frame1", "dashboard.jpg")
+    session.get.reset_mock()
+    await driver.upload_and_display(b"frame2", "dashboard.jpg")
+
+    urls = _urls(session)
+    assert f"{BASE_URL}/photo/toggle?name=dashboard_b.jpg&state=1" in urls
+    # The first frame is disabled and deleted.
+    assert f"{BASE_URL}/photo/toggle?name=dashboard_a.jpg&state=0" in urls
+    assert f"{BASE_URL}/photo/delete?name=dashboard_a.jpg" in urls
+
+
+@pytest.mark.asyncio
+async def test_reboot_swallows_connection_error(driver, session):
+    """The device drops the connection on /restart; that is treated as success."""
+    session.get.return_value.__aenter__.side_effect = aiohttp.ClientError("dropped")
+    await driver.reboot()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_capabilities(driver):
+    caps = driver.capabilities
+    assert caps.supports_navigation is False
+    assert caps.supports_on_demand_image is False
+    assert caps.supports_builtin_themes is False
+    assert caps.builtin_theme_threshold is None

--- a/tests/drivers/test_stock_driver.py
+++ b/tests/drivers/test_stock_driver.py
@@ -52,6 +52,25 @@ async def test_ultra_uses_photo_album_theme(session):
     session.get.assert_called_with(f"{BASE_URL}/set?theme=3")
 
 
+def test_builtin_modes_are_per_firmware():
+    """Pro and Ultra expose different built-in theme maps, excluding custom."""
+    pro_modes = PRO.capabilities.builtin_modes
+    ultra_modes = ULTRA.capabilities.builtin_modes
+
+    # Custom theme is never offered as a built-in mode.
+    assert PRO.capabilities.custom_theme == 4
+    assert 4 not in pro_modes.values()
+    assert ULTRA.capabilities.custom_theme == 3
+    assert 3 not in ultra_modes.values()
+
+    # Pro's theme numbers differ from Ultra's (per the device reports).
+    assert pro_modes["Weather"] == 3
+    assert pro_modes["Clock"] == 6
+    assert ultra_modes["Weather Clock Today"] == 1
+    # The two maps are genuinely distinct, not a shared global table.
+    assert pro_modes != ultra_modes
+
+
 @pytest.mark.asyncio
 async def test_pro_reads_brightness_from_sys_path(session, response):
     """Pro reads brightness from /.sys/brt.json."""

--- a/tests/drivers/test_stock_driver.py
+++ b/tests/drivers/test_stock_driver.py
@@ -1,0 +1,92 @@
+"""Tests for the stock firmware driver (Pro and Ultra variants)."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from custom_components.geekmagic.drivers.stock import PRO, ULTRA, StockDriver
+
+BASE_URL = "http://192.168.1.50"
+HOST = "192.168.1.50"
+
+
+@pytest.fixture
+def response():
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = AsyncMock(return_value={})
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock()
+    return resp
+
+
+@pytest.fixture
+def session(response):
+    sess = MagicMock()
+    sess.get = MagicMock(return_value=response)
+    sess.post = MagicMock(return_value=response)
+    return sess
+
+
+def _driver(variant, session):
+    return StockDriver(variant, HOST, BASE_URL, AsyncMock(return_value=session))
+
+
+@pytest.mark.asyncio
+async def test_pro_uses_picture_theme(session):
+    """Pro custom mode must select theme 4 (Picture), not 3 (Weather)."""
+    driver = _driver(PRO, session)
+    await driver.set_theme_custom()
+    session.get.assert_called_with(f"{BASE_URL}/set?theme=4")
+
+
+@pytest.mark.asyncio
+async def test_ultra_uses_photo_album_theme(session):
+    """Ultra custom mode selects theme 3 (Photo Album)."""
+    driver = _driver(ULTRA, session)
+    await driver.set_theme_custom()
+    session.get.assert_called_with(f"{BASE_URL}/set?theme=3")
+
+
+@pytest.mark.asyncio
+async def test_pro_reads_brightness_from_sys_path(session, response):
+    """Pro reads brightness from /.sys/brt.json."""
+    response.json = AsyncMock(return_value={"brt": "85"})
+    driver = _driver(PRO, session)
+    brightness = await driver.get_brightness()
+    assert brightness == 85
+    session.get.assert_called_once_with(f"{BASE_URL}/.sys/brt.json")
+
+
+@pytest.mark.asyncio
+async def test_ultra_reads_brightness_from_root_path(session, response):
+    """Ultra reads brightness from /brt.json."""
+    response.json = AsyncMock(return_value={"brt": "71"})
+    driver = _driver(ULTRA, session)
+    brightness = await driver.get_brightness()
+    assert brightness == 71
+    session.get.assert_called_once_with(f"{BASE_URL}/brt.json")
+
+
+@pytest.mark.asyncio
+async def test_pro_get_state_makes_no_request(session):
+    """Pro has no /app.json, so get_state returns a null state without a call."""
+    driver = _driver(PRO, session)
+    state = await driver.get_state()
+    assert state.theme is None
+    assert state.brightness is None
+    session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ultra_get_state_reads_app_json(session, response):
+    """Ultra reads theme from /app.json."""
+    response.json = AsyncMock(return_value={"theme": 3})
+    driver = _driver(ULTRA, session)
+    state = await driver.get_state()
+    assert state.theme == 3
+    session.get.assert_called_once_with(f"{BASE_URL}/app.json")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -75,8 +75,9 @@ class TestConfigFlowUser:
 
     async def test_user_flow_connection_timeout(self, hass: HomeAssistant, aioclient_mock):
         """Test user flow shows timeout error when device times out."""
+        # An offline host times out on every request, including detection probes.
         aioclient_mock.get(
-            f"{BASE_URL}/space.json",
+            re.compile(rf"^{re.escape(BASE_URL)}/"),
             exc=TimeoutError("Connection timed out"),
         )
 
@@ -91,8 +92,9 @@ class TestConfigFlowUser:
 
     async def test_user_flow_connection_refused(self, hass: HomeAssistant, aioclient_mock):
         """Test user flow shows connection refused error."""
+        # An offline host refuses every request, including detection probes.
         aioclient_mock.get(
-            f"{BASE_URL}/space.json",
+            re.compile(rf"^{re.escape(BASE_URL)}/"),
             exc=OSError("Connection refused"),
         )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -33,10 +33,9 @@ BASE_URL = f"http://{DEVICE_HOST}"
 def _mock_device_success(aioclient_mock, host: str = DEVICE_HOST):
     """Mock HTTP endpoints for a successful device connection."""
     base = f"http://{host}"
-    # test_connection calls get_space
+    # Firmware detection (primary path) and connection test (get_space)
+    aioclient_mock.get(f"{base}/v.json", json={"m": "SmallTV-Ultra", "v": "Ultra-V9.0.40"})
     aioclient_mock.get(f"{base}/space.json", json={"total": 1048576, "free": 524288})
-    # Model detection
-    aioclient_mock.get(f"{base}/.sys/app.json", status=404)
     aioclient_mock.get(f"{base}/app.json", json={"theme": 0, "brt": 50, "img": None})
     # Brightness, upload, set commands (for full setup after entry creation)
     aioclient_mock.get(f"{base}/brt.json", json={"brt": "50"})

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -37,6 +37,19 @@ def mock_session(mock_response):
     return session
 
 
+def _ultra_device(session) -> GeekMagicDevice:
+    """Build a device with an Ultra stock driver pre-bound.
+
+    Skips firmware detection so call-count assertions on a single delegated
+    request stay clean.
+    """
+    from custom_components.geekmagic.drivers.stock import ULTRA, StockDriver
+
+    device = GeekMagicDevice("192.168.1.100", session=session)
+    device._driver = StockDriver(ULTRA, device.host, device.base_url, device._get_session)
+    return device
+
+
 class TestDeviceState:
     """Tests for DeviceState dataclass."""
 
@@ -111,7 +124,7 @@ class TestGeekMagicDevice:
             return_value={"theme": 3, "brt": 75, "img": "/image/dashboard.jpg"}
         )
 
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
+        device = _ultra_device(mock_session)
         state = await device.get_state()
 
         assert state.theme == 3
@@ -136,7 +149,7 @@ class TestGeekMagicDevice:
         # API returns brightness as string
         mock_response.json = AsyncMock(return_value={"brt": "71"})
 
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
+        device = _ultra_device(mock_session)
         brightness = await device.get_brightness()
 
         assert brightness == 71
@@ -172,7 +185,7 @@ class TestGeekMagicDevice:
     @pytest.mark.asyncio
     async def test_set_image(self, mock_session, mock_response):
         """Test setting displayed image."""
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
+        device = _ultra_device(mock_session)
         await device.set_image("dashboard.jpg")
 
         # Should set theme first, then image
@@ -277,7 +290,7 @@ class TestGeekMagicDevice:
         # Connection test uses /space.json endpoint (wider firmware support)
         mock_response.json = AsyncMock(return_value={"total": 1048576, "free": 524288})
 
-        device = GeekMagicDevice("192.168.1.100", session=mock_session)
+        device = _ultra_device(mock_session)
         result = await device.test_connection()
 
         assert result.success is True
@@ -390,12 +403,16 @@ class TestDeviceModelDetection:
         session.close = AsyncMock()
         return session
 
-    def test_init_with_model(self):
-        """Test device initialization with explicit model."""
-        from custom_components.geekmagic.const import MODEL_PRO
+    def test_init_with_model_kwarg_is_ignored(self):
+        """The legacy ``model=`` kwarg is accepted but no longer sets the model.
+
+        The model is determined by firmware detection; before detection it is
+        always unknown.
+        """
+        from custom_components.geekmagic.const import MODEL_PRO, MODEL_UNKNOWN
 
         device = GeekMagicDevice("192.168.1.100", model=MODEL_PRO)
-        assert device.model == MODEL_PRO
+        assert device.model == MODEL_UNKNOWN
 
     def test_init_default_model(self):
         """Test device initialization has unknown model by default."""
@@ -406,12 +423,14 @@ class TestDeviceModelDetection:
 
     @pytest.mark.asyncio
     async def test_detect_model_pro(self, mock_session):
-        """Test detecting Pro model via /.sys/app.json."""
+        """Test detecting Pro model via /v.json identification."""
         from custom_components.geekmagic.const import MODEL_PRO
 
-        # Create mock response for Pro path
         mock_response = MagicMock()
         mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={"m": "GeekMagic SmallTV-PRO", "v": "V3.3.76EN"}
+        )
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock()
         mock_session.get = MagicMock(return_value=mock_response)
@@ -421,34 +440,29 @@ class TestDeviceModelDetection:
 
         assert result == MODEL_PRO
         assert device.model == MODEL_PRO
-        # Should have tried Pro path first
-        mock_session.get.assert_called()
-        call_url = mock_session.get.call_args[0][0]
-        assert "/.sys/app.json" in call_url
+        assert device.firmware_version == "V3.3.76EN"
+        # /v.json is probed first
+        first_url = mock_session.get.call_args_list[0][0][0]
+        assert "/v.json" in first_url
 
     @pytest.mark.asyncio
     async def test_detect_model_ultra(self, mock_session):
-        """Test detecting Ultra model when Pro path fails."""
+        """Test detecting Ultra model via /v.json identification."""
         from custom_components.geekmagic.const import MODEL_ULTRA
 
-        # First call (Pro path) fails, second call (Ultra path) succeeds
-        mock_response_fail = MagicMock()
-        mock_response_fail.status = 404
-        mock_response_fail.__aenter__ = AsyncMock(return_value=mock_response_fail)
-        mock_response_fail.__aexit__ = AsyncMock()
-
-        mock_response_ok = MagicMock()
-        mock_response_ok.status = 200
-        mock_response_ok.__aenter__ = AsyncMock(return_value=mock_response_ok)
-        mock_response_ok.__aexit__ = AsyncMock()
-
-        mock_session.get = MagicMock(side_effect=[mock_response_fail, mock_response_ok])
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"m": "SmallTV-Ultra", "v": "Ultra-V9.0.40"})
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_response)
 
         device = GeekMagicDevice("192.168.1.100", session=mock_session)
         result = await device.detect_model()
 
         assert result == MODEL_ULTRA
         assert device.model == MODEL_ULTRA
+        assert device.firmware_version == "Ultra-V9.0.40"
 
     @pytest.mark.asyncio
     async def test_navigate_next(self, mock_session):

--- a/tests/test_ha_integration.py
+++ b/tests/test_ha_integration.py
@@ -121,8 +121,18 @@ def _setup_sdpro_mocks(
             "interval": 5,
         },
     )
+    aioclient_mock.get(
+        f"{base}/theme/list",
+        json={
+            "interval": 30,
+            "themes": [
+                {"id": 0, "name": "Classic", "enabled": True},
+                {"id": 2, "name": "Photo", "enabled": True},
+            ],
+        },
+    )
     aioclient_mock.post(f"{base}/photo/upload", status=200)
-    for path in ("api/set", "photo/toggle", "photo/delete", "photo/interval", "theme"):
+    for path in ("api/set", "photo/toggle", "photo/delete", "photo/interval", "theme/toggle"):
         aioclient_mock.get(re.compile(rf"^{re.escape(base)}/{path}"), status=200)
     aioclient_mock.get(f"{base}/restart", status=200)
 
@@ -183,8 +193,9 @@ class TestSetupLifecycle:
     ):
         """Test that connection failure results in ConfigEntryNotReady."""
         base = f"http://{DEVICE_HOST}"
+        # An offline host times out on every request, including detection probes.
         aioclient_mock.get(
-            f"{base}/space.json",
+            re.compile(rf"^{re.escape(base)}/"),
             exc=TimeoutError("Connection timed out"),
         )
 

--- a/tests/test_ha_integration.py
+++ b/tests/test_ha_integration.py
@@ -22,6 +22,13 @@ DEVICE_HOST = "192.168.1.100"
 BASE_URL = f"http://{DEVICE_HOST}"
 
 
+# /v.json identification strings per stock firmware variant.
+_V_JSON = {
+    "ultra": {"m": "SmallTV-Ultra", "v": "Ultra-V9.0.40"},
+    "pro": {"m": "GeekMagic SmallTV-PRO", "v": "V3.3.76EN"},
+}
+
+
 def setup_device_http_mocks(
     aioclient_mock,
     *,
@@ -42,9 +49,23 @@ def setup_device_http_mocks(
         brightness: Device brightness (0-100).
         total_storage: Total storage bytes.
         free_storage: Free storage bytes.
-        model: "ultra" or "pro" — controls /.sys/app.json response.
+        model: Firmware to emulate — "ultra", "pro", or "sdpro".
     """
     base = f"http://{host}"
+
+    if model == "sdpro":
+        _setup_sdpro_mocks(
+            aioclient_mock,
+            base=base,
+            theme=theme,
+            brightness=brightness,
+            total_storage=total_storage,
+            free_storage=free_storage,
+        )
+        return
+
+    # Firmware identification (primary detection path).
+    aioclient_mock.get(f"{base}/v.json", json=_V_JSON[model])
 
     # Connection test (test_connection → get_space)
     aioclient_mock.get(
@@ -52,29 +73,58 @@ def setup_device_http_mocks(
         json={"total": total_storage, "free": free_storage},
     )
 
-    # Model detection
-    if model == "pro":
-        aioclient_mock.get(
-            f"{base}/.sys/app.json",
-            json={"theme": theme, "brt": brightness, "img": None},
-        )
-    else:
-        aioclient_mock.get(f"{base}/.sys/app.json", status=404)
-
-    # Device state
+    # Device state (Ultra only; Pro has no /app.json).
     aioclient_mock.get(
         f"{base}/app.json",
         json={"theme": theme, "brt": brightness, "img": "/image/dashboard.jpg"},
     )
 
-    # Brightness poll
-    aioclient_mock.get(f"{base}/brt.json", json={"brt": str(brightness)})
+    # Brightness poll — Pro reads /.sys/brt.json, Ultra reads /brt.json.
+    if model == "pro":
+        aioclient_mock.get(f"{base}/.sys/brt.json", json={"brt": str(brightness)})
+    else:
+        aioclient_mock.get(f"{base}/brt.json", json={"brt": str(brightness)})
 
     # Upload image (POST)
     aioclient_mock.post(f"{base}/doUpload?dir=/image/", status=200)
 
     # Set commands (image, brightness, theme) — use regex to match any /set?...
     aioclient_mock.get(re.compile(rf"^{re.escape(base)}/set\?"), status=200)
+
+
+def _setup_sdpro_mocks(
+    aioclient_mock,
+    *,
+    base: str,
+    theme: int,
+    brightness: int,
+    total_storage: int,
+    free_storage: int,
+) -> None:
+    """Register HTTP mocks for the SD_PRO community firmware."""
+    # No /v.json on this firmware; detection falls through to /config.
+    aioclient_mock.get(f"{base}/v.json", status=404)
+    aioclient_mock.get(
+        f"{base}/config",
+        json={
+            "theme": theme,
+            "brightness": brightness,
+            "freespace": free_storage,
+        },
+    )
+    aioclient_mock.get(
+        f"{base}/photo/list",
+        json={
+            "files": [],
+            "total": total_storage,
+            "used": total_storage - free_storage,
+            "interval": 5,
+        },
+    )
+    aioclient_mock.post(f"{base}/photo/upload", status=200)
+    for path in ("api/set", "photo/toggle", "photo/delete", "photo/interval", "theme"):
+        aioclient_mock.get(re.compile(rf"^{re.escape(base)}/{path}"), status=200)
+    aioclient_mock.get(f"{base}/restart", status=200)
 
 
 def create_entry(
@@ -147,22 +197,36 @@ class TestSetupLifecycle:
         assert entry.state is ConfigEntryState.SETUP_RETRY
 
     async def test_setup_detects_ultra_model(self, hass: HomeAssistant, aioclient_mock):
-        """Test that setup detects Ultra model when /.sys/app.json returns 404."""
+        """Test that setup detects Ultra model via /v.json."""
         entry = await setup_integration(hass, aioclient_mock, model="ultra")
 
         from custom_components.geekmagic.coordinator import GeekMagicCoordinator
 
         coordinator: GeekMagicCoordinator = hass.data[DOMAIN][entry.entry_id]
         assert coordinator.device.model == "ultra"
+        assert coordinator.device.sw_version == "Ultra-V9.0.40"
 
     async def test_setup_detects_pro_model(self, hass: HomeAssistant, aioclient_mock):
-        """Test that setup detects Pro model when /.sys/app.json returns 200."""
+        """Test that setup detects Pro model via /v.json (no /app.json present)."""
         entry = await setup_integration(hass, aioclient_mock, model="pro")
 
         from custom_components.geekmagic.coordinator import GeekMagicCoordinator
 
         coordinator: GeekMagicCoordinator = hass.data[DOMAIN][entry.entry_id]
         assert coordinator.device.model == "pro"
+        # Pro uses the Picture theme (4) for custom rendering, not Weather (3).
+        assert coordinator.device.capabilities.supports_navigation is True
+
+    async def test_setup_detects_sdpro_model(self, hass: HomeAssistant, aioclient_mock):
+        """Test that setup detects the SD_PRO community firmware via /config."""
+        entry = await setup_integration(hass, aioclient_mock, model="sdpro", theme=2)
+
+        from custom_components.geekmagic.coordinator import GeekMagicCoordinator
+
+        coordinator: GeekMagicCoordinator = hass.data[DOMAIN][entry.entry_id]
+        assert coordinator.device.model == "sdpro"
+        assert coordinator.device.capabilities.supports_on_demand_image is False
+        assert entry.state is ConfigEntryState.LOADED
 
     async def test_unload_entry(self, hass: HomeAssistant, aioclient_mock):
         """Test that unloading an entry cleans up."""


### PR DESCRIPTION
## Summary

Refactor the device HTTP API client to support multiple firmware variants through a driver abstraction layer. This enables support for the SD_PRO community firmware while keeping the coordinator and entities firmware-agnostic.

## Key Changes

- **New driver abstraction** (`drivers/base.py`): Introduce `FirmwareDriver` base class with a common interface for all firmware variants. Each driver implements `test_connection()`, `get_state()`, `get_space()`, brightness/theme/image operations, and file management.

- **Stock firmware driver** (`drivers/stock.py`): Extract existing Pro/Ultra logic into a unified `StockDriver` with per-variant configuration (`StockVariant`). Handles differences in:
  - Custom-image theme numbers (Ultra 3, Pro 4)
  - Brightness read paths (Ultra `/brt.json`, Pro `/.sys/brt.json`)
  - State endpoint availability (Ultra has `/app.json`, Pro does not)
  - Navigation support (Pro only)

- **SD_PRO community firmware driver** (`drivers/sdpro.py`): New driver for the JUZIPi-tech SD_PRO firmware with a completely different API surface:
  - Unified `/config` endpoint for reads, `/api/set` for writes
  - Device-managed photo slideshow (no direct "display this image now" API)
  - Workaround: upload frames as photos, toggle them in the slideshow, delete old frames
  - Alternating frame filenames to avoid blank frames during transitions

- **Firmware detection** (`drivers/__init__.py`): Implement `detect_driver()` that probes in order:
  1. `/v.json` for stock firmware identification (distinguishes Pro/Ultra)
  2. `/config` for SD_PRO community firmware
  3. Legacy fallback to `/.sys/app.json` / `/app.json` for old stock firmware
  4. Default to Ultra with a warning

- **Device facade refactor** (`device.py`): `GeekMagicDevice` now owns the session and host parsing, then delegates all operations to a `FirmwareDriver` chosen by `detect_driver()`. Public API surface unchanged so coordinator/entities need not know which firmware is in use.
  - Add `model`, `model_name`, `capabilities`, `firmware_version` properties that reflect the detected driver
  - Add `detect_model()` to trigger firmware detection on first use
  - All operation methods (`get_state()`, `set_brightness()`, etc.) now delegate to the driver

- **Capability flags** (`DriverCapabilities`): New dataclass lets drivers declare what they support:
  - `supports_navigation`: Device has `/set?page=` and `/set?enter=` (Pro only)
  - `supports_on_demand_image`: Can display a named image immediately (false for SD_PRO slideshow)
  - `supports_builtin_themes`: Has stock built-in theme set (false for SD_PRO)
  - `builtin_theme_threshold`: Theme number below which themes are device-managed (used for display-mode sync)

- **Coordinator/entity updates**: Replace hardcoded `model == MODEL_PRO` checks with capability queries:
  - `device.capabilities.supports_navigation` instead of `device.model == MODEL_PRO`
  - `device.capabilities.supports_builtin_themes` to hide stock themes in SD_PRO

- **Test coverage**: Add comprehensive driver unit tests:
  - `test_detection.py`: Firmware detection logic (Pro/Ultra/SD_PRO identification)
  - `test_stock_driver.py`: Stock driver variant behavior (theme numbers, brightness paths)
  - `test_sdpro_driver.py`: SD_PRO slideshow workaround and frame alternation

- **Integration test updates**: Extend `test_ha_integration.py` to mock SD_PRO endpoints and verify the full setup flow works with all three firmware variants.

## Implementation Details

- **Backward compatibility**: `ConnectionResult`, `DeviceState`, `SpaceInfo` are re-exported from `device.py` so existing imports continue to work.
- **Lazy driver detection**: Driver is instantiated on first operation (via

https://claude.ai/code/session_01Rd2DjWG2CBFB2v32YyhcHH