### PR TITLE
Add firmware profiles for Ultra, Pro, and SD_PRO devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ home-assistant_v2.db
 # then whitelist `skills/`.
 .claude/*
 !.claude/skills/
+
+# Local HA pod test snapshots
+.ha-pod-backup/
+scripts/ha-pod-deploy.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A Home Assistant custom integration for GeekMagic displays (SmallTV Pro, Ultra, and similar ESP8266/ESP32-based devices).
 
-> **How it works:** This integration renders dashboard images directly in Home Assistant using Python/Pillow and pushes them to your GeekMagic device over HTTP. No flashing required - works with stock firmware.
+> **How it works:** This integration renders dashboard images directly in Home Assistant using Python/Pillow and pushes them to your GeekMagic device over HTTP. It supports the known stock firmware profiles and the newer SD_PRO-style firmware used by some Ultra units.
 
 ---
 
@@ -416,13 +416,20 @@ data:
 
 ## Device Compatibility
 
-Tested with:
-- GeekMagic SmallTV Ultra (240x240, ESP8266)
-- GeekMagic SmallTV-PRO stock firmware (240x240, ESP8266)
+GeekMagic devices with the same case/name can ship with very different firmware.
+The integration detects the firmware/API profile first, then uses the matching
+upload and display flow.
 
-Should work with any GeekMagic device that supports the `/doUpload` HTTP API.
+| Device / firmware profile | Detection | Render support | Notes |
+| --- | --- | --- | --- |
+| SmallTV Ultra stock firmware | `/app.json` or `/v.json` with Ultra model | Full | Uses `/doUpload?dir=/image/`, `/set?theme=3`, and `/set?img=/image/{filename}`. |
+| SmallTV-PRO stock firmware | `/v.json` with `GeekMagic SmallTV-PRO`, or `/.sys/app.json` | Full, with managed album | Uses `/doUpload?dir=/image/` and `/set?theme=4`. Picture mode is an album slideshow, so the integration can manage the album and keep only `dashboard.jpg`. |
+| Ultra / SD_PRO community-style firmware | `/theme/list` and `/photo/list` | Supported through Photo slideshow | This firmware is very different from stock Ultra firmware. It uses `/config`, `/api/set?key=...`, `/photo/upload`, `/photo/toggle`, and `/theme/list`; it does not support direct `/set?img=` image selection. |
 
-**Important:** This integration works with the **stock firmware** that ships with GeekMagic devices. No custom firmware or flashing required - just connect your device to your network and add the integration.
+Other GeekMagic devices may work if they expose one of those API profiles. If a
+device has the same product name but a different web UI or endpoint set, run the
+repo-local probe command from the development section below and attach the output
+to an issue.
 
 **SmallTV-PRO note:** Pro Picture mode is an album slideshow. During Pro setup,
 Home Assistant asks for confirmation to manage that album. When enabled, the
@@ -476,7 +483,9 @@ test image on screen for 15 seconds, then restore the original settings. Use
 `--hold-seconds N` to change the viewing window. `--takeover-album` can make Pro
 Picture mode deterministic by backing up the existing album, clearing it for the
 test, and restoring it afterward. If a Pro test image uploads but is not visible,
-manually select the Picture app on the device.
+manually select the Picture app on the device, or add `--try-enter-picture` to
+let the CLI press the Pro menu buttons during a live smoke test. Home Assistant
+does not press those buttons automatically.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -485,7 +485,10 @@ Picture mode deterministic by backing up the existing album, clearing it for the
 test, and restoring it afterward. If a Pro test image uploads but is not visible,
 manually select the Picture app on the device, or add `--try-enter-picture` to
 let the CLI press the Pro menu buttons during a live smoke test. Home Assistant
-does not press those buttons automatically.
+does not press those buttons automatically. If your workstation has multiple
+routes to the device subnet, add `--bind-address LOCAL-IP` to the CLI command to
+force the source interface used for both aiohttp and raw firmware fallback
+requests.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -418,10 +418,19 @@ data:
 
 Tested with:
 - GeekMagic SmallTV Ultra (240x240, ESP8266)
+- GeekMagic SmallTV-PRO stock firmware (240x240, ESP8266)
 
 Should work with any GeekMagic device that supports the `/doUpload` HTTP API.
 
 **Important:** This integration works with the **stock firmware** that ships with GeekMagic devices. No custom firmware or flashing required - just connect your device to your network and add the integration.
+
+**SmallTV-PRO note:** Pro Picture mode is an album slideshow. During Pro setup,
+Home Assistant asks for confirmation to manage that album. When enabled, the
+integration removes other pictures from the Pro album and keeps one managed
+`dashboard.jpg` image updated so the display cannot rotate away from the HA
+dashboard. After setup, manually select the Picture app on the device; the
+integration does not press the Pro menu buttons automatically because the
+firmware does not expose enough menu state to do that reliably.
 
 ### Alternative Firmware
 
@@ -448,6 +457,26 @@ uv run ruff check .                  # Lint
 uv run pre-commit run --all-files    # Run all checks
 uv run python scripts/generate_samples.py  # Generate samples
 ```
+
+### Live Device Testing
+
+You can smoke-test the device client from a repo checkout before installing into Home Assistant:
+
+```bash
+uv run python scripts/device_cli.py probe <DEVICE-IP>
+uv run python scripts/device_cli.py render-test <DEVICE-IP> --dashboard clock
+uv run python scripts/device_cli.py upload-file <DEVICE-IP> path/to/image.jpg
+uv run python scripts/device_cli.py brightness <DEVICE-IP> get
+uv run python scripts/device_cli.py brightness <DEVICE-IP> set 80
+```
+
+`probe` only reads from the device. `render-test`, `upload-file`, and `brightness set` change the display.
+The render/upload smoke tests back up readable device settings first, hold the
+test image on screen for 15 seconds, then restore the original settings. Use
+`--hold-seconds N` to change the viewing window. `--takeover-album` can make Pro
+Picture mode deterministic by backing up the existing album, clearing it for the
+test, and restoring it afterward. If a Pro test image uploads but is not visible,
+manually select the Picture app on the device.
 
 ## License
 

--- a/custom_components/geekmagic/__init__.py
+++ b/custom_components/geekmagic/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
+from .const import CONF_FIRMWARE_VERSION, CONF_MODEL_NAME, CONF_PROFILE_ID, DOMAIN
 from .coordinator import GeekMagicCoordinator
 from .device import GeekMagicDevice
 from .panel import async_register_panel
@@ -122,8 +122,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _LOGGER.debug("Successfully connected to GeekMagic device at %s", host)
 
-    # Detect device model (Pro vs Ultra)
+    # Detect firmware profile and persist it for offline options/UI flows.
     await device.detect_model()
+    detected_data = {
+        CONF_PROFILE_ID: device.profile_id,
+        CONF_MODEL_NAME: device.model_name,
+        CONF_FIRMWARE_VERSION: device.firmware_version,
+    }
+    if any(entry.data.get(key) != value for key, value in detected_data.items()):
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, **detected_data},
+        )
 
     # Create coordinator
     coordinator = GeekMagicCoordinator(

--- a/custom_components/geekmagic/__init__.py
+++ b/custom_components/geekmagic/__init__.py
@@ -21,6 +21,8 @@ from .websocket import async_register_websocket_commands
 
 _LOGGER = logging.getLogger(__name__)
 
+LEGACY_PREVIEW_MODEL = "SmallTV Pro"
+
 # Schema for integrations configured via UI only (no YAML support)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -157,8 +159,52 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    _async_cleanup_legacy_preview_device(hass, entry, device)
+
     _LOGGER.info("GeekMagic integration successfully set up for %s", host)
     return True
+
+
+def _async_cleanup_legacy_preview_device(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device: GeekMagicDevice,
+) -> None:
+    """Remove duplicate devices created by the old preview image identifier.
+
+    Older versions registered the preview image entity as a separate HA device
+    using ``(DOMAIN, host)`` and a hardcoded ``SmallTV Pro`` model. Current
+    entities all identify the physical display by config entry id, so those
+    host-identifier devices are stale duplicates after users upgrade.
+    """
+    dev_reg = dr.async_get(hass)
+    current_device = dev_reg.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+
+    legacy_identifier_values = {
+        str(entry.data.get(CONF_HOST, "")),
+        device.host,
+        device.base_url,
+    }
+    for identifier_value in legacy_identifier_values:
+        if not identifier_value or identifier_value == entry.entry_id:
+            continue
+
+        legacy_device = dev_reg.async_get_device(identifiers={(DOMAIN, identifier_value)})
+        if legacy_device is None:
+            continue
+        if current_device is not None and legacy_device.id == current_device.id:
+            continue
+        if entry.entry_id not in legacy_device.config_entries:
+            continue
+        if legacy_device.manufacturer != "GeekMagic" or legacy_device.model != LEGACY_PREVIEW_MODEL:
+            continue
+
+        _LOGGER.info(
+            "Removing legacy duplicate GeekMagic preview device %s for %s",
+            legacy_device.id,
+            entry.title,
+        )
+        dev_reg.async_remove_device(legacy_device.id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/geekmagic/config_flow.py
+++ b/custom_components/geekmagic/config_flow.py
@@ -14,9 +14,12 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_DISPLAY_ROTATION,
+    CONF_FIRMWARE_VERSION,
     CONF_JPEG_QUALITY,
     CONF_LAYOUT,
     CONF_MANAGE_PRO_ALBUM,
+    CONF_MODEL_NAME,
+    CONF_PROFILE_ID,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
     CONF_SCREEN_THEME,
@@ -75,14 +78,15 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if result.success:
                 _LOGGER.info("Config flow: successfully connected to %s", host)
                 await device.detect_model()
+                entry_data = self._entry_data_with_profile(user_input, device)
 
                 # Pro Picture mode is a slideshow. For deterministic HA rendering,
                 # the integration must own the image album and keep only its
                 # dashboard file on the device. The user still needs to select
                 # the Picture app manually because the Pro menu state is not
                 # exposed reliably enough for automatic button navigation.
-                if device.model == MODEL_PRO:
-                    self._pending_entry_data = user_input
+                if device.capabilities.requires_managed_album:
+                    self._pending_entry_data = entry_data
                     self._pending_entry_title = user_input.get(
                         CONF_NAME, f"GeekMagic ({device.host})"
                     )
@@ -92,7 +96,7 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Create entry with default options
                 return self.async_create_entry(
                     title=user_input.get(CONF_NAME, f"GeekMagic ({device.host})"),
-                    data=user_input,
+                    data=entry_data,
                     options=self._get_default_options(),
                 )
             _LOGGER.warning("Config flow: failed to connect to %s: %s", host, result.message)
@@ -152,6 +156,18 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }
 
     @staticmethod
+    def _entry_data_with_profile(
+        user_input: dict[str, Any],
+        device: GeekMagicDevice,
+    ) -> dict[str, Any]:
+        """Persist detected profile metadata for offline options/UI flows."""
+        data = dict(user_input)
+        data[CONF_PROFILE_ID] = device.profile_id
+        data[CONF_MODEL_NAME] = device.model_name
+        data[CONF_FIRMWARE_VERSION] = device.firmware_version
+        return data
+
+    @staticmethod
     @callback
     def async_get_options_flow(
         config_entry: config_entries.ConfigEntry,
@@ -174,9 +190,9 @@ class GeekMagicOptionsFlow(config_entries.OptionsFlow):
             action = user_input.get("action")
             if action == "reset_defaults":
                 return await self.async_step_reset_defaults()
-            if action == "enable_pro_managed_album":
+            if action == "enable_pro_managed_album" and self._supports_managed_album_option():
                 return await self.async_step_pro_managed_album()
-            if action == "disable_pro_managed_album":
+            if action == "disable_pro_managed_album" and self._supports_managed_album_option():
                 options = dict(self.config_entry.options)
                 options[CONF_MANAGE_PRO_ALBUM] = False
                 return self.async_create_entry(title="", data=options)
@@ -184,10 +200,11 @@ class GeekMagicOptionsFlow(config_entries.OptionsFlow):
         actions = {
             "reset_defaults": "Reset to Default Configuration",
         }
-        if self.config_entry.options.get(CONF_MANAGE_PRO_ALBUM):
-            actions["disable_pro_managed_album"] = "Stop Managing Pro Picture Album"
-        else:
-            actions["enable_pro_managed_album"] = "Manage Pro Picture Album"
+        if self._supports_managed_album_option():
+            if self.config_entry.options.get(CONF_MANAGE_PRO_ALBUM):
+                actions["disable_pro_managed_album"] = "Stop Managing Pro Picture Album"
+            else:
+                actions["enable_pro_managed_album"] = "Manage Pro Picture Album"
 
         return self.async_show_form(
             step_id="init",
@@ -219,6 +236,13 @@ class GeekMagicOptionsFlow(config_entries.OptionsFlow):
                 }
             ),
             errors=errors,
+        )
+
+    def _supports_managed_album_option(self) -> bool:
+        """Return whether this entry should expose Pro album controls offline."""
+        return bool(
+            self.config_entry.data.get(CONF_PROFILE_ID) == MODEL_PRO
+            or self.config_entry.options.get(CONF_MANAGE_PRO_ALBUM)
         )
 
     async def async_step_reset_defaults(

--- a/custom_components/geekmagic/config_flow.py
+++ b/custom_components/geekmagic/config_flow.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_DISPLAY_ROTATION,
     CONF_JPEG_QUALITY,
     CONF_LAYOUT,
+    CONF_MANAGE_PRO_ALBUM,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
     CONF_SCREEN_THEME,
@@ -27,6 +28,7 @@ from .const import (
     DEFAULT_SCREEN_CYCLE_INTERVAL,
     DOMAIN,
     LAYOUT_GRID_2X2,
+    MODEL_PRO,
     THEME_WATCHOS,
 )
 from .device import GeekMagicDevice
@@ -49,6 +51,9 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """
 
     VERSION = 1
+    _pending_entry_data: dict[str, Any] | None = None
+    _pending_entry_title: str | None = None
+    _pending_entry_options: dict[str, Any] | None = None
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step - device connection."""
@@ -69,6 +74,20 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if result.success:
                 _LOGGER.info("Config flow: successfully connected to %s", host)
+                await device.detect_model()
+
+                # Pro Picture mode is a slideshow. For deterministic HA rendering,
+                # the integration must own the image album and keep only its
+                # dashboard file on the device. The user still needs to select
+                # the Picture app manually because the Pro menu state is not
+                # exposed reliably enough for automatic button navigation.
+                if device.model == MODEL_PRO:
+                    self._pending_entry_data = user_input
+                    self._pending_entry_title = user_input.get(
+                        CONF_NAME, f"GeekMagic ({device.host})"
+                    )
+                    self._pending_entry_options = self._get_default_options()
+                    return await self.async_step_pro_managed_album()
 
                 # Create entry with default options
                 return self.async_create_entry(
@@ -82,6 +101,36 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_pro_managed_album(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Warn Pro users that HA needs exclusive control of the Picture album."""
+        errors: dict[str, str] = {}
+
+        if self._pending_entry_data is None or self._pending_entry_options is None:
+            return await self.async_step_user()
+
+        if user_input is not None:
+            if user_input.get(CONF_MANAGE_PRO_ALBUM):
+                options = dict(self._pending_entry_options)
+                options[CONF_MANAGE_PRO_ALBUM] = True
+                return self.async_create_entry(
+                    title=self._pending_entry_title or "GeekMagic Display",
+                    data=self._pending_entry_data,
+                    options=options,
+                )
+            errors["base"] = "confirm_required"
+
+        return self.async_show_form(
+            step_id="pro_managed_album",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_MANAGE_PRO_ALBUM, default=False): bool,
+                }
+            ),
             errors=errors,
         )
 
@@ -125,22 +174,51 @@ class GeekMagicOptionsFlow(config_entries.OptionsFlow):
             action = user_input.get("action")
             if action == "reset_defaults":
                 return await self.async_step_reset_defaults()
+            if action == "enable_pro_managed_album":
+                return await self.async_step_pro_managed_album()
+            if action == "disable_pro_managed_album":
+                options = dict(self.config_entry.options)
+                options[CONF_MANAGE_PRO_ALBUM] = False
+                return self.async_create_entry(title="", data=options)
+
+        actions = {
+            "reset_defaults": "Reset to Default Configuration",
+        }
+        if self.config_entry.options.get(CONF_MANAGE_PRO_ALBUM):
+            actions["disable_pro_managed_album"] = "Stop Managing Pro Picture Album"
+        else:
+            actions["enable_pro_managed_album"] = "Manage Pro Picture Album"
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Required("action"): vol.In(
-                        {
-                            "reset_defaults": "Reset to Default Configuration",
-                        }
-                    )
-                }
-            ),
+            data_schema=vol.Schema({vol.Required("action"): vol.In(actions)}),
             description_placeholders={
                 "tip": "Tip: Configure your display using the device entities "
                 "(brightness, screens, widgets, etc.) on the device page."
             },
+        )
+
+    async def async_step_pro_managed_album(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Warn before enabling destructive Pro album management from options."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            if user_input.get(CONF_MANAGE_PRO_ALBUM):
+                options = dict(self.config_entry.options)
+                options[CONF_MANAGE_PRO_ALBUM] = True
+                return self.async_create_entry(title="", data=options)
+            errors["base"] = "confirm_required"
+
+        return self.async_show_form(
+            step_id="pro_managed_album",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_MANAGE_PRO_ALBUM, default=False): bool,
+                }
+            ),
+            errors=errors,
         )
 
     async def async_step_reset_defaults(
@@ -162,6 +240,8 @@ class GeekMagicOptionsFlow(config_entries.OptionsFlow):
                         }
                     ],
                 }
+                if self.config_entry.options.get(CONF_MANAGE_PRO_ALBUM):
+                    default_options[CONF_MANAGE_PRO_ALBUM] = True
                 return self.async_create_entry(title="", data=default_options)
             # User cancelled
             return await self.async_step_init()

--- a/custom_components/geekmagic/const.py
+++ b/custom_components/geekmagic/const.py
@@ -33,6 +33,9 @@ CONF_DISPLAY_ROTATION = "display_rotation"
 CONF_LAYOUT = "layout"
 CONF_WIDGETS = "widgets"
 CONF_MANAGE_PRO_ALBUM = "manage_pro_album"
+CONF_PROFILE_ID = "profile_id"
+CONF_MODEL_NAME = "model_name"
+CONF_FIRMWARE_VERSION = "firmware_version"
 
 # Multi-screen config keys
 CONF_SCREENS = "screens"

--- a/custom_components/geekmagic/const.py
+++ b/custom_components/geekmagic/const.py
@@ -5,6 +5,7 @@ DOMAIN = "geekmagic"
 # Device models
 MODEL_ULTRA = "ultra"
 MODEL_PRO = "pro"
+MODEL_SD_PRO = "sd_pro"
 MODEL_UNKNOWN = "unknown"
 
 # Display dimensions
@@ -31,6 +32,7 @@ CONF_JPEG_QUALITY = "jpeg_quality"
 CONF_DISPLAY_ROTATION = "display_rotation"
 CONF_LAYOUT = "layout"
 CONF_WIDGETS = "widgets"
+CONF_MANAGE_PRO_ALBUM = "manage_pro_album"
 
 # Multi-screen config keys
 CONF_SCREENS = "screens"

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -56,7 +56,7 @@ from .const import (
     MAX_BACKOFF_MULTIPLIER,
     THEME_WATCHOS,
 )
-from .device import DeviceState, GeekMagicDevice, SpaceInfo
+from .device import DeviceState, GeekMagicDevice, RenderedDashboardRequest, SpaceInfo
 from .layouts.corner_hero import HeroCornerBL, HeroCornerBR, HeroCornerTL, HeroCornerTR
 from .layouts.fullscreen import FullscreenLayout
 from .layouts.grid import Grid2x2, Grid2x3, Grid3x2, Grid3x3
@@ -1107,11 +1107,13 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             )
 
             manage_album = bool(self.options.get(CONF_MANAGE_PRO_ALBUM, False))
-            await self.device.upload_and_display(
-                jpeg_data,
-                "dashboard.jpg",
-                manage_album=manage_album,
-                enter_picture=False,
+            await self.device.display_rendered_dashboard(
+                RenderedDashboardRequest(
+                    image_data=jpeg_data,
+                    filename="dashboard.jpg",
+                    allow_destructive_album_management=manage_album,
+                    try_menu_navigation=False,
+                )
             )
 
             # Track success status
@@ -1262,8 +1264,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
     @property
     def device_version(self) -> str | None:
         """Get device firmware version."""
-        # Could be fetched from device if supported
-        return None
+        return self.device.firmware_version
 
     @property
     def last_update_success(self) -> bool:

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -361,6 +361,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         # "custom" = integration renders views, "builtin" = device shows built-in mode
         self._display_mode: str = "custom"
         self._builtin_theme: int = 0  # Device theme when in builtin mode
+        self._custom_display_requested: bool = bool(self.options.get(CONF_ASSIGNED_VIEWS))
 
         # Sleep/wake state — when paused, the render/upload cycle is skipped entirely
         self._paused: bool = False
@@ -653,6 +654,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         if 0 <= screen_index < len(self._layouts):
             self._current_screen = screen_index
             self._last_screen_change = time.time()
+            self._custom_display_requested = True
 
             # If in builtin mode, switch to custom mode so the screen change is rendered
             if self._display_mode == "builtin":
@@ -680,7 +682,16 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         Args:
             options: New options dictionary
         """
+        old_assigned_views = list(self.options.get(CONF_ASSIGNED_VIEWS, []))
         self.options = self._migrate_options(options)
+        new_assigned_views = list(self.options.get(CONF_ASSIGNED_VIEWS, []))
+
+        if new_assigned_views and new_assigned_views != old_assigned_views:
+            _LOGGER.debug("Assigned views changed; switching device to custom render mode")
+            self._display_mode = "custom"
+            self._custom_display_requested = True
+            self._current_screen = min(self._current_screen, len(new_assigned_views) - 1)
+            self._last_screen_change = time.time()
 
         # Update refresh interval
         interval = int(self.options.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL))
@@ -1056,6 +1067,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                     if (
                         self.device.is_builtin_theme(device_theme)
                         and self._display_mode == "custom"
+                        and not self._custom_display_requested
                     ):
                         # Device is in built-in mode but we thought we were in custom
                         # This can happen on startup - sync to device state
@@ -1344,10 +1356,12 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         self._display_mode = mode
         if mode == "builtin":
             self._builtin_theme = value
+            self._custom_display_requested = False
         else:
             # Custom mode - value is view index
             self._current_screen = value
             self._last_screen_change = time.time()
+            self._custom_display_requested = True
 
     async def async_set_brightness(self, brightness: int) -> None:
         """Set display brightness.
@@ -1396,6 +1410,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         if self._display_mode == "builtin":
             _LOGGER.debug("Switching from builtin to custom mode")
             self._display_mode = "custom"
+        self._custom_display_requested = True
 
         # Ensure device is in custom image mode
         await self.device.set_theme_custom()
@@ -1409,6 +1424,9 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         Call this when a global view's content has been updated.
         """
         self._setup_screens()
+        if self.options.get(CONF_ASSIGNED_VIEWS):
+            self._display_mode = "custom"
+            self._custom_display_requested = True
         self._update_preview = True
         await self.async_request_refresh()
 

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_DISPLAY_ROTATION,
     CONF_JPEG_QUALITY,
     CONF_LAYOUT,
+    CONF_MANAGE_PRO_ALBUM,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
     CONF_SCREEN_THEME,
@@ -53,7 +54,6 @@ from .const import (
     LAYOUT_THREE_COLUMN,
     LAYOUT_THREE_ROW,
     MAX_BACKOFF_MULTIPLIER,
-    MODEL_PRO,
     THEME_WATCHOS,
 )
 from .device import DeviceState, GeekMagicDevice, SpaceInfo
@@ -360,7 +360,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         # Display mode tracking
         # "custom" = integration renders views, "builtin" = device shows built-in mode
         self._display_mode: str = "custom"
-        self._builtin_theme: int = 0  # Device theme when in builtin mode (0-2)
+        self._builtin_theme: int = 0  # Device theme when in builtin mode
 
         # Sleep/wake state — when paused, the render/upload cycle is skipped entirely
         self._paused: bool = False
@@ -668,25 +668,11 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             next_screen = (self._current_screen + 1) % len(self._layouts)
             await self.async_set_screen(next_screen)
 
-            # For Pro devices, also trigger device navigation to help refresh
-            if self.device.model == MODEL_PRO:
-                try:
-                    await self.device.navigate_next()
-                except Exception as err:
-                    _LOGGER.debug("Pro navigate_next failed (non-fatal): %s", err)
-
     async def async_previous_screen(self) -> None:
         """Switch to the previous screen."""
         if len(self._layouts) > 0:
             prev_screen = (self._current_screen - 1) % len(self._layouts)
             await self.async_set_screen(prev_screen)
-
-            # For Pro devices, also trigger device navigation to help refresh
-            if self.device.model == MODEL_PRO:
-                try:
-                    await self.device.navigate_previous()
-                except Exception as err:
-                    _LOGGER.debug("Pro navigate_previous failed (non-fatal): %s", err)
 
     def update_options(self, options: dict[str, Any]) -> None:
         """Update coordinator options.
@@ -1067,7 +1053,10 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                 # If device is in a built-in theme, respect that
                 if self._device_state and self._device_state.theme is not None:
                     device_theme = self._device_state.theme
-                    if device_theme < 3 and self._display_mode == "custom":
+                    if (
+                        self.device.is_builtin_theme(device_theme)
+                        and self._display_mode == "custom"
+                    ):
                         # Device is in built-in mode but we thought we were in custom
                         # This can happen on startup - sync to device state
                         _LOGGER.debug(
@@ -1117,7 +1106,13 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                 len(png_data),
             )
 
-            await self.device.upload_and_display(jpeg_data, "dashboard.jpg")
+            manage_album = bool(self.options.get(CONF_MANAGE_PRO_ALBUM, False))
+            await self.device.upload_and_display(
+                jpeg_data,
+                "dashboard.jpg",
+                manage_album=manage_album,
+                enter_picture=False,
+            )
 
             # Track success status
             self._last_update_success = True
@@ -1335,7 +1330,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
 
     @property
     def builtin_theme(self) -> int:
-        """Get current builtin theme number (0-2) when in builtin mode."""
+        """Get current builtin theme number when in builtin mode."""
         return self._builtin_theme
 
     def set_display_mode(self, mode: str, value: int = 0) -> None:

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -1,159 +1,52 @@
-"""GeekMagic device HTTP API client."""
+"""GeekMagic device facade."""
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import re
-from dataclasses import dataclass
-from typing import ClassVar, Literal
-from urllib.parse import quote, urlparse
 
 import aiohttp
 
-from .const import MODEL_PRO, MODEL_SD_PRO, MODEL_ULTRA, MODEL_UNKNOWN
+from .const import MODEL_UNKNOWN
+from .models import (
+    AlbumSettings,
+    ConnectionResult,
+    DeviceFile,
+    DeviceFileBackup,
+    DeviceSettingsBackup,
+    DeviceState,
+    FirmwareCapabilities,
+    RenderedDashboardRequest,
+    SdProPhoto,
+    SdProPhotoSettings,
+    SdProTheme,
+    SdProThemeSettings,
+    SpaceInfo,
+)
+from .profiles import (
+    PRO_BUILTIN_MODES,
+    SD_PRO_BUILTIN_MODES,
+    ULTRA_BUILTIN_MODES,
+    FirmwareProfile,
+    detect_firmware_profile,
+    optional_int,
+    profile_for_model,
+    state_from_stock_data,
+)
+from .transport import TIMEOUT, DeviceTransport
 
 _LOGGER = logging.getLogger(__name__)
 
-TIMEOUT = aiohttp.ClientTimeout(total=30)
-
-
-@dataclass
-class ConnectionResult:
-    """Result of a connection test."""
-
-    success: bool
-    error: Literal[
-        "none", "timeout", "connection_refused", "dns_error", "http_error", "unknown"
-    ] = "none"
-    message: str | None = None
-
-    def __bool__(self) -> bool:
-        """Allow using ConnectionResult in boolean context."""
-        return self.success
-
-
-@dataclass
-class DeviceState:
-    """Represents the current device state."""
-
-    theme: int | None
-    brightness: int | None
-    current_image: str | None
-
-
-@dataclass
-class AlbumSettings:
-    """Represents stock firmware photo album settings."""
-
-    interval: int | None
-    gif_loop: int | None
-    autoplay: int | None
-
-
-@dataclass
-class DeviceSettingsBackup:
-    """Best-effort snapshot of mutable device settings."""
-
-    state: DeviceState | None
-    brightness: int | None
-    album: AlbumSettings | None
-    pro_album_files: list[DeviceFileBackup] | None = None
-    sdpro_photos: SdProPhotoSettings | None = None
-    sdpro_themes: SdProThemeSettings | None = None
-    sdpro_active_theme: int | None = None
-
-
-@dataclass
-class DeviceFile:
-    """Represents a file stored on stock firmware."""
-
-    name: str
-    path: str
-    size_kb: int | None = None
-
-
-@dataclass
-class DeviceFileBackup:
-    """Represents a backed-up device file."""
-
-    file: DeviceFile
-    data: bytes
-
-
-@dataclass
-class SdProPhoto:
-    """Represents one SD_PRO slideshow file."""
-
-    name: str
-    size: int
-    enabled: bool
-
-
-@dataclass
-class SdProPhotoSettings:
-    """Represents SD_PRO photo slideshow settings."""
-
-    files: list[SdProPhoto]
-    total: int
-    used: int
-    interval: int | None
-
-
-@dataclass
-class SdProTheme:
-    """Represents one SD_PRO firmware theme."""
-
-    id: int
-    name: str
-    enabled: bool
-
-
-@dataclass
-class SdProThemeSettings:
-    """Represents SD_PRO theme rotation settings."""
-
-    themes: list[SdProTheme]
-    interval: int | None
-
-
-@dataclass
-class SpaceInfo:
-    """Represents device storage info."""
-
-    total: int
-    free: int
-
 
 class GeekMagicDevice:
-    """HTTP client for GeekMagic display devices."""
+    """Public facade for GeekMagic display devices.
 
-    PRO_BUILTIN_MODES: ClassVar[dict[str, int]] = {
-        "Bitcoin": 0,
-        "CoinGecko": 1,
-        "Stocks": 2,
-        "Weather": 3,
-        "Monitor": 5,
-        "Clock": 6,
-        "Ideas": 7,
-    }
-    ULTRA_BUILTIN_MODES: ClassVar[dict[str, int]] = {
-        "Weather Clock Today": 1,
-        "Weather Forecast": 2,
-        "Time Style 1": 4,
-        "Time Style 2": 5,
-        "Time Style 3": 6,
-        "Simple Weather Clock": 7,
-    }
-    SD_PRO_BUILTIN_MODES: ClassVar[dict[str, int]] = {
-        "Classic": 0,
-        "Weather": 1,
-        "Photo": 2,
-        "Dial": 3,
-        "Simple": 4,
-        "Weather Forecast": 5,
-        "Flip Clock": 6,
-    }
+    Firmware-specific behavior lives behind profile adapters; callers keep using
+    this class as the stable Home Assistant and script interface.
+    """
+
+    PRO_BUILTIN_MODES = PRO_BUILTIN_MODES
+    ULTRA_BUILTIN_MODES = ULTRA_BUILTIN_MODES
+    SD_PRO_BUILTIN_MODES = SD_PRO_BUILTIN_MODES
 
     def __init__(
         self,
@@ -161,313 +54,192 @@ class GeekMagicDevice:
         session: aiohttp.ClientSession | None = None,
         model: str = MODEL_UNKNOWN,
     ) -> None:
-        """Initialize the device client.
+        """Initialize the device facade."""
+        self.transport = DeviceTransport(host, session=session)
+        self.profile: FirmwareProfile = profile_for_model(model, self.transport)
 
-        Args:
-            host: IP address, hostname, or URL of the device
-            session: Optional aiohttp session (created if not provided)
-            model: Device model (MODEL_PRO, MODEL_ULTRA, or MODEL_UNKNOWN)
-        """
-        # Parse and normalize the host input to handle URLs
-        if host.startswith(("http://", "https://")):
-            parsed = urlparse(host)
-            self.host = parsed.netloc  # e.g., "192.168.1.1" or "192.168.1.1:8080"
-            self.base_url = f"{parsed.scheme}://{parsed.netloc}"
-        else:
-            self.host = host
-            self.base_url = f"http://{host}"
-        self._session = session
-        self._owns_session = session is None
-        self.model = model
-        self.model_name: str | None = None
-        self.firmware_version: str | None = None
-        self._last_theme: int | None = None
-        self._last_image: str | None = None
+    @property
+    def host(self) -> str:
+        """Return normalized host."""
+        return self.transport.host
 
-    async def _get_session(self) -> aiohttp.ClientSession:
-        """Get or create the aiohttp session."""
-        if self._session is None:
-            self._session = aiohttp.ClientSession(timeout=TIMEOUT)
-        return self._session
+    @property
+    def base_url(self) -> str:
+        """Return base URL."""
+        return self.transport.base_url
 
-    async def _check_device_response(self, response: aiohttp.ClientResponse, action: str) -> None:
-        """Raise for HTTP errors and firmware-level FAIL responses."""
-        response.raise_for_status()
-        try:
-            text = (await response.text()).strip()
-        except Exception:
-            return
+    @property
+    def _session(self) -> aiohttp.ClientSession | None:
+        """Compatibility access to the transport session."""
+        return self.transport.session
 
-        if text.upper() == "FAIL":
-            raise RuntimeError(f"Device rejected {action}: {text}")
+    @_session.setter
+    def _session(self, value: aiohttp.ClientSession | None) -> None:
+        self.transport.session = value
 
-    async def _get_json(self, path: str) -> dict[str, object]:
-        """Fetch a JSON object from the device."""
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}{path}") as response:
-            response.raise_for_status()
-            data = await response.json(content_type=None)
-            if not isinstance(data, dict):
-                raise TypeError(f"Expected JSON object from {path}")
-            return data
+    @property
+    def _owns_session(self) -> bool:
+        """Compatibility access to session ownership."""
+        return self.transport.owns_session
 
-    async def _get_text(self, path: str) -> str:
-        """Fetch text from the device."""
-        try:
-            session = await self._get_session()
-            async with session.get(f"{self.base_url}{path}") as response:
-                response.raise_for_status()
-                return await response.text()
-        except aiohttp.ClientResponseError as err:
-            if self._is_malformed_firmware_response(err):
-                return (await self._raw_http_get(path)).decode(errors="replace")
-            raise
+    @_owns_session.setter
+    def _owns_session(self, value: bool) -> None:
+        self.transport.owns_session = value
 
-    async def _get_bytes(self, path: str) -> bytes:
-        """Fetch bytes from the device."""
-        try:
-            session = await self._get_session()
-            async with session.get(f"{self.base_url}{path}") as response:
-                response.raise_for_status()
-                return await response.read()
-        except aiohttp.ClientResponseError as err:
-            if self._is_malformed_firmware_response(err):
-                return await self._raw_http_get(path)
-            raise
+    @property
+    def _last_theme(self) -> int | None:
+        """Compatibility access to the profile's last known theme."""
+        return self.profile.last_theme
 
-    @staticmethod
-    def _is_malformed_firmware_response(err: aiohttp.ClientResponseError) -> bool:
-        """Return whether aiohttp rejected a known malformed device response."""
-        message = str(err.message) if err.message else ""
-        return err.status == 400 and (
-            "Duplicate Content-Length" in message or "Data after" in message
+    @_last_theme.setter
+    def _last_theme(self, value: int | None) -> None:
+        self.profile.last_theme = value
+
+    @property
+    def _last_image(self) -> str | None:
+        """Compatibility access to the profile's last known image."""
+        return self.profile.last_image
+
+    @_last_image.setter
+    def _last_image(self, value: str | None) -> None:
+        self.profile.last_image = value
+
+    @property
+    def model(self) -> str:
+        """Return detected firmware profile id."""
+        return self.profile.capabilities.profile_id
+
+    @model.setter
+    def model(self, value: str) -> None:
+        old = self.profile
+        self.profile = profile_for_model(
+            value,
+            self.transport,
+            model_name=old.model_name,
+            firmware_version=old.firmware_version,
         )
 
-    async def _raw_http_get(self, path: str) -> bytes:
-        """Fallback HTTP/1.0 GET for firmware responses aiohttp refuses to parse."""
-        parsed = urlparse(self.base_url)
-        host = parsed.hostname or self.host
-        port = parsed.port or (443 if parsed.scheme == "https" else 80)
-        if parsed.scheme == "https":
-            raise RuntimeError("Raw fallback only supports HTTP devices")
+    @property
+    def profile_id(self) -> str:
+        """Return detected firmware profile id."""
+        return self.model
 
-        reader, writer = await asyncio.open_connection(host, port)
-        try:
-            request = f"GET {path} HTTP/1.0\r\nHost: {self.host}\r\nConnection: close\r\n\r\n"
-            writer.write(request.encode("ascii"))
-            await writer.drain()
-            raw = await reader.read()
-        finally:
-            writer.close()
-            await writer.wait_closed()
+    @property
+    def model_name(self) -> str | None:
+        """Return detected model name."""
+        return self.profile.model_name or self.profile.capabilities.display_name
 
-        header, _, body = raw.partition(b"\r\n\r\n")
-        status_line = header.splitlines()[0] if header else b""
-        if not status_line.startswith(b"HTTP/") or b" 200 " not in status_line:
-            raise RuntimeError(f"Raw HTTP GET failed for {path}: {status_line!r}")
-        return body
+    @model_name.setter
+    def model_name(self, value: str | None) -> None:
+        self.profile.model_name = value
 
-    @staticmethod
-    def _optional_int(value: object) -> int | None:
-        """Parse an optional integer value returned by device JSON."""
-        if value is None or value == "":
-            return None
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
+    @property
+    def firmware_version(self) -> str | None:
+        """Return detected firmware version."""
+        return self.profile.firmware_version
 
-    @staticmethod
-    def _state_from_data(data: dict[str, object]) -> DeviceState:
-        """Build DeviceState from a stock firmware state payload."""
-        return DeviceState(
-            theme=GeekMagicDevice._optional_int(data.get("theme")),
-            brightness=GeekMagicDevice._optional_int(data.get("brt")),
-            current_image=str(data["img"]) if data.get("img") else None,
-        )
+    @firmware_version.setter
+    def firmware_version(self, value: str | None) -> None:
+        self.profile.firmware_version = value
+
+    @property
+    def capabilities(self) -> FirmwareCapabilities:
+        """Return firmware profile capabilities."""
+        return self.profile.capabilities
 
     @property
     def custom_theme(self) -> int:
-        """Return the device theme used for custom uploaded images."""
-        if self.model == MODEL_SD_PRO:
-            return 2
-        return 4 if self.model == MODEL_PRO else 3
+        """Return theme used for custom uploaded images."""
+        return self.capabilities.custom_image_theme or 3
 
     @property
     def builtin_modes(self) -> dict[str, int]:
-        """Return built-in display modes for the detected model."""
-        if self.model == MODEL_PRO:
-            return self.PRO_BUILTIN_MODES
-        if self.model == MODEL_SD_PRO:
-            return self.SD_PRO_BUILTIN_MODES
-        return self.ULTRA_BUILTIN_MODES
+        """Return built-in display modes for the active firmware profile."""
+        return self.capabilities.builtin_modes
 
     def is_custom_theme(self, theme: int | None) -> bool:
         """Return whether a device theme is the custom image mode."""
-        return theme == self.custom_theme
+        return theme == self.capabilities.custom_image_theme
 
     def is_builtin_theme(self, theme: int | None) -> bool:
         """Return whether a device theme is handled by device firmware."""
         return theme is not None and not self.is_custom_theme(theme)
 
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Compatibility helper for tests and older callers."""
+        return await self.transport.get_session()
+
+    async def _check_device_response(
+        self,
+        response: aiohttp.ClientResponse,
+        action: str,
+    ) -> None:
+        """Compatibility helper for tests and older callers."""
+        await self.transport.check_device_response(response, action)
+
+    async def _get_json(self, path: str) -> dict[str, object]:
+        """Compatibility helper for tests and older callers."""
+        return await self.transport.get_json(path)
+
+    async def _get_text(self, path: str) -> str:
+        """Compatibility helper for tests and older callers."""
+        return await self.transport.get_text(path)
+
+    async def _get_bytes(self, path: str) -> bytes:
+        """Compatibility helper for tests and older callers."""
+        return await self.transport.get_bytes(path)
+
+    @staticmethod
+    def _optional_int(value: object) -> int | None:
+        """Parse an optional integer value returned by device JSON."""
+        return optional_int(value)
+
+    @staticmethod
+    def _state_from_data(data: dict[str, object]) -> DeviceState:
+        """Build DeviceState from a stock firmware state payload."""
+        return state_from_stock_data(data)
+
     async def close(self) -> None:
-        """Close the session if we own it."""
-        if self._owns_session and self._session is not None:
-            await self._session.close()
-            self._session = None
+        """Close the session if this device owns it."""
+        await self.transport.close()
+
+    async def detect_model(self) -> str:
+        """Detect and activate the firmware profile."""
+        self.profile = await detect_firmware_profile(self.transport)
+        _LOGGER.info(
+            "Detected device profile: %s (%s)",
+            self.model_name,
+            self.firmware_version,
+        )
+        return self.model
 
     async def get_state(self) -> DeviceState:
-        """Get current device state.
-
-        Returns:
-            DeviceState with theme, brightness, and current image
-        """
-        _LOGGER.debug("Getting device state from %s", self.host)
-        if self.model == MODEL_SD_PRO:
-            data = await self._get_json("/config")
-            return DeviceState(
-                theme=self._optional_int(data.get("theme")),
-                brightness=self._optional_int(data.get("brightness")),
-                current_image=None,
-            )
-
-        session = await self._get_session()
-        paths = ["/.sys/app.json", "/app.json"] if self.model == MODEL_PRO else ["/app.json"]
-        last_404: aiohttp.ClientResponseError | None = None
-        for path in paths:
-            try:
-                async with session.get(f"{self.base_url}{path}") as response:
-                    response.raise_for_status()
-                    # Device returns text/plain content type, so we need to accept any
-                    data = await response.json(content_type=None)
-                    state = self._state_from_data(data)
-                    _LOGGER.debug(
-                        "Device state: theme=%s, brightness=%s, image=%s",
-                        state.theme,
-                        state.brightness,
-                        state.current_image,
-                    )
-                    return state
-            except aiohttp.ClientResponseError as err:
-                if self.model == MODEL_PRO and err.status == 404:
-                    last_404 = err
-                    continue
-                raise
-
-        if self.model == MODEL_PRO and last_404 is not None:
-            _LOGGER.debug("Pro firmware has no state path; using last known state")
-            return DeviceState(
-                theme=self._last_theme,
-                brightness=None,
-                current_image=self._last_image,
-            )
-
-        raise RuntimeError("Device state was not read")
+        """Get current device state."""
+        return await self.profile.get_state()
 
     async def get_space(self) -> SpaceInfo:
-        """Get device storage information.
-
-        Returns:
-            SpaceInfo with total and free bytes
-        """
-        _LOGGER.debug("Getting storage info from %s", self.host)
-        if self.model == MODEL_SD_PRO:
-            photos = await self.get_sdpro_photo_settings()
-            return SpaceInfo(total=photos.total, free=max(0, photos.total - photos.used))
-
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/space.json") as response:
-            response.raise_for_status()
-            # Device returns text/plain content type, so we need to accept any
-            data = await response.json(content_type=None)
-            space = SpaceInfo(
-                total=data.get("total", 0),
-                free=data.get("free", 0),
-            )
-            _LOGGER.debug(
-                "Storage info: total=%d, free=%d (%.1f%% free)",
-                space.total,
-                space.free,
-                (space.free / space.total * 100) if space.total > 0 else 0,
-            )
-            return space
+        """Get storage information."""
+        return await self.profile.get_space()
 
     async def get_brightness(self) -> int:
-        """Get current brightness from device.
-
-        Returns:
-            Brightness level 0-100
-        """
-        _LOGGER.debug("Getting brightness from %s", self.host)
-        if self.model == MODEL_SD_PRO:
-            data = await self._get_json("/config")
-            brightness = self._optional_int(data.get("brightness"))
-            return brightness or 0
-
-        session = await self._get_session()
-        path = "/.sys/brt.json" if self.model == MODEL_PRO else "/brt.json"
-        async with session.get(f"{self.base_url}{path}") as response:
-            response.raise_for_status()
-            data = await response.json(content_type=None)
-            # API returns brightness as string: {"brt": "71"}
-            brightness = int(data.get("brt", 0))
-            _LOGGER.debug("Device brightness: %d", brightness)
-            return brightness
+        """Get current brightness."""
+        return await self.profile.get_brightness()
 
     async def set_brightness(self, value: int) -> None:
-        """Set display brightness.
-
-        Args:
-            value: Brightness level 0-100
-        """
-        value = max(0, min(100, value))
-        if self.model == MODEL_SD_PRO:
-            value = max(2, min(99, value))
-            session = await self._get_session()
-            async with session.get(
-                f"{self.base_url}/api/set?key=lcd_brightness&value={value}"
-            ) as response:
-                await self._check_device_response(response, "brightness update")
-            _LOGGER.debug("Set SD_PRO brightness to %d", value)
-            return
-
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?brt={value}") as response:
-            await self._check_device_response(response, "brightness update")
-        _LOGGER.debug("Set brightness to %d", value)
+        """Set brightness."""
+        await self.profile.set_brightness(value)
 
     async def set_theme(self, theme: int) -> None:
-        """Set device theme.
+        """Set firmware theme."""
+        await self.profile.set_theme(theme)
 
-        Args:
-            theme: Theme number (3 = custom image on Ultra, 4 = custom image on Pro)
-        """
-        if self.model == MODEL_SD_PRO:
-            session = await self._get_session()
-            async with session.get(f"{self.base_url}/api/set?key=theme&value={theme}") as response:
-                await self._check_device_response(response, "theme update")
-            self._last_theme = theme
-            _LOGGER.debug("Set SD_PRO theme to %d", theme)
-            return
-
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?theme={theme}") as response:
-            await self._check_device_response(response, "theme update")
-        self._last_theme = theme
-        _LOGGER.debug("Set theme to %d", theme)
+    async def set_theme_custom(self) -> None:
+        """Set the firmware's custom image theme."""
+        await self.profile.set_theme_custom()
 
     async def get_album_settings(self) -> AlbumSettings:
-        """Get photo album settings when exposed by stock firmware."""
-        session = await self._get_session()
-        path = "/.sys/album.json" if self.model == MODEL_PRO else "/album.json"
-        async with session.get(f"{self.base_url}{path}") as response:
-            response.raise_for_status()
-            data = await response.json(content_type=None)
-            return AlbumSettings(
-                interval=self._optional_int(data.get("i_i")),
-                gif_loop=self._optional_int(data.get("gif_loop")),
-                autoplay=self._optional_int(data.get("autoplay")),
-            )
+        """Get photo album settings."""
+        return await self.profile.get_album_settings()
 
     async def set_album_display(
         self,
@@ -475,299 +247,84 @@ class GeekMagicDevice:
         gif_loop: int | None = 1,
         autoplay: int | None = 1,
     ) -> None:
-        """Enable the Pro Picture album mode used for uploaded images."""
-        query_parts: list[str] = []
-        if interval is not None:
-            query_parts.append(f"i_i={max(1, interval)}")
-        if gif_loop is not None:
-            query_parts.append(f"gif_loop={max(1, gif_loop)}")
-        if autoplay is not None:
-            query_parts.append(f"autoplay={1 if autoplay else 0}")
-        if not query_parts:
-            return
-
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?{'&'.join(query_parts)}") as response:
-            await self._check_device_response(response, "album display update")
-        _LOGGER.debug(
-            "Updated album display interval=%s gif_loop=%s autoplay=%s",
-            interval,
-            gif_loop,
-            autoplay,
+        """Set photo album display settings."""
+        await self.profile.set_album_display(
+            interval=interval,
+            gif_loop=gif_loop,
+            autoplay=autoplay,
         )
 
     async def get_pro_image_files(self) -> list[DeviceFile]:
         """List files in the stock firmware image album."""
-        html = await self._get_text("/filelist?dir=/image/")
-
-        files: list[DeviceFile] = []
-        pattern = re.compile(
-            r"<a href='(?P<path>[^']+)'>(?P<name>[^<]+)</a></td><td>(?P<size>[^<]+)</td>"
-        )
-        for match in pattern.finditer(html):
-            size = self._optional_int(match.group("size"))
-            files.append(
-                DeviceFile(
-                    name=match.group("name"),
-                    path=match.group("path"),
-                    size_kb=size,
-                )
-            )
-        return files
+        return await self.profile.get_image_files()
 
     async def backup_pro_album_files(self) -> list[DeviceFileBackup]:
-        """Download the current stock firmware image album for later restore."""
-        return [
-            DeviceFileBackup(file=file, data=await self._get_bytes(file.path))
-            for file in await self.get_pro_image_files()
-        ]
+        """Download the current stock firmware image album."""
+        return await self.profile.backup_image_files()
 
     async def restore_pro_album_files(self, backups: list[DeviceFileBackup]) -> None:
         """Restore a previously backed-up stock firmware image album."""
-        await self.clear_pro_album_files()
-        for backup in backups:
-            await self.upload(backup.data, backup.file.name)
+        await self.profile.restore_image_files(backups)
 
     async def clear_pro_album_files(self) -> None:
-        """Clear the stock firmware image album, including files clear=image leaves behind."""
-        await self.clear_images()
-        for file in await self.get_pro_image_files():
-            await self.delete_file(file.path)
+        """Clear the stock firmware image album."""
+        await self.profile.clear_album_files()
 
     async def pro_image_exists(self, filename: str) -> bool:
-        """Return whether a stock firmware image album contains filename."""
-        return any(file.name == filename for file in await self.get_pro_image_files())
+        """Return whether the stock firmware image album contains filename."""
+        return await self.profile.image_exists(filename)
 
     async def keep_only_pro_image(self, filename: str) -> None:
         """Delete every Pro album file except filename."""
-        kept = False
-        for file in await self.get_pro_image_files():
-            if file.name == filename:
-                kept = True
-                continue
-            await self.delete_file(file.path)
-
-        if not kept:
-            raise RuntimeError(f"Uploaded image {filename} was not found in the Pro album")
+        await self.profile.keep_only_image(filename)
 
     async def get_sdpro_photo_settings(self) -> SdProPhotoSettings:
         """Read SD_PRO photo slideshow settings."""
-        data = await self._get_json("/photo/list")
-        files_data = data.get("files", [])
-        files: list[SdProPhoto] = []
-        if isinstance(files_data, list):
-            for item in files_data:
-                if isinstance(item, dict):
-                    name = item.get("name")
-                    if name is not None:
-                        files.append(
-                            SdProPhoto(
-                                name=str(name),
-                                size=self._optional_int(item.get("size")) or 0,
-                                enabled=bool(item.get("enabled")),
-                            )
-                        )
-        return SdProPhotoSettings(
-            files=files,
-            total=self._optional_int(data.get("total")) or 0,
-            used=self._optional_int(data.get("used")) or 0,
-            interval=self._optional_int(data.get("interval")),
-        )
+        return await self.profile.get_sdpro_photo_settings()
 
     async def get_sdpro_theme_settings(self) -> SdProThemeSettings:
         """Read SD_PRO theme rotation settings."""
-        data = await self._get_json("/theme/list")
-        themes_data = data.get("themes", [])
-        themes: list[SdProTheme] = []
-        if isinstance(themes_data, list):
-            for item in themes_data:
-                if isinstance(item, dict):
-                    theme_id = self._optional_int(item.get("id"))
-                    if theme_id is not None:
-                        themes.append(
-                            SdProTheme(
-                                id=theme_id,
-                                name=str(item.get("name", theme_id)),
-                                enabled=bool(item.get("enabled")),
-                            )
-                        )
-        return SdProThemeSettings(
-            themes=themes,
-            interval=self._optional_int(data.get("interval")),
-        )
+        return await self.profile.get_sdpro_theme_settings()
 
     async def set_sdpro_photo_enabled(self, name: str, enabled: bool) -> None:
         """Enable or disable a photo in the SD_PRO slideshow."""
-        session = await self._get_session()
-        async with session.get(
-            f"{self.base_url}/photo/toggle?name={quote(name)}&state={1 if enabled else 0}"
-        ) as response:
-            await self._check_device_response(response, f"photo toggle {name}")
+        await self.profile.set_sdpro_photo_enabled(name, enabled)
 
     async def set_sdpro_photo_interval(self, interval: int) -> None:
         """Set SD_PRO photo slideshow interval."""
-        interval = max(1, interval)
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/photo/interval?val={interval}") as response:
-            await self._check_device_response(response, "photo interval update")
+        await self.profile.set_sdpro_photo_interval(interval)
 
     async def set_sdpro_theme_enabled(self, theme_id: int, enabled: bool) -> None:
         """Enable or disable a theme in the SD_PRO rotation."""
-        session = await self._get_session()
-        async with session.get(
-            f"{self.base_url}/theme/toggle?id={theme_id}&state={1 if enabled else 0}"
-        ) as response:
-            await self._check_device_response(response, f"theme toggle {theme_id}")
+        await self.profile.set_sdpro_theme_enabled(theme_id, enabled)
 
     async def set_sdpro_theme_interval(self, interval: int) -> None:
         """Set SD_PRO theme rotation interval."""
-        interval = max(0, interval)
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/theme/interval?val={interval}") as response:
-            await self._check_device_response(response, "theme interval update")
+        await self.profile.set_sdpro_theme_interval(interval)
 
     async def delete_sdpro_photo(self, name: str) -> None:
         """Delete a photo from the SD_PRO slideshow."""
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/photo/delete?name={quote(name)}") as response:
-            await self._check_device_response(response, f"photo delete {name}")
+        await self.profile.delete_sdpro_photo(name)
 
     async def upload_sdpro_photo(self, image_data: bytes, filename: str) -> None:
         """Upload a photo to the SD_PRO slideshow."""
-        if filename.lower().endswith(".png"):
-            content_type = "image/png"
-        elif filename.lower().endswith(".gif"):
-            content_type = "image/gif"
-        else:
-            content_type = "image/jpeg"
-
-        form = aiohttp.FormData()
-        form.add_field("file", image_data, filename=filename, content_type=content_type)
-        session = await self._get_session()
-        async with session.post(f"{self.base_url}/photo/upload", data=form) as response:
-            response.raise_for_status()
+        await self.profile.upload(image_data, filename)
 
     async def prepare_sdpro_exclusive_photo(self, filename: str) -> None:
-        """Make one SD_PRO photo and the Photo theme active for visual testing."""
-        photos = await self.get_sdpro_photo_settings()
-        for photo in photos.files:
-            await self.set_sdpro_photo_enabled(photo.name, photo.name == filename)
-
-        themes = await self.get_sdpro_theme_settings()
-        for theme in themes.themes:
-            await self.set_sdpro_theme_enabled(theme.id, theme.id == self.custom_theme)
-
-        await self.set_sdpro_photo_interval(1)
-        await self.set_theme(self.custom_theme)
-
-    async def set_theme_custom(self) -> None:
-        """Set device to custom image mode with the correct theme number.
-
-        Ultra devices use theme 3, Pro devices use theme 4.
-        Uses the model detected at startup via detect_model().
-        """
-        await self.set_theme(self.custom_theme)
+        """Make one SD_PRO photo and the Photo theme active."""
+        await self.profile.prepare_exclusive_photo(filename)
 
     async def set_image(self, filename: str, enter_picture: bool = False) -> None:
-        """Set the displayed image.
-
-        Args:
-            filename: Image filename (without path)
-            enter_picture: For Pro diagnostics, press buttons to enter Picture mode
-        """
-        if self.model == MODEL_SD_PRO:
-            await self.prepare_sdpro_exclusive_photo(filename)
-            self._last_image = f"/photo/{filename}"
-            _LOGGER.debug("Set SD_PRO photo slideshow mode for %s", filename)
-            return
-
-        if self.model == MODEL_PRO:
-            # This Pro firmware accepts uploads but returns body "FAIL" for
-            # /set?img=... JPG selection. Its Picture mode is album-based.
-            # Optional button navigation is kept for explicit live diagnostics,
-            # but HA does not use it because the Pro menu state is not exposed.
-            await self.set_album_display()
-            await self.set_theme_custom()
-            if enter_picture:
-                await self.navigate_enter()
-                await asyncio.sleep(0.5)
-                await self.navigate_next()
-                await asyncio.sleep(0.5)
-                await self.navigate_enter()
-            self._last_image = f"/image/{filename}"
-            _LOGGER.debug("Set Pro album image mode for %s", filename)
-            return
-
-        # Ensure we're in custom image mode
-        await self.set_theme_custom()
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?img=/image/{filename}") as response:
-            await self._check_device_response(response, f"image selection for {filename}")
-        self._last_image = f"/image/{filename}"
-        _LOGGER.debug("Set image to %s", filename)
+        """Set the displayed image."""
+        await self.profile.set_image(filename, try_menu_navigation=enter_picture)
 
     async def upload(self, image_data: bytes, filename: str) -> None:
-        """Upload an image to the device.
+        """Upload an image to the device."""
+        await self.profile.upload(image_data, filename)
 
-        Args:
-            image_data: Raw image bytes (JPEG or PNG)
-            filename: Filename to save as
-        """
-        # Determine content type from filename
-        if filename.lower().endswith(".png"):
-            content_type = "image/png"
-        elif filename.lower().endswith(".gif"):
-            content_type = "image/gif"
-        else:
-            content_type = "image/jpeg"
-
-        # Create multipart form data
-        form = aiohttp.FormData()
-        form.add_field(
-            "file",
-            image_data,
-            filename=filename,
-            content_type=content_type,
-        )
-
-        if self.model == MODEL_SD_PRO:
-            await self.upload_sdpro_photo(image_data, filename)
-            _LOGGER.debug("Uploaded SD_PRO photo %s (%d bytes)", filename, len(image_data))
-            return
-
-        session = await self._get_session()
-        try:
-            async with session.post(
-                f"{self.base_url}/doUpload?dir=/image/",
-                data=form,
-            ) as response:
-                response.raise_for_status()
-        except aiohttp.ClientResponseError as e:
-            # Device firmware returns malformed HTTP responses, but upload succeeds.
-            # Known issues:
-            # - SmallTV-Ultra: Duplicate Content-Length headers
-            # - SmallTV-Pro: "Data after Connection: close" (sends OK + new response)
-            if e.status == 400:
-                msg = str(e.message) if e.message else ""
-                if "Duplicate Content-Length" in msg or "Data after" in msg:
-                    _LOGGER.debug("Ignoring malformed HTTP response from device: %s", msg)
-                    return
-            raise
-        except aiohttp.ClientError as err:
-            if self.model == MODEL_PRO:
-                try:
-                    if await self.pro_image_exists(filename):
-                        _LOGGER.debug(
-                            "Treating Pro upload connection error as success; %s is present: %s",
-                            filename,
-                            err,
-                        )
-                        return
-                except Exception as verify_err:
-                    _LOGGER.debug("Could not verify Pro upload after error: %s", verify_err)
-            raise
-
-        _LOGGER.debug("Uploaded %s (%d bytes)", filename, len(image_data))
+    async def display_rendered_dashboard(self, request: RenderedDashboardRequest) -> None:
+        """Upload and make a rendered dashboard visible."""
+        await self.profile.display_rendered_dashboard(request)
 
     async def upload_and_display(
         self,
@@ -776,154 +333,36 @@ class GeekMagicDevice:
         manage_album: bool = False,
         enter_picture: bool = False,
     ) -> None:
-        """Upload an image and immediately display it.
-
-        Args:
-            image_data: Raw image bytes
-            filename: Filename to save as
-            manage_album: For Pro, delete all other album files after upload
-            enter_picture: For Pro diagnostics, press buttons to enter Picture mode
-        """
-        _LOGGER.debug(
-            "Uploading and displaying %s (%d bytes) to %s",
-            filename,
-            len(image_data),
-            self.host,
-        )
-        await self.upload(image_data, filename)
-        if self.model == MODEL_PRO and manage_album:
-            await self.keep_only_pro_image(filename)
-        await self.set_image(filename, enter_picture=enter_picture)
-        _LOGGER.debug("Upload and display completed for %s", filename)
-
-    async def backup_settings(self) -> DeviceSettingsBackup:
-        """Take a best-effort snapshot of settings changed by smoke tests."""
-        state: DeviceState | None = None
-        brightness: int | None = None
-        album: AlbumSettings | None = None
-        sdpro_photos: SdProPhotoSettings | None = None
-        sdpro_themes: SdProThemeSettings | None = None
-        sdpro_active_theme: int | None = None
-
-        try:
-            state = await self.get_state()
-            if self.model == MODEL_SD_PRO:
-                sdpro_active_theme = state.theme
-        except Exception as err:
-            _LOGGER.debug("Could not back up device state: %s", err)
-
-        try:
-            brightness = await self.get_brightness()
-        except Exception as err:
-            _LOGGER.debug("Could not back up brightness: %s", err)
-
-        if self.model == MODEL_PRO:
-            try:
-                album = await self.get_album_settings()
-            except Exception as err:
-                _LOGGER.debug("Could not back up album settings: %s", err)
-
-        if self.model == MODEL_SD_PRO:
-            try:
-                sdpro_photos = await self.get_sdpro_photo_settings()
-            except Exception as err:
-                _LOGGER.debug("Could not back up SD_PRO photo settings: %s", err)
-            try:
-                sdpro_themes = await self.get_sdpro_theme_settings()
-            except Exception as err:
-                _LOGGER.debug("Could not back up SD_PRO theme settings: %s", err)
-
-        return DeviceSettingsBackup(
-            state=state,
-            brightness=brightness,
-            album=album,
-            sdpro_photos=sdpro_photos,
-            sdpro_themes=sdpro_themes,
-            sdpro_active_theme=sdpro_active_theme,
-        )
-
-    async def restore_settings(self, backup: DeviceSettingsBackup) -> None:
-        """Restore settings captured by backup_settings()."""
-        if backup.brightness is not None:
-            await self.set_brightness(backup.brightness)
-
-        if self.model == MODEL_PRO and backup.pro_album_files is not None:
-            await self.restore_pro_album_files(backup.pro_album_files)
-
-        if self.model == MODEL_PRO and backup.album is not None:
-            await self.set_album_display(
-                interval=backup.album.interval,
-                gif_loop=backup.album.gif_loop,
-                autoplay=backup.album.autoplay,
+        """Upload an image and immediately display it."""
+        await self.display_rendered_dashboard(
+            RenderedDashboardRequest(
+                image_data=image_data,
+                filename=filename,
+                allow_destructive_album_management=manage_album,
+                try_menu_navigation=enter_picture,
             )
-
-        if self.model == MODEL_SD_PRO:
-            if backup.sdpro_photos is not None:
-                for photo in backup.sdpro_photos.files:
-                    await self.set_sdpro_photo_enabled(photo.name, photo.enabled)
-                if backup.sdpro_photos.interval is not None:
-                    await self.set_sdpro_photo_interval(backup.sdpro_photos.interval)
-
-            if backup.sdpro_themes is not None:
-                for theme in backup.sdpro_themes.themes:
-                    await self.set_sdpro_theme_enabled(theme.id, theme.enabled)
-                if backup.sdpro_themes.interval is not None:
-                    await self.set_sdpro_theme_interval(backup.sdpro_themes.interval)
-
-            if backup.sdpro_active_theme is not None:
-                await self.set_theme(backup.sdpro_active_theme)
-                return
-
-        if backup.state is None or backup.state.theme is None:
-            return
-
-        if (
-            self.model != MODEL_PRO
-            and backup.state.current_image
-            and self.is_custom_theme(backup.state.theme)
-        ):
-            await self.set_theme(backup.state.theme)
-            await self._select_image_path(backup.state.current_image)
-            return
-
-        await self.set_theme(backup.state.theme)
+        )
 
     async def _select_image_path(self, image_path: str) -> None:
         """Select an uploaded image path on firmware that supports it."""
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?img={image_path}") as response:
-            await self._check_device_response(response, f"image selection for {image_path}")
-        self._last_image = image_path
-        _LOGGER.debug("Set image path to %s", image_path)
+        await self.select_image_path(image_path)
+
+    async def select_image_path(self, image_path: str) -> None:
+        """Select an uploaded image path on firmware that supports it."""
+        await self.profile.select_image_path(image_path)
 
     async def delete_file(self, path: str) -> None:
-        """Delete a file from the device.
-
-        Args:
-            path: Full path to the file
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/delete?file={path}") as response:
-            await self._check_device_response(response, f"delete {path}")
-        _LOGGER.debug("Deleted %s", path)
+        """Delete a file from the device."""
+        await self.profile.delete_file(path)
 
     async def clear_images(self) -> None:
         """Clear all images from the device."""
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?clear=image") as response:
-            await self._check_device_response(response, "clear images")
-        _LOGGER.debug("Cleared all images")
+        await self.profile.clear_images()
 
     async def test_connection(self) -> ConnectionResult:  # noqa: PLR0911
-        """Test if the device is reachable.
-
-        Returns:
-            ConnectionResult with success status and error details if failed.
-            Can be used in boolean context (truthy if successful).
-        """
+        """Test if the device is reachable."""
         _LOGGER.debug("Testing connection to %s", self.host)
         try:
-            # use space.json as it's more widely supported across firmware versions
             await self.get_space()
         except TimeoutError:
             _LOGGER.warning("Connection test timed out for %s", self.host)
@@ -932,174 +371,81 @@ class GeekMagicDevice:
                 error="timeout",
                 message="Connection timed out after 30 seconds",
             )
-        except aiohttp.ClientConnectorDNSError as e:
-            _LOGGER.warning("DNS resolution failed for %s: %s", self.host, e)
+        except aiohttp.ClientConnectorDNSError as err:
+            _LOGGER.warning("DNS resolution failed for %s: %s", self.host, err)
             return ConnectionResult(
                 success=False,
                 error="dns_error",
                 message=f"Could not resolve hostname: {self.host}",
             )
-        except aiohttp.ClientConnectorError as e:
-            _LOGGER.warning("Connection failed for %s: %s", self.host, e)
+        except aiohttp.ClientConnectorError as err:
+            _LOGGER.warning("Connection failed for %s: %s", self.host, err)
             return ConnectionResult(
                 success=False,
                 error="connection_refused",
-                message=str(e),
+                message=str(err),
             )
-        except aiohttp.ClientResponseError as e:
-            if e.status == 404 and self.model == MODEL_UNKNOWN:
+        except aiohttp.ClientResponseError as err:
+            if err.status == 404 and self.model == MODEL_UNKNOWN:
                 await self.detect_model()
-                if self.model == MODEL_SD_PRO:
-                    try:
-                        await self.get_space()
-                    except Exception as retry_err:
-                        _LOGGER.warning(
-                            "SD_PRO connection retry failed for %s: %s",
-                            self.host,
-                            retry_err,
-                        )
-                    else:
-                        return ConnectionResult(success=True)
-            _LOGGER.warning("HTTP error for %s: %s", self.host, e)
+                try:
+                    await self.get_space()
+                except Exception as retry_err:
+                    _LOGGER.warning(
+                        "Connection retry failed for %s: %s",
+                        self.host,
+                        retry_err,
+                    )
+                else:
+                    return ConnectionResult(success=True)
+            _LOGGER.warning("HTTP error for %s: %s", self.host, err)
             return ConnectionResult(
                 success=False,
                 error="http_error",
-                message=f"HTTP error {e.status}: {e.message}",
+                message=f"HTTP error {err.status}: {err.message}",
             )
-        except Exception as e:
-            _LOGGER.warning("Connection test failed for %s: %s", self.host, e)
+        except Exception as err:
+            _LOGGER.warning("Connection test failed for %s: %s", self.host, err)
             return ConnectionResult(
                 success=False,
                 error="unknown",
-                message=str(e),
+                message=str(err),
             )
         else:
             _LOGGER.debug("Connection test successful for %s", self.host)
             return ConnectionResult(success=True)
 
-    # Pro-specific navigation methods
-    # These simulate the physical button presses on SmallTV Pro devices
-
     async def navigate_next(self) -> None:
-        """Navigate to next page (Pro devices).
-
-        Simulates pressing the right/next button on the device.
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?page=1") as response:
-            await self._check_device_response(response, "navigate next")
-        _LOGGER.debug("Navigated to next page")
+        """Navigate to next page."""
+        await self.profile.navigate_next()
 
     async def navigate_previous(self) -> None:
-        """Navigate to previous page (Pro devices).
-
-        Simulates pressing the left/previous button on the device.
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?page=-1") as response:
-            await self._check_device_response(response, "navigate previous")
-        _LOGGER.debug("Navigated to previous page")
+        """Navigate to previous page."""
+        await self.profile.navigate_previous()
 
     async def navigate_enter(self) -> None:
-        """Press enter/exit button (Pro devices).
-
-        Simulates pressing the enter/menu button on the device.
-        """
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?enter=-1") as response:
-            await self._check_device_response(response, "navigate enter")
-        _LOGGER.debug("Pressed enter button")
+        """Press enter/exit button."""
+        await self.profile.navigate_enter()
 
     async def reboot(self) -> None:
-        """Reboot the device (Pro devices)."""
-        session = await self._get_session()
-        async with session.get(f"{self.base_url}/set?reboot=1") as response:
-            await self._check_device_response(response, "reboot")
-        _LOGGER.debug("Rebooting device")
+        """Reboot the device."""
+        await self.profile.reboot()
 
-    async def detect_model(self) -> str:
-        """Attempt to detect the device model.
 
-        Newer stock firmware exposes identity through /v.json. Older firmware
-        may only expose model-specific state paths.
-        Returns MODEL_PRO, MODEL_ULTRA, or MODEL_UNKNOWN.
-        """
-        session = await self._get_session()
-
-        # Current stock firmware exposes a reliable model/version endpoint.
-        try:
-            async with session.get(
-                f"{self.base_url}/v.json", timeout=aiohttp.ClientTimeout(total=5)
-            ) as response:
-                if response.status == 200:
-                    data = await response.json(content_type=None)
-                    model_name = str(data.get("m", ""))
-                    firmware_version = data.get("v")
-                    self.model_name = model_name or None
-                    self.firmware_version = (
-                        str(firmware_version) if firmware_version is not None else None
-                    )
-
-                    model_key = model_name.lower()
-                    if "pro" in model_key:
-                        self.model = MODEL_PRO
-                        _LOGGER.info(
-                            "Detected device model: %s (%s)",
-                            self.model_name,
-                            self.firmware_version,
-                        )
-                        return self.model
-                    if "ultra" in model_key:
-                        self.model = MODEL_ULTRA
-                        _LOGGER.info(
-                            "Detected device model: %s (%s)",
-                            self.model_name,
-                            self.firmware_version,
-                        )
-                        return self.model
-        except Exception as err:
-            _LOGGER.debug("Identity path /v.json not available: %s", err)
-
-        # Try Pro-specific path first (/.sys/app.json)
-        try:
-            async with session.get(
-                f"{self.base_url}/.sys/app.json", timeout=aiohttp.ClientTimeout(total=5)
-            ) as response:
-                if response.status == 200:
-                    self.model = MODEL_PRO
-                    self.model_name = "SmallTV Pro"
-                    _LOGGER.info("Detected device model: SmallTV Pro")
-                    return self.model
-        except Exception as err:
-            _LOGGER.debug("Pro path /.sys/app.json not available: %s", err)
-
-        # Fall back to Ultra (standard path works)
-        try:
-            async with session.get(
-                f"{self.base_url}/app.json", timeout=aiohttp.ClientTimeout(total=5)
-            ) as response:
-                if response.status == 200:
-                    self.model = MODEL_ULTRA
-                    self.model_name = "SmallTV Ultra"
-                    _LOGGER.info("Detected device model: SmallTV Ultra")
-                    return self.model
-        except Exception as err:
-            _LOGGER.debug("Ultra path /app.json not available: %s", err)
-
-        # SD_PRO community firmware exposes /theme/list and /photo/list instead.
-        try:
-            async with session.get(
-                f"{self.base_url}/theme/list", timeout=aiohttp.ClientTimeout(total=5)
-            ) as response:
-                if response.status == 200:
-                    data = await response.json(content_type=None)
-                    if isinstance(data.get("themes"), list):
-                        self.model = MODEL_SD_PRO
-                        self.model_name = "SD_PRO Community Firmware"
-                        _LOGGER.info("Detected device model: SD_PRO Community Firmware")
-                        return self.model
-        except Exception as err:
-            _LOGGER.debug("SD_PRO path /theme/list not available: %s", err)
-
-        _LOGGER.warning("Could not detect device model for %s", self.host)
-        return MODEL_UNKNOWN
+__all__ = [
+    "TIMEOUT",
+    "AlbumSettings",
+    "ConnectionResult",
+    "DeviceFile",
+    "DeviceFileBackup",
+    "DeviceSettingsBackup",
+    "DeviceState",
+    "FirmwareCapabilities",
+    "GeekMagicDevice",
+    "RenderedDashboardRequest",
+    "SdProPhoto",
+    "SdProPhotoSettings",
+    "SdProTheme",
+    "SdProThemeSettings",
+    "SpaceInfo",
+]

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import re
 from dataclasses import dataclass
-from typing import Literal
-from urllib.parse import urlparse
+from typing import ClassVar, Literal
+from urllib.parse import quote, urlparse
 
 import aiohttp
 
-from .const import MODEL_PRO, MODEL_ULTRA, MODEL_UNKNOWN
+from .const import MODEL_PRO, MODEL_SD_PRO, MODEL_ULTRA, MODEL_UNKNOWN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,9 +37,84 @@ class ConnectionResult:
 class DeviceState:
     """Represents the current device state."""
 
-    theme: int
+    theme: int | None
     brightness: int | None
     current_image: str | None
+
+
+@dataclass
+class AlbumSettings:
+    """Represents stock firmware photo album settings."""
+
+    interval: int | None
+    gif_loop: int | None
+    autoplay: int | None
+
+
+@dataclass
+class DeviceSettingsBackup:
+    """Best-effort snapshot of mutable device settings."""
+
+    state: DeviceState | None
+    brightness: int | None
+    album: AlbumSettings | None
+    pro_album_files: list[DeviceFileBackup] | None = None
+    sdpro_photos: SdProPhotoSettings | None = None
+    sdpro_themes: SdProThemeSettings | None = None
+    sdpro_active_theme: int | None = None
+
+
+@dataclass
+class DeviceFile:
+    """Represents a file stored on stock firmware."""
+
+    name: str
+    path: str
+    size_kb: int | None = None
+
+
+@dataclass
+class DeviceFileBackup:
+    """Represents a backed-up device file."""
+
+    file: DeviceFile
+    data: bytes
+
+
+@dataclass
+class SdProPhoto:
+    """Represents one SD_PRO slideshow file."""
+
+    name: str
+    size: int
+    enabled: bool
+
+
+@dataclass
+class SdProPhotoSettings:
+    """Represents SD_PRO photo slideshow settings."""
+
+    files: list[SdProPhoto]
+    total: int
+    used: int
+    interval: int | None
+
+
+@dataclass
+class SdProTheme:
+    """Represents one SD_PRO firmware theme."""
+
+    id: int
+    name: str
+    enabled: bool
+
+
+@dataclass
+class SdProThemeSettings:
+    """Represents SD_PRO theme rotation settings."""
+
+    themes: list[SdProTheme]
+    interval: int | None
 
 
 @dataclass
@@ -50,6 +127,33 @@ class SpaceInfo:
 
 class GeekMagicDevice:
     """HTTP client for GeekMagic display devices."""
+
+    PRO_BUILTIN_MODES: ClassVar[dict[str, int]] = {
+        "Bitcoin": 0,
+        "CoinGecko": 1,
+        "Stocks": 2,
+        "Weather": 3,
+        "Monitor": 5,
+        "Clock": 6,
+        "Ideas": 7,
+    }
+    ULTRA_BUILTIN_MODES: ClassVar[dict[str, int]] = {
+        "Weather Clock Today": 1,
+        "Weather Forecast": 2,
+        "Time Style 1": 4,
+        "Time Style 2": 5,
+        "Time Style 3": 6,
+        "Simple Weather Clock": 7,
+    }
+    SD_PRO_BUILTIN_MODES: ClassVar[dict[str, int]] = {
+        "Classic": 0,
+        "Weather": 1,
+        "Photo": 2,
+        "Dial": 3,
+        "Simple": 4,
+        "Weather Forecast": 5,
+        "Flip Clock": 6,
+    }
 
     def __init__(
         self,
@@ -75,12 +179,136 @@ class GeekMagicDevice:
         self._session = session
         self._owns_session = session is None
         self.model = model
+        self.model_name: str | None = None
+        self.firmware_version: str | None = None
+        self._last_theme: int | None = None
+        self._last_image: str | None = None
 
     async def _get_session(self) -> aiohttp.ClientSession:
         """Get or create the aiohttp session."""
         if self._session is None:
             self._session = aiohttp.ClientSession(timeout=TIMEOUT)
         return self._session
+
+    async def _check_device_response(self, response: aiohttp.ClientResponse, action: str) -> None:
+        """Raise for HTTP errors and firmware-level FAIL responses."""
+        response.raise_for_status()
+        try:
+            text = (await response.text()).strip()
+        except Exception:
+            return
+
+        if text.upper() == "FAIL":
+            raise RuntimeError(f"Device rejected {action}: {text}")
+
+    async def _get_json(self, path: str) -> dict[str, object]:
+        """Fetch a JSON object from the device."""
+        session = await self._get_session()
+        async with session.get(f"{self.base_url}{path}") as response:
+            response.raise_for_status()
+            data = await response.json(content_type=None)
+            if not isinstance(data, dict):
+                raise TypeError(f"Expected JSON object from {path}")
+            return data
+
+    async def _get_text(self, path: str) -> str:
+        """Fetch text from the device."""
+        try:
+            session = await self._get_session()
+            async with session.get(f"{self.base_url}{path}") as response:
+                response.raise_for_status()
+                return await response.text()
+        except aiohttp.ClientResponseError as err:
+            if self._is_malformed_firmware_response(err):
+                return (await self._raw_http_get(path)).decode(errors="replace")
+            raise
+
+    async def _get_bytes(self, path: str) -> bytes:
+        """Fetch bytes from the device."""
+        try:
+            session = await self._get_session()
+            async with session.get(f"{self.base_url}{path}") as response:
+                response.raise_for_status()
+                return await response.read()
+        except aiohttp.ClientResponseError as err:
+            if self._is_malformed_firmware_response(err):
+                return await self._raw_http_get(path)
+            raise
+
+    @staticmethod
+    def _is_malformed_firmware_response(err: aiohttp.ClientResponseError) -> bool:
+        """Return whether aiohttp rejected a known malformed device response."""
+        message = str(err.message) if err.message else ""
+        return err.status == 400 and (
+            "Duplicate Content-Length" in message or "Data after" in message
+        )
+
+    async def _raw_http_get(self, path: str) -> bytes:
+        """Fallback HTTP/1.0 GET for firmware responses aiohttp refuses to parse."""
+        parsed = urlparse(self.base_url)
+        host = parsed.hostname or self.host
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        if parsed.scheme == "https":
+            raise RuntimeError("Raw fallback only supports HTTP devices")
+
+        reader, writer = await asyncio.open_connection(host, port)
+        try:
+            request = f"GET {path} HTTP/1.0\r\nHost: {self.host}\r\nConnection: close\r\n\r\n"
+            writer.write(request.encode("ascii"))
+            await writer.drain()
+            raw = await reader.read()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+        header, _, body = raw.partition(b"\r\n\r\n")
+        status_line = header.splitlines()[0] if header else b""
+        if not status_line.startswith(b"HTTP/") or b" 200 " not in status_line:
+            raise RuntimeError(f"Raw HTTP GET failed for {path}: {status_line!r}")
+        return body
+
+    @staticmethod
+    def _optional_int(value: object) -> int | None:
+        """Parse an optional integer value returned by device JSON."""
+        if value is None or value == "":
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _state_from_data(data: dict[str, object]) -> DeviceState:
+        """Build DeviceState from a stock firmware state payload."""
+        return DeviceState(
+            theme=GeekMagicDevice._optional_int(data.get("theme")),
+            brightness=GeekMagicDevice._optional_int(data.get("brt")),
+            current_image=str(data["img"]) if data.get("img") else None,
+        )
+
+    @property
+    def custom_theme(self) -> int:
+        """Return the device theme used for custom uploaded images."""
+        if self.model == MODEL_SD_PRO:
+            return 2
+        return 4 if self.model == MODEL_PRO else 3
+
+    @property
+    def builtin_modes(self) -> dict[str, int]:
+        """Return built-in display modes for the detected model."""
+        if self.model == MODEL_PRO:
+            return self.PRO_BUILTIN_MODES
+        if self.model == MODEL_SD_PRO:
+            return self.SD_PRO_BUILTIN_MODES
+        return self.ULTRA_BUILTIN_MODES
+
+    def is_custom_theme(self, theme: int | None) -> bool:
+        """Return whether a device theme is the custom image mode."""
+        return theme == self.custom_theme
+
+    def is_builtin_theme(self, theme: int | None) -> bool:
+        """Return whether a device theme is handled by device firmware."""
+        return theme is not None and not self.is_custom_theme(theme)
 
     async def close(self) -> None:
         """Close the session if we own it."""
@@ -95,23 +323,46 @@ class GeekMagicDevice:
             DeviceState with theme, brightness, and current image
         """
         _LOGGER.debug("Getting device state from %s", self.host)
+        if self.model == MODEL_SD_PRO:
+            data = await self._get_json("/config")
+            return DeviceState(
+                theme=self._optional_int(data.get("theme")),
+                brightness=self._optional_int(data.get("brightness")),
+                current_image=None,
+            )
+
         session = await self._get_session()
-        async with session.get(f"{self.base_url}/app.json") as response:
-            response.raise_for_status()
-            # Device returns text/plain content type, so we need to accept any
-            data = await response.json(content_type=None)
-            state = DeviceState(
-                theme=data.get("theme", 0),
-                brightness=data.get("brt"),
-                current_image=data.get("img"),
+        paths = ["/.sys/app.json", "/app.json"] if self.model == MODEL_PRO else ["/app.json"]
+        last_404: aiohttp.ClientResponseError | None = None
+        for path in paths:
+            try:
+                async with session.get(f"{self.base_url}{path}") as response:
+                    response.raise_for_status()
+                    # Device returns text/plain content type, so we need to accept any
+                    data = await response.json(content_type=None)
+                    state = self._state_from_data(data)
+                    _LOGGER.debug(
+                        "Device state: theme=%s, brightness=%s, image=%s",
+                        state.theme,
+                        state.brightness,
+                        state.current_image,
+                    )
+                    return state
+            except aiohttp.ClientResponseError as err:
+                if self.model == MODEL_PRO and err.status == 404:
+                    last_404 = err
+                    continue
+                raise
+
+        if self.model == MODEL_PRO and last_404 is not None:
+            _LOGGER.debug("Pro firmware has no state path; using last known state")
+            return DeviceState(
+                theme=self._last_theme,
+                brightness=None,
+                current_image=self._last_image,
             )
-            _LOGGER.debug(
-                "Device state: theme=%d, brightness=%s, image=%s",
-                state.theme,
-                state.brightness,
-                state.current_image,
-            )
-            return state
+
+        raise RuntimeError("Device state was not read")
 
     async def get_space(self) -> SpaceInfo:
         """Get device storage information.
@@ -120,6 +371,10 @@ class GeekMagicDevice:
             SpaceInfo with total and free bytes
         """
         _LOGGER.debug("Getting storage info from %s", self.host)
+        if self.model == MODEL_SD_PRO:
+            photos = await self.get_sdpro_photo_settings()
+            return SpaceInfo(total=photos.total, free=max(0, photos.total - photos.used))
+
         session = await self._get_session()
         async with session.get(f"{self.base_url}/space.json") as response:
             response.raise_for_status()
@@ -144,8 +399,14 @@ class GeekMagicDevice:
             Brightness level 0-100
         """
         _LOGGER.debug("Getting brightness from %s", self.host)
+        if self.model == MODEL_SD_PRO:
+            data = await self._get_json("/config")
+            brightness = self._optional_int(data.get("brightness"))
+            return brightness or 0
+
         session = await self._get_session()
-        async with session.get(f"{self.base_url}/brt.json") as response:
+        path = "/.sys/brt.json" if self.model == MODEL_PRO else "/brt.json"
+        async with session.get(f"{self.base_url}{path}") as response:
             response.raise_for_status()
             data = await response.json(content_type=None)
             # API returns brightness as string: {"brt": "71"}
@@ -160,9 +421,19 @@ class GeekMagicDevice:
             value: Brightness level 0-100
         """
         value = max(0, min(100, value))
+        if self.model == MODEL_SD_PRO:
+            value = max(2, min(99, value))
+            session = await self._get_session()
+            async with session.get(
+                f"{self.base_url}/api/set?key=lcd_brightness&value={value}"
+            ) as response:
+                await self._check_device_response(response, "brightness update")
+            _LOGGER.debug("Set SD_PRO brightness to %d", value)
+            return
+
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?brt={value}") as response:
-            response.raise_for_status()
+            await self._check_device_response(response, "brightness update")
         _LOGGER.debug("Set brightness to %d", value)
 
     async def set_theme(self, theme: int) -> None:
@@ -171,10 +442,223 @@ class GeekMagicDevice:
         Args:
             theme: Theme number (3 = custom image on Ultra, 4 = custom image on Pro)
         """
+        if self.model == MODEL_SD_PRO:
+            session = await self._get_session()
+            async with session.get(f"{self.base_url}/api/set?key=theme&value={theme}") as response:
+                await self._check_device_response(response, "theme update")
+            self._last_theme = theme
+            _LOGGER.debug("Set SD_PRO theme to %d", theme)
+            return
+
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?theme={theme}") as response:
-            response.raise_for_status()
+            await self._check_device_response(response, "theme update")
+        self._last_theme = theme
         _LOGGER.debug("Set theme to %d", theme)
+
+    async def get_album_settings(self) -> AlbumSettings:
+        """Get photo album settings when exposed by stock firmware."""
+        session = await self._get_session()
+        path = "/.sys/album.json" if self.model == MODEL_PRO else "/album.json"
+        async with session.get(f"{self.base_url}{path}") as response:
+            response.raise_for_status()
+            data = await response.json(content_type=None)
+            return AlbumSettings(
+                interval=self._optional_int(data.get("i_i")),
+                gif_loop=self._optional_int(data.get("gif_loop")),
+                autoplay=self._optional_int(data.get("autoplay")),
+            )
+
+    async def set_album_display(
+        self,
+        interval: int | None = 1,
+        gif_loop: int | None = 1,
+        autoplay: int | None = 1,
+    ) -> None:
+        """Enable the Pro Picture album mode used for uploaded images."""
+        query_parts: list[str] = []
+        if interval is not None:
+            query_parts.append(f"i_i={max(1, interval)}")
+        if gif_loop is not None:
+            query_parts.append(f"gif_loop={max(1, gif_loop)}")
+        if autoplay is not None:
+            query_parts.append(f"autoplay={1 if autoplay else 0}")
+        if not query_parts:
+            return
+
+        session = await self._get_session()
+        async with session.get(f"{self.base_url}/set?{'&'.join(query_parts)}") as response:
+            await self._check_device_response(response, "album display update")
+        _LOGGER.debug(
+            "Updated album display interval=%s gif_loop=%s autoplay=%s",
+            interval,
+            gif_loop,
+            autoplay,
+        )
+
+    async def get_pro_image_files(self) -> list[DeviceFile]:
+        """List files in the stock firmware image album."""
+        html = await self._get_text("/filelist?dir=/image/")
+
+        files: list[DeviceFile] = []
+        pattern = re.compile(
+            r"<a href='(?P<path>[^']+)'>(?P<name>[^<]+)</a></td><td>(?P<size>[^<]+)</td>"
+        )
+        for match in pattern.finditer(html):
+            size = self._optional_int(match.group("size"))
+            files.append(
+                DeviceFile(
+                    name=match.group("name"),
+                    path=match.group("path"),
+                    size_kb=size,
+                )
+            )
+        return files
+
+    async def backup_pro_album_files(self) -> list[DeviceFileBackup]:
+        """Download the current stock firmware image album for later restore."""
+        return [
+            DeviceFileBackup(file=file, data=await self._get_bytes(file.path))
+            for file in await self.get_pro_image_files()
+        ]
+
+    async def restore_pro_album_files(self, backups: list[DeviceFileBackup]) -> None:
+        """Restore a previously backed-up stock firmware image album."""
+        await self.clear_pro_album_files()
+        for backup in backups:
+            await self.upload(backup.data, backup.file.name)
+
+    async def clear_pro_album_files(self) -> None:
+        """Clear the stock firmware image album, including files clear=image leaves behind."""
+        await self.clear_images()
+        for file in await self.get_pro_image_files():
+            await self.delete_file(file.path)
+
+    async def pro_image_exists(self, filename: str) -> bool:
+        """Return whether a stock firmware image album contains filename."""
+        return any(file.name == filename for file in await self.get_pro_image_files())
+
+    async def keep_only_pro_image(self, filename: str) -> None:
+        """Delete every Pro album file except filename."""
+        kept = False
+        for file in await self.get_pro_image_files():
+            if file.name == filename:
+                kept = True
+                continue
+            await self.delete_file(file.path)
+
+        if not kept:
+            raise RuntimeError(f"Uploaded image {filename} was not found in the Pro album")
+
+    async def get_sdpro_photo_settings(self) -> SdProPhotoSettings:
+        """Read SD_PRO photo slideshow settings."""
+        data = await self._get_json("/photo/list")
+        files_data = data.get("files", [])
+        files: list[SdProPhoto] = []
+        if isinstance(files_data, list):
+            for item in files_data:
+                if isinstance(item, dict):
+                    name = item.get("name")
+                    if name is not None:
+                        files.append(
+                            SdProPhoto(
+                                name=str(name),
+                                size=self._optional_int(item.get("size")) or 0,
+                                enabled=bool(item.get("enabled")),
+                            )
+                        )
+        return SdProPhotoSettings(
+            files=files,
+            total=self._optional_int(data.get("total")) or 0,
+            used=self._optional_int(data.get("used")) or 0,
+            interval=self._optional_int(data.get("interval")),
+        )
+
+    async def get_sdpro_theme_settings(self) -> SdProThemeSettings:
+        """Read SD_PRO theme rotation settings."""
+        data = await self._get_json("/theme/list")
+        themes_data = data.get("themes", [])
+        themes: list[SdProTheme] = []
+        if isinstance(themes_data, list):
+            for item in themes_data:
+                if isinstance(item, dict):
+                    theme_id = self._optional_int(item.get("id"))
+                    if theme_id is not None:
+                        themes.append(
+                            SdProTheme(
+                                id=theme_id,
+                                name=str(item.get("name", theme_id)),
+                                enabled=bool(item.get("enabled")),
+                            )
+                        )
+        return SdProThemeSettings(
+            themes=themes,
+            interval=self._optional_int(data.get("interval")),
+        )
+
+    async def set_sdpro_photo_enabled(self, name: str, enabled: bool) -> None:
+        """Enable or disable a photo in the SD_PRO slideshow."""
+        session = await self._get_session()
+        async with session.get(
+            f"{self.base_url}/photo/toggle?name={quote(name)}&state={1 if enabled else 0}"
+        ) as response:
+            await self._check_device_response(response, f"photo toggle {name}")
+
+    async def set_sdpro_photo_interval(self, interval: int) -> None:
+        """Set SD_PRO photo slideshow interval."""
+        interval = max(1, interval)
+        session = await self._get_session()
+        async with session.get(f"{self.base_url}/photo/interval?val={interval}") as response:
+            await self._check_device_response(response, "photo interval update")
+
+    async def set_sdpro_theme_enabled(self, theme_id: int, enabled: bool) -> None:
+        """Enable or disable a theme in the SD_PRO rotation."""
+        session = await self._get_session()
+        async with session.get(
+            f"{self.base_url}/theme/toggle?id={theme_id}&state={1 if enabled else 0}"
+        ) as response:
+            await self._check_device_response(response, f"theme toggle {theme_id}")
+
+    async def set_sdpro_theme_interval(self, interval: int) -> None:
+        """Set SD_PRO theme rotation interval."""
+        interval = max(0, interval)
+        session = await self._get_session()
+        async with session.get(f"{self.base_url}/theme/interval?val={interval}") as response:
+            await self._check_device_response(response, "theme interval update")
+
+    async def delete_sdpro_photo(self, name: str) -> None:
+        """Delete a photo from the SD_PRO slideshow."""
+        session = await self._get_session()
+        async with session.get(f"{self.base_url}/photo/delete?name={quote(name)}") as response:
+            await self._check_device_response(response, f"photo delete {name}")
+
+    async def upload_sdpro_photo(self, image_data: bytes, filename: str) -> None:
+        """Upload a photo to the SD_PRO slideshow."""
+        if filename.lower().endswith(".png"):
+            content_type = "image/png"
+        elif filename.lower().endswith(".gif"):
+            content_type = "image/gif"
+        else:
+            content_type = "image/jpeg"
+
+        form = aiohttp.FormData()
+        form.add_field("file", image_data, filename=filename, content_type=content_type)
+        session = await self._get_session()
+        async with session.post(f"{self.base_url}/photo/upload", data=form) as response:
+            response.raise_for_status()
+
+    async def prepare_sdpro_exclusive_photo(self, filename: str) -> None:
+        """Make one SD_PRO photo and the Photo theme active for visual testing."""
+        photos = await self.get_sdpro_photo_settings()
+        for photo in photos.files:
+            await self.set_sdpro_photo_enabled(photo.name, photo.name == filename)
+
+        themes = await self.get_sdpro_theme_settings()
+        for theme in themes.themes:
+            await self.set_sdpro_theme_enabled(theme.id, theme.id == self.custom_theme)
+
+        await self.set_sdpro_photo_interval(1)
+        await self.set_theme(self.custom_theme)
 
     async def set_theme_custom(self) -> None:
         """Set device to custom image mode with the correct theme number.
@@ -182,20 +666,44 @@ class GeekMagicDevice:
         Ultra devices use theme 3, Pro devices use theme 4.
         Uses the model detected at startup via detect_model().
         """
-        theme = 4 if self.model == MODEL_PRO else 3
-        await self.set_theme(theme)
+        await self.set_theme(self.custom_theme)
 
-    async def set_image(self, filename: str) -> None:
+    async def set_image(self, filename: str, enter_picture: bool = False) -> None:
         """Set the displayed image.
 
         Args:
             filename: Image filename (without path)
+            enter_picture: For Pro diagnostics, press buttons to enter Picture mode
         """
+        if self.model == MODEL_SD_PRO:
+            await self.prepare_sdpro_exclusive_photo(filename)
+            self._last_image = f"/photo/{filename}"
+            _LOGGER.debug("Set SD_PRO photo slideshow mode for %s", filename)
+            return
+
+        if self.model == MODEL_PRO:
+            # This Pro firmware accepts uploads but returns body "FAIL" for
+            # /set?img=... JPG selection. Its Picture mode is album-based.
+            # Optional button navigation is kept for explicit live diagnostics,
+            # but HA does not use it because the Pro menu state is not exposed.
+            await self.set_album_display()
+            await self.set_theme_custom()
+            if enter_picture:
+                await self.navigate_enter()
+                await asyncio.sleep(0.5)
+                await self.navigate_next()
+                await asyncio.sleep(0.5)
+                await self.navigate_enter()
+            self._last_image = f"/image/{filename}"
+            _LOGGER.debug("Set Pro album image mode for %s", filename)
+            return
+
         # Ensure we're in custom image mode
         await self.set_theme_custom()
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?img=/image/{filename}") as response:
-            response.raise_for_status()
+            await self._check_device_response(response, f"image selection for {filename}")
+        self._last_image = f"/image/{filename}"
         _LOGGER.debug("Set image to %s", filename)
 
     async def upload(self, image_data: bytes, filename: str) -> None:
@@ -222,6 +730,11 @@ class GeekMagicDevice:
             content_type=content_type,
         )
 
+        if self.model == MODEL_SD_PRO:
+            await self.upload_sdpro_photo(image_data, filename)
+            _LOGGER.debug("Uploaded SD_PRO photo %s (%d bytes)", filename, len(image_data))
+            return
+
         session = await self._get_session()
         try:
             async with session.post(
@@ -240,15 +753,36 @@ class GeekMagicDevice:
                     _LOGGER.debug("Ignoring malformed HTTP response from device: %s", msg)
                     return
             raise
+        except aiohttp.ClientError as err:
+            if self.model == MODEL_PRO:
+                try:
+                    if await self.pro_image_exists(filename):
+                        _LOGGER.debug(
+                            "Treating Pro upload connection error as success; %s is present: %s",
+                            filename,
+                            err,
+                        )
+                        return
+                except Exception as verify_err:
+                    _LOGGER.debug("Could not verify Pro upload after error: %s", verify_err)
+            raise
 
         _LOGGER.debug("Uploaded %s (%d bytes)", filename, len(image_data))
 
-    async def upload_and_display(self, image_data: bytes, filename: str) -> None:
+    async def upload_and_display(
+        self,
+        image_data: bytes,
+        filename: str,
+        manage_album: bool = False,
+        enter_picture: bool = False,
+    ) -> None:
         """Upload an image and immediately display it.
 
         Args:
             image_data: Raw image bytes
             filename: Filename to save as
+            manage_album: For Pro, delete all other album files after upload
+            enter_picture: For Pro diagnostics, press buttons to enter Picture mode
         """
         _LOGGER.debug(
             "Uploading and displaying %s (%d bytes) to %s",
@@ -257,8 +791,110 @@ class GeekMagicDevice:
             self.host,
         )
         await self.upload(image_data, filename)
-        await self.set_image(filename)
+        if self.model == MODEL_PRO and manage_album:
+            await self.keep_only_pro_image(filename)
+        await self.set_image(filename, enter_picture=enter_picture)
         _LOGGER.debug("Upload and display completed for %s", filename)
+
+    async def backup_settings(self) -> DeviceSettingsBackup:
+        """Take a best-effort snapshot of settings changed by smoke tests."""
+        state: DeviceState | None = None
+        brightness: int | None = None
+        album: AlbumSettings | None = None
+        sdpro_photos: SdProPhotoSettings | None = None
+        sdpro_themes: SdProThemeSettings | None = None
+        sdpro_active_theme: int | None = None
+
+        try:
+            state = await self.get_state()
+            if self.model == MODEL_SD_PRO:
+                sdpro_active_theme = state.theme
+        except Exception as err:
+            _LOGGER.debug("Could not back up device state: %s", err)
+
+        try:
+            brightness = await self.get_brightness()
+        except Exception as err:
+            _LOGGER.debug("Could not back up brightness: %s", err)
+
+        if self.model == MODEL_PRO:
+            try:
+                album = await self.get_album_settings()
+            except Exception as err:
+                _LOGGER.debug("Could not back up album settings: %s", err)
+
+        if self.model == MODEL_SD_PRO:
+            try:
+                sdpro_photos = await self.get_sdpro_photo_settings()
+            except Exception as err:
+                _LOGGER.debug("Could not back up SD_PRO photo settings: %s", err)
+            try:
+                sdpro_themes = await self.get_sdpro_theme_settings()
+            except Exception as err:
+                _LOGGER.debug("Could not back up SD_PRO theme settings: %s", err)
+
+        return DeviceSettingsBackup(
+            state=state,
+            brightness=brightness,
+            album=album,
+            sdpro_photos=sdpro_photos,
+            sdpro_themes=sdpro_themes,
+            sdpro_active_theme=sdpro_active_theme,
+        )
+
+    async def restore_settings(self, backup: DeviceSettingsBackup) -> None:
+        """Restore settings captured by backup_settings()."""
+        if backup.brightness is not None:
+            await self.set_brightness(backup.brightness)
+
+        if self.model == MODEL_PRO and backup.pro_album_files is not None:
+            await self.restore_pro_album_files(backup.pro_album_files)
+
+        if self.model == MODEL_PRO and backup.album is not None:
+            await self.set_album_display(
+                interval=backup.album.interval,
+                gif_loop=backup.album.gif_loop,
+                autoplay=backup.album.autoplay,
+            )
+
+        if self.model == MODEL_SD_PRO:
+            if backup.sdpro_photos is not None:
+                for photo in backup.sdpro_photos.files:
+                    await self.set_sdpro_photo_enabled(photo.name, photo.enabled)
+                if backup.sdpro_photos.interval is not None:
+                    await self.set_sdpro_photo_interval(backup.sdpro_photos.interval)
+
+            if backup.sdpro_themes is not None:
+                for theme in backup.sdpro_themes.themes:
+                    await self.set_sdpro_theme_enabled(theme.id, theme.enabled)
+                if backup.sdpro_themes.interval is not None:
+                    await self.set_sdpro_theme_interval(backup.sdpro_themes.interval)
+
+            if backup.sdpro_active_theme is not None:
+                await self.set_theme(backup.sdpro_active_theme)
+                return
+
+        if backup.state is None or backup.state.theme is None:
+            return
+
+        if (
+            self.model != MODEL_PRO
+            and backup.state.current_image
+            and self.is_custom_theme(backup.state.theme)
+        ):
+            await self.set_theme(backup.state.theme)
+            await self._select_image_path(backup.state.current_image)
+            return
+
+        await self.set_theme(backup.state.theme)
+
+    async def _select_image_path(self, image_path: str) -> None:
+        """Select an uploaded image path on firmware that supports it."""
+        session = await self._get_session()
+        async with session.get(f"{self.base_url}/set?img={image_path}") as response:
+            await self._check_device_response(response, f"image selection for {image_path}")
+        self._last_image = image_path
+        _LOGGER.debug("Set image path to %s", image_path)
 
     async def delete_file(self, path: str) -> None:
         """Delete a file from the device.
@@ -268,17 +904,17 @@ class GeekMagicDevice:
         """
         session = await self._get_session()
         async with session.get(f"{self.base_url}/delete?file={path}") as response:
-            response.raise_for_status()
+            await self._check_device_response(response, f"delete {path}")
         _LOGGER.debug("Deleted %s", path)
 
     async def clear_images(self) -> None:
         """Clear all images from the device."""
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?clear=image") as response:
-            response.raise_for_status()
+            await self._check_device_response(response, "clear images")
         _LOGGER.debug("Cleared all images")
 
-    async def test_connection(self) -> ConnectionResult:
+    async def test_connection(self) -> ConnectionResult:  # noqa: PLR0911
         """Test if the device is reachable.
 
         Returns:
@@ -311,6 +947,19 @@ class GeekMagicDevice:
                 message=str(e),
             )
         except aiohttp.ClientResponseError as e:
+            if e.status == 404 and self.model == MODEL_UNKNOWN:
+                await self.detect_model()
+                if self.model == MODEL_SD_PRO:
+                    try:
+                        await self.get_space()
+                    except Exception as retry_err:
+                        _LOGGER.warning(
+                            "SD_PRO connection retry failed for %s: %s",
+                            self.host,
+                            retry_err,
+                        )
+                    else:
+                        return ConnectionResult(success=True)
             _LOGGER.warning("HTTP error for %s: %s", self.host, e)
             return ConnectionResult(
                 success=False,
@@ -338,7 +987,7 @@ class GeekMagicDevice:
         """
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?page=1") as response:
-            response.raise_for_status()
+            await self._check_device_response(response, "navigate next")
         _LOGGER.debug("Navigated to next page")
 
     async def navigate_previous(self) -> None:
@@ -348,7 +997,7 @@ class GeekMagicDevice:
         """
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?page=-1") as response:
-            response.raise_for_status()
+            await self._check_device_response(response, "navigate previous")
         _LOGGER.debug("Navigated to previous page")
 
     async def navigate_enter(self) -> None:
@@ -358,23 +1007,58 @@ class GeekMagicDevice:
         """
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?enter=-1") as response:
-            response.raise_for_status()
+            await self._check_device_response(response, "navigate enter")
         _LOGGER.debug("Pressed enter button")
 
     async def reboot(self) -> None:
         """Reboot the device (Pro devices)."""
         session = await self._get_session()
         async with session.get(f"{self.base_url}/set?reboot=1") as response:
-            response.raise_for_status()
+            await self._check_device_response(response, "reboot")
         _LOGGER.debug("Rebooting device")
 
     async def detect_model(self) -> str:
         """Attempt to detect the device model.
 
-        Pro devices use /.sys/ paths, Ultra devices use root paths.
+        Newer stock firmware exposes identity through /v.json. Older firmware
+        may only expose model-specific state paths.
         Returns MODEL_PRO, MODEL_ULTRA, or MODEL_UNKNOWN.
         """
         session = await self._get_session()
+
+        # Current stock firmware exposes a reliable model/version endpoint.
+        try:
+            async with session.get(
+                f"{self.base_url}/v.json", timeout=aiohttp.ClientTimeout(total=5)
+            ) as response:
+                if response.status == 200:
+                    data = await response.json(content_type=None)
+                    model_name = str(data.get("m", ""))
+                    firmware_version = data.get("v")
+                    self.model_name = model_name or None
+                    self.firmware_version = (
+                        str(firmware_version) if firmware_version is not None else None
+                    )
+
+                    model_key = model_name.lower()
+                    if "pro" in model_key:
+                        self.model = MODEL_PRO
+                        _LOGGER.info(
+                            "Detected device model: %s (%s)",
+                            self.model_name,
+                            self.firmware_version,
+                        )
+                        return self.model
+                    if "ultra" in model_key:
+                        self.model = MODEL_ULTRA
+                        _LOGGER.info(
+                            "Detected device model: %s (%s)",
+                            self.model_name,
+                            self.firmware_version,
+                        )
+                        return self.model
+        except Exception as err:
+            _LOGGER.debug("Identity path /v.json not available: %s", err)
 
         # Try Pro-specific path first (/.sys/app.json)
         try:
@@ -383,6 +1067,7 @@ class GeekMagicDevice:
             ) as response:
                 if response.status == 200:
                     self.model = MODEL_PRO
+                    self.model_name = "SmallTV Pro"
                     _LOGGER.info("Detected device model: SmallTV Pro")
                     return self.model
         except Exception as err:
@@ -395,10 +1080,26 @@ class GeekMagicDevice:
             ) as response:
                 if response.status == 200:
                     self.model = MODEL_ULTRA
+                    self.model_name = "SmallTV Ultra"
                     _LOGGER.info("Detected device model: SmallTV Ultra")
                     return self.model
         except Exception as err:
             _LOGGER.debug("Ultra path /app.json not available: %s", err)
+
+        # SD_PRO community firmware exposes /theme/list and /photo/list instead.
+        try:
+            async with session.get(
+                f"{self.base_url}/theme/list", timeout=aiohttp.ClientTimeout(total=5)
+            ) as response:
+                if response.status == 200:
+                    data = await response.json(content_type=None)
+                    if isinstance(data.get("themes"), list):
+                        self.model = MODEL_SD_PRO
+                        self.model_name = "SD_PRO Community Firmware"
+                        _LOGGER.info("Detected device model: SD_PRO Community Firmware")
+                        return self.model
+        except Exception as err:
+            _LOGGER.debug("SD_PRO path /theme/list not available: %s", err)
 
         _LOGGER.warning("Could not detect device model for %s", self.host)
         return MODEL_UNKNOWN

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -53,9 +53,11 @@ class GeekMagicDevice:
         host: str,
         session: aiohttp.ClientSession | None = None,
         model: str = MODEL_UNKNOWN,
+        *,
+        source_address: str | None = None,
     ) -> None:
         """Initialize the device facade."""
-        self.transport = DeviceTransport(host, session=session)
+        self.transport = DeviceTransport(host, session=session, source_address=source_address)
         self.profile: FirmwareProfile = profile_for_model(model, self.transport)
 
     @property

--- a/custom_components/geekmagic/entities/base.py
+++ b/custom_components/geekmagic/entities/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ..const import DOMAIN, MODEL_PRO, MODEL_ULTRA
+from ..const import DOMAIN
 
 if TYPE_CHECKING:
     from ..coordinator import GeekMagicCoordinator
@@ -31,13 +31,13 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
     @property
     def _device_model_name(self) -> str:
         """Return human-readable device model name."""
-        if self.coordinator.device.model_name:
-            return self.coordinator.device.model_name
-        model = self.coordinator.device.model
-        if model == MODEL_PRO:
-            return "SmallTV Pro"
-        if model == MODEL_ULTRA:
-            return "SmallTV Ultra"
+        capabilities = getattr(self.coordinator.device, "capabilities", None)
+        display_name = getattr(capabilities, "display_name", None)
+        if isinstance(display_name, str) and display_name:
+            return display_name
+        model_name = self.coordinator.device.model_name
+        if isinstance(model_name, str) and model_name:
+            return model_name
         return "SmallTV"
 
     @property
@@ -49,6 +49,12 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
             manufacturer="GeekMagic",
             model=self._device_model_name,
         )
-        if self.coordinator.device.firmware_version:
-            device_info["sw_version"] = self.coordinator.device.firmware_version
+        capabilities = getattr(self.coordinator.device, "capabilities", None)
+        firmware_version = (
+            getattr(capabilities, "firmware_version", None)
+            if capabilities is not None
+            else self.coordinator.device.firmware_version
+        )
+        if isinstance(firmware_version, str) and firmware_version:
+            device_info["sw_version"] = firmware_version
         return device_info

--- a/custom_components/geekmagic/entities/base.py
+++ b/custom_components/geekmagic/entities/base.py
@@ -31,6 +31,8 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
     @property
     def _device_model_name(self) -> str:
         """Return human-readable device model name."""
+        if self.coordinator.device.model_name:
+            return self.coordinator.device.model_name
         model = self.coordinator.device.model
         if model == MODEL_PRO:
             return "SmallTV Pro"
@@ -41,9 +43,12 @@ class GeekMagicEntity(CoordinatorEntity["GeekMagicCoordinator"]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
-        return DeviceInfo(
+        device_info = DeviceInfo(
             identifiers={(DOMAIN, self.coordinator.entry.entry_id)},
             name=self.coordinator.entry.title,
             manufacturer="GeekMagic",
             model=self._device_model_name,
         )
+        if self.coordinator.device.firmware_version:
+            device_info["sw_version"] = self.coordinator.device.firmware_version
+        return device_info

--- a/custom_components/geekmagic/entities/select.py
+++ b/custom_components/geekmagic/entities/select.py
@@ -19,18 +19,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Built-in device modes with their theme numbers
-# These are handled by the device firmware, not rendered by the integration
-# Theme 3 (Photo Album) is intentionally omitted - used for custom rendered views
-BUILTIN_MODES = {
-    "Weather Clock Today": 1,
-    "Weather Forecast": 2,
-    "Time Style 1": 4,
-    "Time Style 2": 5,
-    "Time Style 3": 6,
-    "Simple Weather Clock": 7,
-}
-
 # Prefix used to identify custom views in the combined select
 CUSTOM_VIEW_PREFIX = ""  # No prefix - views shown by name directly
 
@@ -86,13 +74,17 @@ class GeekMagicDisplaySelect(GeekMagicEntity, SelectEntity):
                 names.append(view.get("name", view_id))
         return names
 
+    def _get_builtin_modes(self) -> dict[str, int]:
+        """Get built-in modes for the active device profile."""
+        return self.coordinator.device.builtin_modes
+
     @property
     def options(self) -> list[str]:
         """Return all available display options.
 
         Built-in modes come first, followed by custom views.
         """
-        options = list(BUILTIN_MODES.keys())
+        options = list(self._get_builtin_modes().keys())
         options.extend(self._get_custom_view_names())
         return options or ["Clock"]
 
@@ -102,7 +94,7 @@ class GeekMagicDisplaySelect(GeekMagicEntity, SelectEntity):
         # Check if coordinator is in builtin mode
         if self.coordinator.display_mode == "builtin":
             theme = self.coordinator.builtin_theme
-            for mode_name, mode_theme in BUILTIN_MODES.items():
+            for mode_name, mode_theme in self._get_builtin_modes().items():
                 if mode_theme == theme:
                     return mode_name
             return "Clock"
@@ -121,9 +113,10 @@ class GeekMagicDisplaySelect(GeekMagicEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Handle selection of a display option."""
-        if option in BUILTIN_MODES:
+        builtin_modes = self._get_builtin_modes()
+        if option in builtin_modes:
             # Built-in mode selected - set device theme and enter builtin mode
-            theme = BUILTIN_MODES[option]
+            theme = builtin_modes[option]
             _LOGGER.debug("Switching to built-in mode: %s (theme=%d)", option, theme)
             await self.coordinator.device.set_theme(theme)
             self.coordinator.set_display_mode("builtin", theme)

--- a/custom_components/geekmagic/image.py
+++ b/custom_components/geekmagic/image.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.components.image import ImageEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -59,12 +59,21 @@ class GeekMagicPreviewImage(ImageEntity):
 
         # Entity attributes
         self._attr_unique_id = f"{entry.data[CONF_HOST]}_preview"
+        capabilities = getattr(coordinator.device, "capabilities", None)
+        model_name = getattr(capabilities, "display_name", None) or coordinator.device.model_name
+        firmware_version = (
+            getattr(capabilities, "firmware_version", None)
+            if capabilities is not None
+            else coordinator.device.firmware_version
+        )
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, entry.data[CONF_HOST])},
-            "name": entry.data.get(CONF_NAME, "GeekMagic Display"),
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": entry.title,
             "manufacturer": "GeekMagic",
-            "model": "SmallTV Pro",
+            "model": model_name or "SmallTV",
         }
+        if firmware_version:
+            self._attr_device_info["sw_version"] = firmware_version
 
         # Set initial timestamp
         if coordinator.last_image is not None:

--- a/custom_components/geekmagic/live_transaction.py
+++ b/custom_components/geekmagic/live_transaction.py
@@ -1,0 +1,143 @@
+"""Live-device mutation backup and restore helpers."""
+
+from __future__ import annotations
+
+import logging
+
+from .const import MODEL_PRO, MODEL_SD_PRO
+from .device import GeekMagicDevice
+from .models import DeviceSettingsBackup, DeviceState
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def backup_settings(device: GeekMagicDevice) -> DeviceSettingsBackup:
+    """Take a best-effort snapshot of settings changed by live smoke tests."""
+    state: DeviceState | None = None
+    brightness: int | None = None
+    album = None
+    sdpro_photos = None
+    sdpro_themes = None
+    sdpro_active_theme: int | None = None
+
+    try:
+        state = await device.get_state()
+        if device.profile_id == MODEL_SD_PRO:
+            sdpro_active_theme = state.theme
+    except Exception as err:
+        _LOGGER.debug("Could not back up device state: %s", err)
+
+    try:
+        brightness = await device.get_brightness()
+    except Exception as err:
+        _LOGGER.debug("Could not back up brightness: %s", err)
+
+    if device.profile_id == MODEL_PRO:
+        try:
+            album = await device.get_album_settings()
+        except Exception as err:
+            _LOGGER.debug("Could not back up album settings: %s", err)
+
+    if device.profile_id == MODEL_SD_PRO:
+        try:
+            sdpro_photos = await device.get_sdpro_photo_settings()
+        except Exception as err:
+            _LOGGER.debug("Could not back up SD_PRO photo settings: %s", err)
+        try:
+            sdpro_themes = await device.get_sdpro_theme_settings()
+        except Exception as err:
+            _LOGGER.debug("Could not back up SD_PRO theme settings: %s", err)
+
+    return DeviceSettingsBackup(
+        state=state,
+        brightness=brightness,
+        album=album,
+        sdpro_photos=sdpro_photos,
+        sdpro_themes=sdpro_themes,
+        sdpro_active_theme=sdpro_active_theme,
+    )
+
+
+async def restore_settings(device: GeekMagicDevice, backup: DeviceSettingsBackup) -> None:
+    """Restore settings captured before a live smoke test."""
+    if backup.brightness is not None:
+        await device.set_brightness(backup.brightness)
+
+    if device.profile_id == MODEL_PRO and backup.pro_album_files is not None:
+        await device.restore_pro_album_files(backup.pro_album_files)
+
+    if device.profile_id == MODEL_PRO and backup.album is not None:
+        await device.set_album_display(
+            interval=backup.album.interval,
+            gif_loop=backup.album.gif_loop,
+            autoplay=backup.album.autoplay,
+        )
+
+    if device.profile_id == MODEL_SD_PRO:
+        if backup.sdpro_photos is not None:
+            for photo in backup.sdpro_photos.files:
+                await device.set_sdpro_photo_enabled(photo.name, photo.enabled)
+            if backup.sdpro_photos.interval is not None:
+                await device.set_sdpro_photo_interval(backup.sdpro_photos.interval)
+
+        if backup.sdpro_themes is not None:
+            for theme in backup.sdpro_themes.themes:
+                await device.set_sdpro_theme_enabled(theme.id, theme.enabled)
+            if backup.sdpro_themes.interval is not None:
+                await device.set_sdpro_theme_interval(backup.sdpro_themes.interval)
+
+        if backup.sdpro_active_theme is not None:
+            await device.set_theme(backup.sdpro_active_theme)
+            return
+
+    if backup.state is None or backup.state.theme is None:
+        return
+
+    if (
+        device.profile_id != MODEL_PRO
+        and backup.state.current_image
+        and device.is_custom_theme(backup.state.theme)
+    ):
+        await device.set_theme(backup.state.theme)
+        await device.select_image_path(backup.state.current_image)
+        return
+
+    await device.set_theme(backup.state.theme)
+
+
+async def backup_and_clear_album(
+    device: GeekMagicDevice,
+    backup: DeviceSettingsBackup,
+) -> int | None:
+    """Back up and clear images for firmware profiles that support it."""
+    if device.profile_id == MODEL_PRO:
+        backup.pro_album_files = await device.backup_pro_album_files()
+        await device.clear_pro_album_files()
+        return len(backup.pro_album_files)
+
+    if device.profile_id == MODEL_SD_PRO:
+        return None
+
+    await device.clear_images()
+    return 0
+
+
+async def cleanup_uploaded_sdpro_photo(
+    device: GeekMagicDevice,
+    backup: DeviceSettingsBackup,
+    filename: str,
+) -> bool:
+    """Remove an uploaded SD_PRO test photo when it was not present before."""
+    if device.profile_id != MODEL_SD_PRO:
+        return False
+
+    names = (
+        {photo.name for photo in backup.sdpro_photos.files}
+        if backup.sdpro_photos is not None
+        else set()
+    )
+    if filename in names:
+        return False
+
+    await device.delete_sdpro_photo(filename)
+    return True

--- a/custom_components/geekmagic/models.py
+++ b/custom_components/geekmagic/models.py
@@ -1,0 +1,139 @@
+"""Shared models for GeekMagic devices and firmware profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+@dataclass
+class ConnectionResult:
+    """Result of a connection test."""
+
+    success: bool
+    error: Literal[
+        "none", "timeout", "connection_refused", "dns_error", "http_error", "unknown"
+    ] = "none"
+    message: str | None = None
+
+    def __bool__(self) -> bool:
+        """Allow using ConnectionResult in boolean context."""
+        return self.success
+
+
+@dataclass
+class DeviceState:
+    """Represents the current device state."""
+
+    theme: int | None
+    brightness: int | None
+    current_image: str | None
+
+
+@dataclass
+class AlbumSettings:
+    """Represents stock firmware photo album settings."""
+
+    interval: int | None
+    gif_loop: int | None
+    autoplay: int | None
+
+
+@dataclass
+class DeviceFile:
+    """Represents a file stored on stock firmware."""
+
+    name: str
+    path: str
+    size_kb: int | None = None
+
+
+@dataclass
+class DeviceFileBackup:
+    """Represents a backed-up device file."""
+
+    file: DeviceFile
+    data: bytes
+
+
+@dataclass
+class SdProPhoto:
+    """Represents one SD_PRO slideshow file."""
+
+    name: str
+    size: int
+    enabled: bool
+
+
+@dataclass
+class SdProPhotoSettings:
+    """Represents SD_PRO photo slideshow settings."""
+
+    files: list[SdProPhoto]
+    total: int
+    used: int
+    interval: int | None
+
+
+@dataclass
+class SdProTheme:
+    """Represents one SD_PRO firmware theme."""
+
+    id: int
+    name: str
+    enabled: bool
+
+
+@dataclass
+class SdProThemeSettings:
+    """Represents SD_PRO theme rotation settings."""
+
+    themes: list[SdProTheme]
+    interval: int | None
+
+
+@dataclass
+class SpaceInfo:
+    """Represents device storage info."""
+
+    total: int
+    free: int
+
+
+@dataclass
+class DeviceSettingsBackup:
+    """Best-effort snapshot of mutable device settings."""
+
+    state: DeviceState | None
+    brightness: int | None
+    album: AlbumSettings | None
+    pro_album_files: list[DeviceFileBackup] | None = None
+    sdpro_photos: SdProPhotoSettings | None = None
+    sdpro_themes: SdProThemeSettings | None = None
+    sdpro_active_theme: int | None = None
+
+
+@dataclass(frozen=True)
+class FirmwareCapabilities:
+    """Capabilities exposed by a detected firmware profile."""
+
+    profile_id: str
+    display_name: str
+    firmware_version: str | None = None
+    supports_rendered_dashboard: bool = True
+    builtin_modes: dict[str, int] = field(default_factory=dict)
+    custom_image_theme: int | None = None
+    display_mechanism: str = "direct_image"
+    brightness_range: tuple[int, int] = (0, 100)
+    user_warnings: tuple[str, ...] = ()
+    requires_managed_album: bool = False
+
+
+@dataclass(frozen=True)
+class RenderedDashboardRequest:
+    """Request to upload and make a rendered dashboard visible."""
+
+    image_data: bytes
+    filename: str
+    allow_destructive_album_management: bool = False
+    try_menu_navigation: bool = False

--- a/custom_components/geekmagic/profiles.py
+++ b/custom_components/geekmagic/profiles.py
@@ -1,0 +1,772 @@
+"""Firmware profile adapters for GeekMagic devices."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from collections.abc import Mapping
+from typing import Any, cast
+from urllib.parse import quote
+
+import aiohttp
+
+from .const import MODEL_PRO, MODEL_SD_PRO, MODEL_ULTRA, MODEL_UNKNOWN
+from .models import (
+    AlbumSettings,
+    DeviceFile,
+    DeviceFileBackup,
+    DeviceState,
+    FirmwareCapabilities,
+    RenderedDashboardRequest,
+    SdProPhoto,
+    SdProPhotoSettings,
+    SdProTheme,
+    SdProThemeSettings,
+    SpaceInfo,
+)
+from .transport import DeviceTransport
+
+_LOGGER = logging.getLogger(__name__)
+
+PRO_BUILTIN_MODES: dict[str, int] = {
+    "Bitcoin": 0,
+    "CoinGecko": 1,
+    "Stocks": 2,
+    "Weather": 3,
+    "Monitor": 5,
+    "Clock": 6,
+    "Ideas": 7,
+}
+
+ULTRA_BUILTIN_MODES: dict[str, int] = {
+    "Weather Clock Today": 1,
+    "Weather Forecast": 2,
+    "Time Style 1": 4,
+    "Time Style 2": 5,
+    "Time Style 3": 6,
+    "Simple Weather Clock": 7,
+}
+
+SD_PRO_BUILTIN_MODES: dict[str, int] = {
+    "Classic": 0,
+    "Weather": 1,
+    "Photo": 2,
+    "Dial": 3,
+    "Simple": 4,
+    "Weather Forecast": 5,
+    "Flip Clock": 6,
+}
+
+PRO_PICTURE_WARNING = (
+    "SmallTV Pro Picture mode is a slideshow. Manually select the Picture app "
+    "on the device; the integration will not press menu buttons automatically."
+)
+
+
+def optional_int(value: object) -> int | None:
+    """Parse an optional integer value returned by device JSON."""
+    if value is None:
+        return None
+    if isinstance(value, str) and value == "":
+        return None
+    try:
+        return int(cast("Any", value))
+    except (TypeError, ValueError):
+        return None
+
+
+def content_type_for_filename(filename: str) -> str:
+    """Return a multipart content type for an uploaded file."""
+    if filename.lower().endswith(".png"):
+        return "image/png"
+    if filename.lower().endswith(".gif"):
+        return "image/gif"
+    return "image/jpeg"
+
+
+def state_from_stock_data(data: dict[str, object]) -> DeviceState:
+    """Build DeviceState from a stock firmware state payload."""
+    return DeviceState(
+        theme=optional_int(data.get("theme")),
+        brightness=optional_int(data.get("brt")),
+        current_image=str(data["img"]) if data.get("img") else None,
+    )
+
+
+class FirmwareProfile:
+    """Base adapter for a GeekMagic firmware profile."""
+
+    profile_id = MODEL_UNKNOWN
+    default_display_name = "SmallTV"
+    default_builtin_modes: dict[str, int] = ULTRA_BUILTIN_MODES
+    custom_image_theme: int | None = 3
+    display_mechanism = "direct_image"
+    brightness_range = (0, 100)
+    user_warnings: tuple[str, ...] = ()
+    supports_rendered_dashboard = False
+    requires_managed_album = False
+
+    def __init__(
+        self,
+        transport: DeviceTransport,
+        *,
+        profile_id: str | None = None,
+        model_name: str | None = None,
+        firmware_version: str | None = None,
+    ) -> None:
+        """Initialize the firmware profile adapter."""
+        self.transport = transport
+        self._profile_id = profile_id or self.profile_id
+        self.model_name = model_name
+        self.firmware_version = firmware_version
+        self._last_theme: int | None = None
+        self._last_image: str | None = None
+
+    @property
+    def capabilities(self) -> FirmwareCapabilities:
+        """Return firmware capabilities for runtime/UI callers."""
+        return FirmwareCapabilities(
+            profile_id=self._profile_id,
+            display_name=self.model_name or self.default_display_name,
+            firmware_version=self.firmware_version,
+            supports_rendered_dashboard=self.supports_rendered_dashboard,
+            builtin_modes=dict(self.default_builtin_modes),
+            custom_image_theme=self.custom_image_theme,
+            display_mechanism=self.display_mechanism,
+            brightness_range=self.brightness_range,
+            user_warnings=self.user_warnings,
+            requires_managed_album=self.requires_managed_album,
+        )
+
+    @property
+    def last_theme(self) -> int | None:
+        """Return the last theme selected by this profile adapter."""
+        return self._last_theme
+
+    @last_theme.setter
+    def last_theme(self, value: int | None) -> None:
+        self._last_theme = value
+
+    @property
+    def last_image(self) -> str | None:
+        """Return the last image selected by this profile adapter."""
+        return self._last_image
+
+    @last_image.setter
+    def last_image(self, value: str | None) -> None:
+        self._last_image = value
+
+    @property
+    def builtin_modes(self) -> dict[str, int]:
+        """Return built-in display modes."""
+        return self.capabilities.builtin_modes
+
+    async def get_state(self) -> DeviceState:
+        """Get current device state."""
+        data = await self.transport.get_json("/app.json")
+        state = state_from_stock_data(data)
+        _LOGGER.debug(
+            "Device state: theme=%s, brightness=%s, image=%s",
+            state.theme,
+            state.brightness,
+            state.current_image,
+        )
+        return state
+
+    async def get_space(self) -> SpaceInfo:
+        """Get device storage information."""
+        data = await self.transport.get_json("/space.json")
+        space = SpaceInfo(
+            total=optional_int(data.get("total")) or 0,
+            free=optional_int(data.get("free")) or 0,
+        )
+        _LOGGER.debug(
+            "Storage info: total=%d, free=%d (%.1f%% free)",
+            space.total,
+            space.free,
+            (space.free / space.total * 100) if space.total > 0 else 0,
+        )
+        return space
+
+    async def get_brightness(self) -> int:
+        """Get current brightness from device."""
+        data = await self.transport.get_json("/brt.json")
+        brightness = optional_int(data.get("brt")) or 0
+        _LOGGER.debug("Device brightness: %d", brightness)
+        return brightness
+
+    async def set_brightness(self, value: int) -> None:
+        """Set display brightness."""
+        low, high = self.brightness_range
+        value = max(low, min(high, value))
+        await self.transport.get_checked(f"/set?brt={value}", "brightness update")
+        _LOGGER.debug("Set brightness to %d", value)
+
+    async def set_theme(self, theme: int) -> None:
+        """Set device theme."""
+        await self.transport.get_checked(f"/set?theme={theme}", "theme update")
+        self._last_theme = theme
+        _LOGGER.debug("Set theme to %d", theme)
+
+    async def set_theme_custom(self) -> None:
+        """Set device to custom image mode."""
+        if self.custom_image_theme is None:
+            raise RuntimeError("Firmware profile has no custom image theme")
+        await self.set_theme(self.custom_image_theme)
+
+    async def get_album_settings(self) -> AlbumSettings:
+        """Get photo album settings when exposed by stock firmware."""
+        data = await self.transport.get_json("/album.json")
+        return AlbumSettings(
+            interval=optional_int(data.get("i_i")),
+            gif_loop=optional_int(data.get("gif_loop")),
+            autoplay=optional_int(data.get("autoplay")),
+        )
+
+    async def set_album_display(
+        self,
+        interval: int | None = 1,
+        gif_loop: int | None = 1,
+        autoplay: int | None = 1,
+    ) -> None:
+        """Enable album display behavior used for uploaded images."""
+        query_parts: list[str] = []
+        if interval is not None:
+            query_parts.append(f"i_i={max(1, interval)}")
+        if gif_loop is not None:
+            query_parts.append(f"gif_loop={max(1, gif_loop)}")
+        if autoplay is not None:
+            query_parts.append(f"autoplay={1 if autoplay else 0}")
+        if not query_parts:
+            return
+
+        await self.transport.get_checked(
+            f"/set?{'&'.join(query_parts)}",
+            "album display update",
+        )
+        _LOGGER.debug(
+            "Updated album display interval=%s gif_loop=%s autoplay=%s",
+            interval,
+            gif_loop,
+            autoplay,
+        )
+
+    async def get_image_files(self) -> list[DeviceFile]:
+        """List files in the stock firmware image album."""
+        html = await self.transport.get_text("/filelist?dir=/image/")
+        pattern = re.compile(
+            r"<a href='(?P<path>[^']+)'>(?P<name>[^<]+)</a></td><td>(?P<size>[^<]+)</td>"
+        )
+        return [
+            DeviceFile(
+                name=match.group("name"),
+                path=match.group("path"),
+                size_kb=optional_int(match.group("size")),
+            )
+            for match in pattern.finditer(html)
+        ]
+
+    async def backup_image_files(self) -> list[DeviceFileBackup]:
+        """Download the current stock firmware image album for later restore."""
+        return [
+            DeviceFileBackup(file=file, data=await self.transport.get_bytes(file.path))
+            for file in await self.get_image_files()
+        ]
+
+    async def restore_image_files(self, backups: list[DeviceFileBackup]) -> None:
+        """Restore a previously backed-up stock firmware image album."""
+        await self.clear_images()
+        for backup in backups:
+            await self.upload(backup.data, backup.file.name)
+
+    async def clear_album_files(self) -> None:
+        """Clear stock firmware images, including files clear=image leaves behind."""
+        await self.clear_images()
+        for file in await self.get_image_files():
+            await self.delete_file(file.path)
+
+    async def image_exists(self, filename: str) -> bool:
+        """Return whether the stock firmware image album contains filename."""
+        return any(file.name == filename for file in await self.get_image_files())
+
+    async def keep_only_image(self, filename: str) -> None:
+        """Delete every album file except filename."""
+        kept = False
+        for file in await self.get_image_files():
+            if file.name == filename:
+                kept = True
+                continue
+            await self.delete_file(file.path)
+
+        if not kept:
+            raise RuntimeError(f"Uploaded image {filename} was not found in the album")
+
+    async def upload(self, image_data: bytes, filename: str) -> None:
+        """Upload an image to stock firmware storage."""
+        await self._stock_upload(image_data, filename)
+
+    async def _stock_upload(self, image_data: bytes, filename: str) -> None:
+        """Upload through the stock /doUpload endpoint."""
+        try:
+            await self.transport.post_file(
+                "/doUpload?dir=/image/",
+                "file",
+                image_data,
+                filename,
+                content_type_for_filename(filename),
+            )
+        except aiohttp.ClientResponseError as err:
+            if self.transport.is_malformed_firmware_response(err):
+                _LOGGER.debug("Ignoring malformed HTTP response from device: %s", err.message)
+                return
+            raise
+
+        _LOGGER.debug("Uploaded %s (%d bytes)", filename, len(image_data))
+
+    async def set_image(self, filename: str, try_menu_navigation: bool = False) -> None:
+        """Set the displayed image."""
+        await self.set_theme_custom()
+        await self.select_image_path(f"/image/{filename}")
+        _LOGGER.debug("Set image to %s", filename)
+
+    async def select_image_path(self, image_path: str) -> None:
+        """Select an uploaded image path on firmware that supports it."""
+        await self.transport.get_checked(
+            f"/set?img={image_path}",
+            f"image selection for {image_path}",
+        )
+        self._last_image = image_path
+        _LOGGER.debug("Set image path to %s", image_path)
+
+    async def display_rendered_dashboard(self, request: RenderedDashboardRequest) -> None:
+        """Upload and display a rendered dashboard."""
+        await self.upload(request.image_data, request.filename)
+        await self.set_image(request.filename, try_menu_navigation=request.try_menu_navigation)
+        _LOGGER.debug("Upload and display completed for %s", request.filename)
+
+    async def delete_file(self, path: str) -> None:
+        """Delete a file from the device."""
+        await self.transport.get_checked(f"/delete?file={path}", f"delete {path}")
+        _LOGGER.debug("Deleted %s", path)
+
+    async def clear_images(self) -> None:
+        """Clear all images from the device."""
+        await self.transport.get_checked("/set?clear=image", "clear images")
+        _LOGGER.debug("Cleared all images")
+
+    async def navigate_next(self) -> None:
+        """Navigate to next page."""
+        await self.transport.get_checked("/set?page=1", "navigate next")
+        _LOGGER.debug("Navigated to next page")
+
+    async def navigate_previous(self) -> None:
+        """Navigate to previous page."""
+        await self.transport.get_checked("/set?page=-1", "navigate previous")
+        _LOGGER.debug("Navigated to previous page")
+
+    async def navigate_enter(self) -> None:
+        """Press enter/exit button."""
+        await self.transport.get_checked("/set?enter=-1", "navigate enter")
+        _LOGGER.debug("Pressed enter button")
+
+    async def reboot(self) -> None:
+        """Reboot the device."""
+        await self.transport.get_checked("/set?reboot=1", "reboot")
+        _LOGGER.debug("Rebooting device")
+
+    async def get_sdpro_photo_settings(self) -> SdProPhotoSettings:
+        """Read SD_PRO photo slideshow settings."""
+        raise NotImplementedError("Firmware profile does not expose SD_PRO photo settings")
+
+    async def get_sdpro_theme_settings(self) -> SdProThemeSettings:
+        """Read SD_PRO theme rotation settings."""
+        raise NotImplementedError("Firmware profile does not expose SD_PRO theme settings")
+
+    async def set_sdpro_photo_enabled(self, name: str, enabled: bool) -> None:
+        """Enable or disable a SD_PRO photo."""
+        raise NotImplementedError("Firmware profile does not expose SD_PRO photo settings")
+
+    async def set_sdpro_photo_interval(self, interval: int) -> None:
+        """Set SD_PRO photo interval."""
+        raise NotImplementedError("Firmware profile does not expose SD_PRO photo settings")
+
+    async def set_sdpro_theme_enabled(self, theme_id: int, enabled: bool) -> None:
+        """Enable or disable a SD_PRO theme."""
+        raise NotImplementedError("Firmware profile does not expose SD_PRO theme settings")
+
+    async def set_sdpro_theme_interval(self, interval: int) -> None:
+        """Set SD_PRO theme interval."""
+        raise NotImplementedError("Firmware profile does not expose SD_PRO theme settings")
+
+    async def delete_sdpro_photo(self, name: str) -> None:
+        """Delete a SD_PRO photo."""
+        raise NotImplementedError("Firmware profile does not expose SD_PRO photo settings")
+
+    async def prepare_exclusive_photo(self, filename: str) -> None:
+        """Make one photo active on firmware that exposes slideshow settings."""
+        raise NotImplementedError("Firmware profile does not expose SD_PRO photo settings")
+
+
+class UnknownStockProfile(FirmwareProfile):
+    """Ultra-compatible fallback used before detection."""
+
+    profile_id = MODEL_UNKNOWN
+    default_display_name = "SmallTV"
+    supports_rendered_dashboard = False
+
+
+class StockUltraProfile(FirmwareProfile):
+    """Adapter for stock SmallTV Ultra firmware."""
+
+    profile_id = MODEL_ULTRA
+    default_display_name = "SmallTV Ultra"
+    default_builtin_modes = ULTRA_BUILTIN_MODES
+    custom_image_theme = 3
+    display_mechanism = "direct_image"
+    supports_rendered_dashboard = True
+
+
+class StockProProfile(FirmwareProfile):
+    """Adapter for stock SmallTV-PRO firmware."""
+
+    profile_id = MODEL_PRO
+    default_display_name = "SmallTV Pro"
+    default_builtin_modes = PRO_BUILTIN_MODES
+    custom_image_theme = 4
+    display_mechanism = "picture_album"
+    supports_rendered_dashboard = True
+    requires_managed_album = True
+    user_warnings = (PRO_PICTURE_WARNING,)
+
+    async def get_state(self) -> DeviceState:
+        """Get current Pro state, tolerating missing app state paths."""
+        last_404: aiohttp.ClientResponseError | None = None
+        for path in ("/.sys/app.json", "/app.json"):
+            try:
+                data = await self.transport.get_json(path)
+            except aiohttp.ClientResponseError as err:
+                if err.status == 404:
+                    last_404 = err
+                    continue
+                raise
+            else:
+                state = state_from_stock_data(data)
+                _LOGGER.debug(
+                    "Device state: theme=%s, brightness=%s, image=%s",
+                    state.theme,
+                    state.brightness,
+                    state.current_image,
+                )
+                return state
+
+        if last_404 is not None:
+            _LOGGER.debug("Pro firmware has no state path; using last known state")
+            return DeviceState(
+                theme=self._last_theme,
+                brightness=None,
+                current_image=self._last_image,
+            )
+
+        raise RuntimeError("Device state was not read")
+
+    async def get_brightness(self) -> int:
+        """Get Pro brightness from /.sys."""
+        data = await self.transport.get_json("/.sys/brt.json")
+        brightness = optional_int(data.get("brt")) or 0
+        _LOGGER.debug("Device brightness: %d", brightness)
+        return brightness
+
+    async def get_album_settings(self) -> AlbumSettings:
+        """Get Pro photo album settings."""
+        data = await self.transport.get_json("/.sys/album.json")
+        return AlbumSettings(
+            interval=optional_int(data.get("i_i")),
+            gif_loop=optional_int(data.get("gif_loop")),
+            autoplay=optional_int(data.get("autoplay")),
+        )
+
+    async def upload(self, image_data: bytes, filename: str) -> None:
+        """Upload to Pro, tolerating connection errors after a successful write."""
+        try:
+            await self._stock_upload(image_data, filename)
+        except aiohttp.ClientError as err:
+            try:
+                if await self.image_exists(filename):
+                    _LOGGER.debug(
+                        "Treating Pro upload connection error as success; %s is present: %s",
+                        filename,
+                        err,
+                    )
+                    return
+            except Exception as verify_err:
+                _LOGGER.debug("Could not verify Pro upload after error: %s", verify_err)
+            raise
+
+    async def set_image(self, filename: str, try_menu_navigation: bool = False) -> None:
+        """Prepare Pro Picture album mode for the uploaded image."""
+        await self.set_album_display()
+        await self.set_theme_custom()
+        if try_menu_navigation:
+            await self.navigate_enter()
+            await asyncio.sleep(0.5)
+            await self.navigate_next()
+            await asyncio.sleep(0.5)
+            await self.navigate_enter()
+        self._last_image = f"/image/{filename}"
+        _LOGGER.debug("Set Pro album image mode for %s", filename)
+
+    async def display_rendered_dashboard(self, request: RenderedDashboardRequest) -> None:
+        """Upload and display a Pro rendered dashboard."""
+        await self.upload(request.image_data, request.filename)
+        if request.allow_destructive_album_management:
+            await self.keep_only_image(request.filename)
+        await self.set_image(request.filename, try_menu_navigation=request.try_menu_navigation)
+        _LOGGER.debug("Upload and display completed for %s", request.filename)
+
+
+class SdProProfile(FirmwareProfile):
+    """Adapter for SD_PRO community-style firmware."""
+
+    profile_id = MODEL_SD_PRO
+    default_display_name = "SD_PRO Community Firmware"
+    default_builtin_modes = SD_PRO_BUILTIN_MODES
+    custom_image_theme = 2
+    display_mechanism = "photo_slideshow"
+    brightness_range = (2, 99)
+    supports_rendered_dashboard = True
+    user_warnings = ("This firmware displays rendered dashboards through the Photo slideshow.",)
+
+    async def get_state(self) -> DeviceState:
+        """Get current SD_PRO state from /config."""
+        data = await self.transport.get_json("/config")
+        return DeviceState(
+            theme=optional_int(data.get("theme")),
+            brightness=optional_int(data.get("brightness")),
+            current_image=None,
+        )
+
+    async def get_space(self) -> SpaceInfo:
+        """Get SD_PRO photo storage information."""
+        photos = await self.get_sdpro_photo_settings()
+        return SpaceInfo(total=photos.total, free=max(0, photos.total - photos.used))
+
+    async def get_brightness(self) -> int:
+        """Get SD_PRO brightness from /config."""
+        data = await self.transport.get_json("/config")
+        brightness = optional_int(data.get("brightness"))
+        return brightness or 0
+
+    async def set_brightness(self, value: int) -> None:
+        """Set SD_PRO brightness."""
+        low, high = self.brightness_range
+        value = max(low, min(high, value))
+        await self.transport.get_checked(
+            f"/api/set?key=lcd_brightness&value={value}",
+            "brightness update",
+        )
+        _LOGGER.debug("Set SD_PRO brightness to %d", value)
+
+    async def set_theme(self, theme: int) -> None:
+        """Set SD_PRO active theme."""
+        await self.transport.get_checked(
+            f"/api/set?key=theme&value={theme}",
+            "theme update",
+        )
+        self._last_theme = theme
+        _LOGGER.debug("Set SD_PRO theme to %d", theme)
+
+    async def upload(self, image_data: bytes, filename: str) -> None:
+        """Upload a photo to the SD_PRO slideshow."""
+        await self.transport.post_file(
+            "/photo/upload",
+            "file",
+            image_data,
+            filename,
+            content_type_for_filename(filename),
+        )
+        _LOGGER.debug("Uploaded SD_PRO photo %s (%d bytes)", filename, len(image_data))
+
+    async def set_image(self, filename: str, try_menu_navigation: bool = False) -> None:
+        """Make one SD_PRO photo and the Photo theme active."""
+        await self.prepare_exclusive_photo(filename)
+        self._last_image = f"/photo/{filename}"
+        _LOGGER.debug("Set SD_PRO photo slideshow mode for %s", filename)
+
+    async def prepare_exclusive_photo(self, filename: str) -> None:
+        """Make one SD_PRO photo and the Photo theme active for visual testing."""
+        photos = await self.get_sdpro_photo_settings()
+        for photo in photos.files:
+            await self.set_sdpro_photo_enabled(photo.name, photo.name == filename)
+
+        themes = await self.get_sdpro_theme_settings()
+        for theme in themes.themes:
+            await self.set_sdpro_theme_enabled(theme.id, theme.id == self.custom_image_theme)
+
+        await self.set_sdpro_photo_interval(1)
+        await self.set_theme(self.custom_image_theme or 2)
+
+    async def get_sdpro_photo_settings(self) -> SdProPhotoSettings:
+        """Read SD_PRO photo slideshow settings."""
+        data = await self.transport.get_json("/photo/list")
+        files_data = data.get("files", [])
+        files: list[SdProPhoto] = []
+        if isinstance(files_data, list):
+            for item in files_data:
+                if isinstance(item, Mapping):
+                    item_data = cast("Mapping[str, object]", item)
+                    name = item_data.get("name")
+                    if name is not None:
+                        files.append(
+                            SdProPhoto(
+                                name=str(name),
+                                size=optional_int(item_data.get("size")) or 0,
+                                enabled=bool(item_data.get("enabled")),
+                            )
+                        )
+        return SdProPhotoSettings(
+            files=files,
+            total=optional_int(data.get("total")) or 0,
+            used=optional_int(data.get("used")) or 0,
+            interval=optional_int(data.get("interval")),
+        )
+
+    async def get_sdpro_theme_settings(self) -> SdProThemeSettings:
+        """Read SD_PRO theme rotation settings."""
+        data = await self.transport.get_json("/theme/list")
+        themes_data = data.get("themes", [])
+        themes: list[SdProTheme] = []
+        if isinstance(themes_data, list):
+            for item in themes_data:
+                if isinstance(item, Mapping):
+                    item_data = cast("Mapping[str, object]", item)
+                    theme_id = optional_int(item_data.get("id"))
+                    if theme_id is not None:
+                        themes.append(
+                            SdProTheme(
+                                id=theme_id,
+                                name=str(item_data.get("name", theme_id)),
+                                enabled=bool(item_data.get("enabled")),
+                            )
+                        )
+        return SdProThemeSettings(
+            themes=themes,
+            interval=optional_int(data.get("interval")),
+        )
+
+    async def set_sdpro_photo_enabled(self, name: str, enabled: bool) -> None:
+        """Enable or disable a photo in the SD_PRO slideshow."""
+        await self.transport.get_checked(
+            f"/photo/toggle?name={quote(name)}&state={1 if enabled else 0}",
+            f"photo toggle {name}",
+        )
+
+    async def set_sdpro_photo_interval(self, interval: int) -> None:
+        """Set SD_PRO photo slideshow interval."""
+        await self.transport.get_checked(
+            f"/photo/interval?val={max(1, interval)}",
+            "photo interval update",
+        )
+
+    async def set_sdpro_theme_enabled(self, theme_id: int, enabled: bool) -> None:
+        """Enable or disable a theme in the SD_PRO rotation."""
+        await self.transport.get_checked(
+            f"/theme/toggle?id={theme_id}&state={1 if enabled else 0}",
+            f"theme toggle {theme_id}",
+        )
+
+    async def set_sdpro_theme_interval(self, interval: int) -> None:
+        """Set SD_PRO theme rotation interval."""
+        await self.transport.get_checked(
+            f"/theme/interval?val={max(0, interval)}",
+            "theme interval update",
+        )
+
+    async def delete_sdpro_photo(self, name: str) -> None:
+        """Delete a photo from the SD_PRO slideshow."""
+        await self.transport.get_checked(
+            f"/photo/delete?name={quote(name)}",
+            f"photo delete {name}",
+        )
+
+
+def profile_for_model(
+    model: str,
+    transport: DeviceTransport,
+    *,
+    model_name: str | None = None,
+    firmware_version: str | None = None,
+) -> FirmwareProfile:
+    """Create a profile adapter for a model/profile id."""
+    if model == MODEL_PRO:
+        return StockProProfile(
+            transport,
+            model_name=model_name,
+            firmware_version=firmware_version,
+        )
+    if model == MODEL_SD_PRO:
+        return SdProProfile(
+            transport,
+            model_name=model_name,
+            firmware_version=firmware_version,
+        )
+    if model == MODEL_ULTRA:
+        return StockUltraProfile(
+            transport,
+            model_name=model_name,
+            firmware_version=firmware_version,
+        )
+    return UnknownStockProfile(
+        transport,
+        profile_id=MODEL_UNKNOWN,
+        model_name=model_name,
+        firmware_version=firmware_version,
+    )
+
+
+async def detect_firmware_profile(transport: DeviceTransport) -> FirmwareProfile:
+    """Detect the firmware profile exposed by a device."""
+    timeout = aiohttp.ClientTimeout(total=5)
+
+    try:
+        data = await transport.get_json("/v.json", request_timeout=timeout)
+        model_name = str(data.get("m", ""))
+        firmware_value = data.get("v")
+        firmware_version = str(firmware_value) if firmware_value is not None else None
+        model_key = model_name.lower()
+        if "pro" in model_key:
+            return StockProProfile(
+                transport,
+                model_name=model_name or None,
+                firmware_version=firmware_version,
+            )
+        if "ultra" in model_key:
+            return StockUltraProfile(
+                transport,
+                model_name=model_name or None,
+                firmware_version=firmware_version,
+            )
+    except Exception as err:
+        _LOGGER.debug("Identity path /v.json not available: %s", err)
+
+    try:
+        await transport.get_json("/.sys/app.json", request_timeout=timeout)
+        return StockProProfile(transport, model_name="SmallTV Pro")
+    except Exception as err:
+        _LOGGER.debug("Pro path /.sys/app.json not available: %s", err)
+
+    try:
+        await transport.get_json("/app.json", request_timeout=timeout)
+        return StockUltraProfile(transport, model_name="SmallTV Ultra")
+    except Exception as err:
+        _LOGGER.debug("Ultra path /app.json not available: %s", err)
+
+    try:
+        data = await transport.get_json("/theme/list", request_timeout=timeout)
+        if isinstance(data.get("themes"), list):
+            return SdProProfile(transport, model_name="SD_PRO Community Firmware")
+    except Exception as err:
+        _LOGGER.debug("SD_PRO path /theme/list not available: %s", err)
+
+    _LOGGER.warning("Could not detect device model for %s", transport.host)
+    return UnknownStockProfile(transport)

--- a/custom_components/geekmagic/strings.json
+++ b/custom_components/geekmagic/strings.json
@@ -82,9 +82,9 @@
       },
       "pro_managed_album": {
         "title": "SmallTV Pro Picture Album",
-        "description": "SmallTV Pro Picture mode is a slideshow. To show Home Assistant dashboards reliably, GeekMagic will delete the existing pictures on this device and keep only its managed dashboard image. After setup, manually select the Picture app on the device; the integration will not press the device menu buttons automatically.",
+        "description": "SmallTV Pro Picture mode is a slideshow. To show Home Assistant dashboards reliably, GeekMagic needs exclusive control of the Picture album: it will delete existing pictures on this device and keep only one managed dashboard image. Back up any pictures you want to keep before continuing. After setup, manually select the Picture app on the device; the integration will not press the device menu buttons automatically.",
         "data": {
-          "manage_pro_album": "I understand and allow GeekMagic to manage the Pro picture album"
+          "manage_pro_album": "I understand GeekMagic will delete existing Pro album pictures and keep one managed dashboard image"
         }
       }
     },
@@ -107,6 +107,13 @@
         "description": "Choose what to configure.",
         "data": {
           "action": "Action"
+        }
+      },
+      "pro_managed_album": {
+        "title": "Manage SmallTV Pro Picture Album",
+        "description": "This lets GeekMagic make the Pro Picture album deterministic for Home Assistant dashboards. It is destructive on the device: GeekMagic will delete existing pictures and keep only one managed dashboard image, so the Pro slideshow cannot rotate away from the dashboard. Back up any pictures you want to keep before enabling this. You still need to manually select the Picture app on the device.",
+        "data": {
+          "manage_pro_album": "I understand GeekMagic will delete existing Pro album pictures and keep one managed dashboard image"
         }
       },
       "device_settings": {
@@ -423,6 +430,9 @@
           "confirm": "Yes, delete this screen"
         }
       }
+    },
+    "error": {
+      "confirm_required": "You must confirm that GeekMagic may delete and manage the Pro Picture album before enabling this."
     }
   }
 }

--- a/custom_components/geekmagic/strings.json
+++ b/custom_components/geekmagic/strings.json
@@ -79,9 +79,17 @@
           "host": "Host (IP, hostname, or URL)",
           "name": "Display name"
         }
+      },
+      "pro_managed_album": {
+        "title": "SmallTV Pro Picture Album",
+        "description": "SmallTV Pro Picture mode is a slideshow. To show Home Assistant dashboards reliably, GeekMagic will delete the existing pictures on this device and keep only its managed dashboard image. After setup, manually select the Picture app on the device; the integration will not press the device menu buttons automatically.",
+        "data": {
+          "manage_pro_album": "I understand and allow GeekMagic to manage the Pro picture album"
+        }
       }
     },
     "error": {
+      "confirm_required": "You must confirm album management before adding this Pro device.",
       "timeout": "Connection timed out. The device may be offline or unreachable.",
       "connection_refused": "Connection refused. Verify the device is powered on and the address is correct.",
       "dns_error": "Could not resolve hostname. Check the address is correct.",

--- a/custom_components/geekmagic/transport.py
+++ b/custom_components/geekmagic/transport.py
@@ -1,0 +1,165 @@
+"""HTTP transport helpers for GeekMagic firmware profiles."""
+
+from __future__ import annotations
+
+import asyncio
+from urllib.parse import urlparse
+
+import aiohttp
+
+TIMEOUT = aiohttp.ClientTimeout(total=30)
+
+
+class DeviceTransport:
+    """Small HTTP transport used by firmware profile adapters."""
+
+    def __init__(self, host: str, session: aiohttp.ClientSession | None = None) -> None:
+        """Initialize transport for a device host, hostname, or URL."""
+        if host.startswith(("http://", "https://")):
+            parsed = urlparse(host)
+            self.host = parsed.netloc
+            self.base_url = f"{parsed.scheme}://{parsed.netloc}"
+        else:
+            self.host = host
+            self.base_url = f"http://{host}"
+
+        self._session = session
+        self._owns_session = session is None
+
+    @property
+    def session(self) -> aiohttp.ClientSession | None:
+        """Return the current aiohttp session, if created."""
+        return self._session
+
+    @session.setter
+    def session(self, value: aiohttp.ClientSession | None) -> None:
+        self._session = value
+
+    @property
+    def owns_session(self) -> bool:
+        """Return whether this transport owns its aiohttp session."""
+        return self._owns_session
+
+    @owns_session.setter
+    def owns_session(self, value: bool) -> None:
+        self._owns_session = value
+
+    async def get_session(self) -> aiohttp.ClientSession:
+        """Get or create the aiohttp session."""
+        if self._session is None:
+            self._session = aiohttp.ClientSession(timeout=TIMEOUT)
+        return self._session
+
+    async def close(self) -> None:
+        """Close the session if this transport owns it."""
+        if self._owns_session and self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def check_device_response(self, response: aiohttp.ClientResponse, action: str) -> None:
+        """Raise for HTTP errors and firmware-level FAIL responses."""
+        response.raise_for_status()
+        try:
+            text = (await response.text()).strip()
+        except Exception:
+            return
+
+        if text.upper() == "FAIL":
+            raise RuntimeError(f"Device rejected {action}: {text}")
+
+    async def get_json(
+        self,
+        path: str,
+        request_timeout: aiohttp.ClientTimeout | None = None,
+    ) -> dict[str, object]:
+        """Fetch a JSON object from the device."""
+        session = await self.get_session()
+        kwargs = {"timeout": request_timeout} if request_timeout is not None else {}
+        async with session.get(f"{self.base_url}{path}", **kwargs) as response:
+            response.raise_for_status()
+            data = await response.json(content_type=None)
+            if not isinstance(data, dict):
+                raise TypeError(f"Expected JSON object from {path}")
+            return data
+
+    async def get_text(self, path: str) -> str:
+        """Fetch text from the device."""
+        try:
+            session = await self.get_session()
+            async with session.get(f"{self.base_url}{path}") as response:
+                response.raise_for_status()
+                return await response.text()
+        except aiohttp.ClientResponseError as err:
+            if self.is_malformed_firmware_response(err):
+                return (await self.raw_http_get(path)).decode(errors="replace")
+            raise
+
+    async def get_bytes(self, path: str) -> bytes:
+        """Fetch bytes from the device."""
+        try:
+            session = await self.get_session()
+            async with session.get(f"{self.base_url}{path}") as response:
+                response.raise_for_status()
+                return await response.read()
+        except aiohttp.ClientResponseError as err:
+            if self.is_malformed_firmware_response(err):
+                return await self.raw_http_get(path)
+            raise
+
+    async def get_checked(self, path: str, action: str) -> None:
+        """Run a GET request that must return OK rather than FAIL."""
+        session = await self.get_session()
+        async with session.get(f"{self.base_url}{path}") as response:
+            await self.check_device_response(response, action)
+
+    async def post_file(
+        self,
+        path: str,
+        field_name: str,
+        image_data: bytes,
+        filename: str,
+        content_type: str,
+    ) -> None:
+        """Post a multipart file upload to the device."""
+        form = aiohttp.FormData()
+        form.add_field(
+            field_name,
+            image_data,
+            filename=filename,
+            content_type=content_type,
+        )
+        session = await self.get_session()
+        async with session.post(f"{self.base_url}{path}", data=form) as response:
+            response.raise_for_status()
+
+    @staticmethod
+    def is_malformed_firmware_response(err: aiohttp.ClientResponseError) -> bool:
+        """Return whether aiohttp rejected a known malformed device response."""
+        message = str(err.message) if err.message else ""
+        return err.status == 400 and (
+            "Duplicate Content-Length" in message or "Data after" in message
+        )
+
+    async def raw_http_get(self, path: str) -> bytes:
+        """Fallback HTTP/1.0 GET for firmware responses aiohttp refuses to parse."""
+        parsed = urlparse(self.base_url)
+        host = parsed.hostname or self.host
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        if parsed.scheme == "https":
+            raise RuntimeError("Raw fallback only supports HTTP devices")
+
+        reader, writer = await asyncio.open_connection(host, port)
+        try:
+            request = f"GET {path} HTTP/1.0\r\nHost: {self.host}\r\nConnection: close\r\n\r\n"
+            writer.write(request.encode("ascii"))
+            await writer.drain()
+            raw = await reader.read()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+        header, _, body = raw.partition(b"\r\n\r\n")
+        status_line = header.splitlines()[0] if header else b""
+        if not status_line.startswith(b"HTTP/") or b" 200 " not in status_line:
+            raise RuntimeError(f"Raw HTTP GET failed for {path}: {status_line!r}")
+        return body

--- a/custom_components/geekmagic/transport.py
+++ b/custom_components/geekmagic/transport.py
@@ -13,7 +13,12 @@ TIMEOUT = aiohttp.ClientTimeout(total=30)
 class DeviceTransport:
     """Small HTTP transport used by firmware profile adapters."""
 
-    def __init__(self, host: str, session: aiohttp.ClientSession | None = None) -> None:
+    def __init__(
+        self,
+        host: str,
+        session: aiohttp.ClientSession | None = None,
+        source_address: str | None = None,
+    ) -> None:
         """Initialize transport for a device host, hostname, or URL."""
         if host.startswith(("http://", "https://")):
             parsed = urlparse(host)
@@ -25,6 +30,7 @@ class DeviceTransport:
 
         self._session = session
         self._owns_session = session is None
+        self.source_address = source_address
 
     @property
     def session(self) -> aiohttp.ClientSession | None:
@@ -47,7 +53,12 @@ class DeviceTransport:
     async def get_session(self) -> aiohttp.ClientSession:
         """Get or create the aiohttp session."""
         if self._session is None:
-            self._session = aiohttp.ClientSession(timeout=TIMEOUT)
+            connector = (
+                aiohttp.TCPConnector(local_addr=(self.source_address, 0))
+                if self.source_address
+                else None
+            )
+            self._session = aiohttp.ClientSession(timeout=TIMEOUT, connector=connector)
         return self._session
 
     async def close(self) -> None:
@@ -148,7 +159,8 @@ class DeviceTransport:
         if parsed.scheme == "https":
             raise RuntimeError("Raw fallback only supports HTTP devices")
 
-        reader, writer = await asyncio.open_connection(host, port)
+        local_addr = (self.source_address, 0) if self.source_address else None
+        reader, writer = await asyncio.open_connection(host, port, local_addr=local_addr)
         try:
             request = f"GET {path} HTTP/1.0\r\nHost: {self.host}\r\nConnection: close\r\n\r\n"
             writer.write(request.encode("ascii"))

--- a/scripts/debug_render.py
+++ b/scripts/debug_render.py
@@ -43,16 +43,27 @@ from custom_components.geekmagic.const import (
     COLOR_TEAL,
     COLOR_WHITE,
     COLOR_YELLOW,
-    MODEL_PRO,
 )
-from custom_components.geekmagic.device import GeekMagicDevice
+from custom_components.geekmagic.device import GeekMagicDevice, RenderedDashboardRequest
 from custom_components.geekmagic.renderer import Renderer
 
 
 def _print_pro_picture_note(device: GeekMagicDevice) -> None:
     """Tell Pro users how to make the uploaded image visible."""
-    if device.model == MODEL_PRO:
+    if device.capabilities.requires_managed_album:
         print("For Pro devices, manually select the Picture app if the image is not visible.")
+
+
+async def _display_debug_image(device: GeekMagicDevice, jpeg_data: bytes) -> None:
+    """Upload the debug render through the same profile-backed display flow as HA."""
+    await device.display_rendered_dashboard(
+        RenderedDashboardRequest(
+            image_data=jpeg_data,
+            filename="debug.jpg",
+            allow_destructive_album_management=False,
+            try_menu_navigation=False,
+        )
+    )
 
 
 def render_system_monitor(renderer: Renderer) -> bytes:
@@ -530,7 +541,7 @@ async def main() -> None:
             print(f"Rendering {name}...")
             jpeg_data = render_func(renderer)
             print(f"Uploading ({len(jpeg_data)} bytes)...")
-            await device.upload_and_display(jpeg_data, "debug.jpg")
+            await _display_debug_image(device, jpeg_data)
             _print_pro_picture_note(device)
             print("Done!")
 
@@ -546,7 +557,7 @@ async def main() -> None:
 
                 print(f"[{datetime.now().strftime('%H:%M:%S')}] Rendering {name}...")
                 jpeg_data = render_func(renderer)
-                await device.upload_and_display(jpeg_data, "debug.jpg")
+                await _display_debug_image(device, jpeg_data)
                 print(f"  Uploaded {len(jpeg_data)} bytes")
                 _print_pro_picture_note(device)
 
@@ -558,7 +569,7 @@ async def main() -> None:
             print("Rendering System Monitor...")
             jpeg_data = render_system_monitor(renderer)
             print(f"Uploading ({len(jpeg_data)} bytes)...")
-            await device.upload_and_display(jpeg_data, "debug.jpg")
+            await _display_debug_image(device, jpeg_data)
             _print_pro_picture_note(device)
             print("Done!")
 

--- a/scripts/debug_render.py
+++ b/scripts/debug_render.py
@@ -43,9 +43,16 @@ from custom_components.geekmagic.const import (
     COLOR_TEAL,
     COLOR_WHITE,
     COLOR_YELLOW,
+    MODEL_PRO,
 )
 from custom_components.geekmagic.device import GeekMagicDevice
 from custom_components.geekmagic.renderer import Renderer
+
+
+def _print_pro_picture_note(device: GeekMagicDevice) -> None:
+    """Tell Pro users how to make the uploaded image visible."""
+    if device.model == MODEL_PRO:
+        print("For Pro devices, manually select the Picture app if the image is not visible.")
 
 
 def render_system_monitor(renderer: Renderer) -> bytes:
@@ -499,8 +506,23 @@ async def main() -> None:
             print(f"Error: Could not connect to device at {args.device_ip}")
             return
 
-        state = await device.get_state()
-        print(f"Connected! Current theme: {state.theme}, brightness: {state.brightness}")
+        await device.detect_model()
+        identity = device.model_name or device.model
+        if device.firmware_version:
+            identity = f"{identity} ({device.firmware_version})"
+        print(f"Connected! Detected: {identity}")
+
+        try:
+            brightness = await device.get_brightness()
+            print(f"Current brightness: {brightness}")
+        except Exception as err:
+            print(f"Brightness unavailable: {err}")
+
+        try:
+            state = await device.get_state()
+            print(f"Current theme: {state.theme}, current image: {state.current_image}")
+        except Exception as err:
+            print(f"State unavailable: {err}")
 
         if args.dashboard:
             # Single dashboard
@@ -509,6 +531,7 @@ async def main() -> None:
             jpeg_data = render_func(renderer)
             print(f"Uploading ({len(jpeg_data)} bytes)...")
             await device.upload_and_display(jpeg_data, "debug.jpg")
+            _print_pro_picture_note(device)
             print("Done!")
 
         elif args.cycle:
@@ -525,6 +548,7 @@ async def main() -> None:
                 jpeg_data = render_func(renderer)
                 await device.upload_and_display(jpeg_data, "debug.jpg")
                 print(f"  Uploaded {len(jpeg_data)} bytes")
+                _print_pro_picture_note(device)
 
                 idx += 1
                 await asyncio.sleep(args.interval)
@@ -535,6 +559,7 @@ async def main() -> None:
             jpeg_data = render_system_monitor(renderer)
             print(f"Uploading ({len(jpeg_data)} bytes)...")
             await device.upload_and_display(jpeg_data, "debug.jpg")
+            _print_pro_picture_note(device)
             print("Done!")
 
     except KeyboardInterrupt:

--- a/scripts/device_cli.py
+++ b/scripts/device_cli.py
@@ -19,15 +19,21 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from custom_components.geekmagic.const import MODEL_PRO, MODEL_SD_PRO, MODEL_ULTRA
-from custom_components.geekmagic.device import DeviceSettingsBackup, GeekMagicDevice
+from custom_components.geekmagic.const import MODEL_PRO, MODEL_SD_PRO
+from custom_components.geekmagic.device import GeekMagicDevice
+from custom_components.geekmagic.live_transaction import (
+    backup_and_clear_album,
+    backup_settings,
+    cleanup_uploaded_sdpro_photo,
+    restore_settings,
+)
+from custom_components.geekmagic.models import DeviceSettingsBackup, RenderedDashboardRequest
 from custom_components.geekmagic.renderer import Renderer
 from scripts.debug_render import DASHBOARDS
 
 DeviceFactory = Callable[[str], GeekMagicDevice]
 SleepFunc = Callable[[float], Awaitable[None]]
 
-SUPPORTED_RENDER_MODELS = {MODEL_PRO, MODEL_SD_PRO, MODEL_ULTRA}
 DEFAULT_HOLD_SECONDS = 15.0
 
 
@@ -70,6 +76,11 @@ def create_parser() -> argparse.ArgumentParser:
             "Makes Pro display tests deterministic."
         ),
     )
+    render_test.add_argument(
+        "--try-enter-picture",
+        action="store_true",
+        help="Try Pro Enter/Right/Enter button navigation after upload.",
+    )
 
     upload_file = subparsers.add_parser("upload-file", help="Upload and display an image file")
     upload_file.add_argument("host", help="Device IP, hostname, or URL")
@@ -93,6 +104,11 @@ def create_parser() -> argparse.ArgumentParser:
             "Makes Pro display tests deterministic."
         ),
     )
+    upload_file.add_argument(
+        "--try-enter-picture",
+        action="store_true",
+        help="Try Pro Enter/Right/Enter button navigation after upload.",
+    )
 
     brightness = subparsers.add_parser("brightness", help="Get or set display brightness")
     brightness.add_argument("host", help="Device IP, hostname, or URL")
@@ -106,9 +122,10 @@ def create_parser() -> argparse.ArgumentParser:
 
 def _identity_text(device: GeekMagicDevice) -> str:
     """Return a human-readable device identity."""
-    identity = device.model_name or device.model
-    if device.firmware_version:
-        return f"{identity} ({device.firmware_version})"
+    capabilities = device.capabilities
+    identity = capabilities.display_name or device.profile_id
+    if capabilities.firmware_version:
+        return f"{identity} ({capabilities.firmware_version})"
     return identity
 
 
@@ -177,23 +194,27 @@ async def _run_probe(device: GeekMagicDevice) -> int:
     supports_rendering = _supports_rendering(device)
     print(f"  rendered dashboard: {supports_rendering}")
     if supports_rendering:
-        print(f"  custom image theme: {device.custom_theme}")
-        print(f"  built-in modes: {', '.join(device.builtin_modes)}")
+        print(f"  display mechanism: {device.capabilities.display_mechanism}")
+        print(f"  custom image theme: {device.capabilities.custom_image_theme}")
+        print(f"  built-in modes: {', '.join(device.capabilities.builtin_modes)}")
     else:
+        print(f"  display mechanism: {device.capabilities.display_mechanism}")
         print("  custom image theme: unavailable")
         print("  built-in modes: unavailable")
+    for warning in device.capabilities.user_warnings:
+        print(f"  warning: {warning}")
     return 0
 
 
 def _supports_rendering(device: GeekMagicDevice) -> bool:
     """Return whether the stock render/upload/display path is supported."""
-    return device.model in SUPPORTED_RENDER_MODELS
+    return device.capabilities.supports_rendered_dashboard
 
 
 async def _backup_settings(device: GeekMagicDevice, step: int) -> DeviceSettingsBackup:
     """Back up settings before mutating a live device."""
     print(f"Step {step}: back up device settings")
-    backup = await device.backup_settings()
+    backup = await backup_settings(device)
     print(f"  backup: {_format_backup(backup)}")
     return backup
 
@@ -214,7 +235,7 @@ async def _restore_settings(
 ) -> None:
     """Restore settings captured before a mutating test."""
     print(f"Step {step}: restore original settings")
-    await device.restore_settings(backup)
+    await restore_settings(device, backup)
     print("  restore: success")
 
 
@@ -227,20 +248,20 @@ async def _maybe_takeover_album(
     """Optionally clear the device album before uploading."""
     if takeover_album:
         print(f"Step {step}: back up and clear image album")
-        if device.model == MODEL_PRO:
-            backup.pro_album_files = await device.backup_pro_album_files()
-            print(f"  backed up: {len(backup.pro_album_files)} album files")
-            await device.clear_pro_album_files()
+        if device.profile_id == MODEL_PRO:
+            count = await backup_and_clear_album(device, backup)
+            print(f"  backed up: {count or 0} album files")
             print("  cleared: all existing device images were removed")
-        elif device.model == MODEL_SD_PRO:
+        elif device.profile_id == MODEL_SD_PRO:
+            await backup_and_clear_album(device, backup)
             print("  SD_PRO: using slideshow toggles instead of deleting photos")
         else:
-            await device.clear_images()
+            await backup_and_clear_album(device, backup)
             print("  cleared: all existing device images were removed")
-    elif device.model == MODEL_PRO:
+    elif device.profile_id == MODEL_PRO:
         print("Note: Pro Picture mode cycles the device album.")
         print("      Use --takeover-album for deterministic display on a Pro.")
-    elif device.model == MODEL_SD_PRO:
+    elif device.profile_id == MODEL_SD_PRO:
         print(
             "Note: SD_PRO test temporarily makes the uploaded photo the only active slideshow item."
         )
@@ -251,6 +272,7 @@ async def _run_render_test(
     dashboard: str,
     filename: str,
     takeover_album: bool,
+    try_enter_picture: bool,
     hold_seconds: float,
     restore: bool,
     sleep: SleepFunc,
@@ -260,7 +282,7 @@ async def _run_render_test(
 
     if not _supports_rendering(device):
         print("Step 2: stop before mutation")
-        print(f"  unsupported: profile '{device.model}' has no stock upload/display path")
+        print(f"  unsupported: profile '{device.profile_id}' has no upload/display path")
         return 2
 
     backup = await _backup_settings(device, 2)
@@ -274,35 +296,31 @@ async def _run_render_test(
         await _maybe_takeover_album(device, backup, takeover_album, 4)
 
         print(f"Step 5: upload and display as {filename}")
-        print(f"  custom image theme: {device.custom_theme}")
-        await device.upload_and_display(
-            image_data,
-            filename,
-            manage_album=takeover_album,
-            enter_picture=True,
+        print(f"  custom image theme: {device.capabilities.custom_image_theme}")
+        await device.display_rendered_dashboard(
+            RenderedDashboardRequest(
+                image_data=image_data,
+                filename=filename,
+                allow_destructive_album_management=takeover_album,
+                try_menu_navigation=try_enter_picture,
+            )
         )
         print("  success: device should now show the rendered dashboard")
-        if device.model == MODEL_PRO:
+        if device.profile_id == MODEL_PRO:
             print("  note: if it is not visible, manually select the Picture app on the device")
 
         await _hold_for_viewing(hold_seconds, sleep, 6)
     finally:
         if restore:
             await _restore_settings(device, backup, 7)
-            if device.model == MODEL_SD_PRO:
-                names = (
-                    {photo.name for photo in backup.sdpro_photos.files}
-                    if backup.sdpro_photos is not None
-                    else set()
-                )
-                if filename not in names:
-                    print("Step 8: remove uploaded SD_PRO test photo")
-                    try:
-                        await device.delete_sdpro_photo(filename)
-                    except Exception as err:
-                        print(f"  cleanup warning: {err}")
-                    else:
-                        print("  cleanup: success")
+            if device.profile_id == MODEL_SD_PRO:
+                print("Step 8: remove uploaded SD_PRO test photo")
+                try:
+                    removed = await cleanup_uploaded_sdpro_photo(device, backup, filename)
+                except Exception as err:
+                    print(f"  cleanup warning: {err}")
+                else:
+                    print("  cleanup: success" if removed else "  cleanup: not needed")
         else:
             print("Step 7: restore skipped (--no-restore)")
     return 0
@@ -312,6 +330,7 @@ async def _run_upload_file(
     device: GeekMagicDevice,
     path: Path,
     takeover_album: bool,
+    try_enter_picture: bool,
     hold_seconds: float,
     restore: bool,
     sleep: SleepFunc,
@@ -321,7 +340,7 @@ async def _run_upload_file(
 
     if not _supports_rendering(device):
         print("Step 2: stop before mutation")
-        print(f"  unsupported: profile '{device.model}' has no stock upload/display path")
+        print(f"  unsupported: profile '{device.profile_id}' has no upload/display path")
         return 2
 
     backup = await _backup_settings(device, 2)
@@ -333,35 +352,31 @@ async def _run_upload_file(
         await _maybe_takeover_album(device, backup, takeover_album, 4)
 
         print(f"Step 5: upload and display as {path.name}")
-        print(f"  custom image theme: {device.custom_theme}")
-        await device.upload_and_display(
-            image_data,
-            path.name,
-            manage_album=takeover_album,
-            enter_picture=True,
+        print(f"  custom image theme: {device.capabilities.custom_image_theme}")
+        await device.display_rendered_dashboard(
+            RenderedDashboardRequest(
+                image_data=image_data,
+                filename=path.name,
+                allow_destructive_album_management=takeover_album,
+                try_menu_navigation=try_enter_picture,
+            )
         )
         print("  success: device should now show the uploaded image")
-        if device.model == MODEL_PRO:
+        if device.profile_id == MODEL_PRO:
             print("  note: if it is not visible, manually select the Picture app on the device")
 
         await _hold_for_viewing(hold_seconds, sleep, 6)
     finally:
         if restore:
             await _restore_settings(device, backup, 7)
-            if device.model == MODEL_SD_PRO:
-                names = (
-                    {photo.name for photo in backup.sdpro_photos.files}
-                    if backup.sdpro_photos is not None
-                    else set()
-                )
-                if path.name not in names:
-                    print("Step 8: remove uploaded SD_PRO test photo")
-                    try:
-                        await device.delete_sdpro_photo(path.name)
-                    except Exception as err:
-                        print(f"  cleanup warning: {err}")
-                    else:
-                        print("  cleanup: success")
+            if device.profile_id == MODEL_SD_PRO:
+                print("Step 8: remove uploaded SD_PRO test photo")
+                try:
+                    removed = await cleanup_uploaded_sdpro_photo(device, backup, path.name)
+                except Exception as err:
+                    print(f"  cleanup warning: {err}")
+                else:
+                    print("  cleanup: success" if removed else "  cleanup: not needed")
         else:
             print("Step 7: restore skipped (--no-restore)")
     return 0
@@ -399,6 +414,7 @@ async def run(
                 args.dashboard,
                 args.filename,
                 args.takeover_album,
+                args.try_enter_picture,
                 args.hold_seconds,
                 not args.no_restore,
                 sleep,
@@ -408,6 +424,7 @@ async def run(
                 device,
                 args.path,
                 args.takeover_album,
+                args.try_enter_picture,
                 args.hold_seconds,
                 not args.no_restore,
                 sleep,

--- a/scripts/device_cli.py
+++ b/scripts/device_cli.py
@@ -40,13 +40,23 @@ DEFAULT_HOLD_SECONDS = 15.0
 def create_parser() -> argparse.ArgumentParser:
     """Create the command-line parser."""
     parser = argparse.ArgumentParser(description="Test GeekMagic devices from the repo")
+    device_parent = argparse.ArgumentParser(add_help=False)
+    device_parent.add_argument(
+        "--bind-address",
+        help="Local source IP to bind live-device HTTP connections to",
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    probe = subparsers.add_parser("probe", help="Detect and inspect a device")
+    probe = subparsers.add_parser(
+        "probe",
+        parents=[device_parent],
+        help="Detect and inspect a device",
+    )
     probe.add_argument("host", help="Device IP, hostname, or URL")
 
     render_test = subparsers.add_parser(
         "render-test",
+        parents=[device_parent],
         help="Render a test dashboard, upload it, and display it",
     )
     render_test.add_argument("host", help="Device IP, hostname, or URL")
@@ -82,7 +92,11 @@ def create_parser() -> argparse.ArgumentParser:
         help="Try Pro Enter/Right/Enter button navigation after upload.",
     )
 
-    upload_file = subparsers.add_parser("upload-file", help="Upload and display an image file")
+    upload_file = subparsers.add_parser(
+        "upload-file",
+        parents=[device_parent],
+        help="Upload and display an image file",
+    )
     upload_file.add_argument("host", help="Device IP, hostname, or URL")
     upload_file.add_argument("path", type=Path, help="Local image path")
     upload_file.add_argument(
@@ -110,7 +124,11 @@ def create_parser() -> argparse.ArgumentParser:
         help="Try Pro Enter/Right/Enter button navigation after upload.",
     )
 
-    brightness = subparsers.add_parser("brightness", help="Get or set display brightness")
+    brightness = subparsers.add_parser(
+        "brightness",
+        parents=[device_parent],
+        help="Get or set display brightness",
+    )
     brightness.add_argument("host", help="Device IP, hostname, or URL")
     brightness_sub = brightness.add_subparsers(dest="brightness_command", required=True)
     brightness_sub.add_parser("get", help="Read brightness")
@@ -404,7 +422,11 @@ async def run(
     sleep: SleepFunc = asyncio.sleep,
 ) -> int:
     """Run a parsed CLI command."""
-    device = device_factory(args.host)
+    bind_address = getattr(args, "bind_address", None)
+    if bind_address and device_factory is GeekMagicDevice:
+        device = GeekMagicDevice(args.host, source_address=bind_address)
+    else:
+        device = device_factory(args.host)
     try:
         if args.command == "probe":
             return await _run_probe(device)

--- a/scripts/device_cli.py
+++ b/scripts/device_cli.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Live-device smoke tests for GeekMagic displays.
+
+Examples:
+    uv run python scripts/device_cli.py probe 192.168.1.100
+    uv run python scripts/device_cli.py render-test 192.168.1.100 --dashboard clock
+    uv run python scripts/device_cli.py upload-file 192.168.1.100 ./dashboard.jpg
+    uv run python scripts/device_cli.py brightness 192.168.1.100 get
+    uv run python scripts/device_cli.py brightness 192.168.1.100 set 80
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from custom_components.geekmagic.const import MODEL_PRO, MODEL_SD_PRO, MODEL_ULTRA
+from custom_components.geekmagic.device import DeviceSettingsBackup, GeekMagicDevice
+from custom_components.geekmagic.renderer import Renderer
+from scripts.debug_render import DASHBOARDS
+
+DeviceFactory = Callable[[str], GeekMagicDevice]
+SleepFunc = Callable[[float], Awaitable[None]]
+
+SUPPORTED_RENDER_MODELS = {MODEL_PRO, MODEL_SD_PRO, MODEL_ULTRA}
+DEFAULT_HOLD_SECONDS = 15.0
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(description="Test GeekMagic devices from the repo")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    probe = subparsers.add_parser("probe", help="Detect and inspect a device")
+    probe.add_argument("host", help="Device IP, hostname, or URL")
+
+    render_test = subparsers.add_parser(
+        "render-test",
+        help="Render a test dashboard, upload it, and display it",
+    )
+    render_test.add_argument("host", help="Device IP, hostname, or URL")
+    render_test.add_argument(
+        "--dashboard",
+        choices=list(DASHBOARDS.keys()),
+        default="clock",
+        help="Debug dashboard to render",
+    )
+    render_test.add_argument("--filename", default="cli-test.jpg", help="Device filename")
+    render_test.add_argument(
+        "--hold-seconds",
+        type=float,
+        default=DEFAULT_HOLD_SECONDS,
+        help="Seconds to keep the test image visible before restoring settings",
+    )
+    render_test.add_argument(
+        "--no-restore",
+        action="store_true",
+        help="Leave device settings changed after the test",
+    )
+    render_test.add_argument(
+        "--takeover-album",
+        action="store_true",
+        help=(
+            "Back up and clear device images first, then restore them afterward. "
+            "Makes Pro display tests deterministic."
+        ),
+    )
+
+    upload_file = subparsers.add_parser("upload-file", help="Upload and display an image file")
+    upload_file.add_argument("host", help="Device IP, hostname, or URL")
+    upload_file.add_argument("path", type=Path, help="Local image path")
+    upload_file.add_argument(
+        "--hold-seconds",
+        type=float,
+        default=DEFAULT_HOLD_SECONDS,
+        help="Seconds to keep the uploaded image visible before restoring settings",
+    )
+    upload_file.add_argument(
+        "--no-restore",
+        action="store_true",
+        help="Leave device settings changed after the upload",
+    )
+    upload_file.add_argument(
+        "--takeover-album",
+        action="store_true",
+        help=(
+            "Back up and clear device images first, then restore them afterward. "
+            "Makes Pro display tests deterministic."
+        ),
+    )
+
+    brightness = subparsers.add_parser("brightness", help="Get or set display brightness")
+    brightness.add_argument("host", help="Device IP, hostname, or URL")
+    brightness_sub = brightness.add_subparsers(dest="brightness_command", required=True)
+    brightness_sub.add_parser("get", help="Read brightness")
+    brightness_set = brightness_sub.add_parser("set", help="Set brightness")
+    brightness_set.add_argument("value", type=int, help="Brightness 0-100")
+
+    return parser
+
+
+def _identity_text(device: GeekMagicDevice) -> str:
+    """Return a human-readable device identity."""
+    identity = device.model_name or device.model
+    if device.firmware_version:
+        return f"{identity} ({device.firmware_version})"
+    return identity
+
+
+def _format_backup(backup: DeviceSettingsBackup) -> str:
+    """Return a concise settings snapshot summary."""
+    parts: list[str] = []
+    if backup.state is not None:
+        parts.append(f"theme={backup.state.theme}")
+        parts.append(f"image={backup.state.current_image or 'unknown'}")
+    if backup.brightness is not None:
+        parts.append(f"brightness={backup.brightness}")
+    if backup.album is not None:
+        parts.append(
+            "album="
+            f"interval:{backup.album.interval},"
+            f"gif_loop:{backup.album.gif_loop},"
+            f"autoplay:{backup.album.autoplay}"
+        )
+    if backup.pro_album_files is not None:
+        parts.append(f"pro_album_files={len(backup.pro_album_files)}")
+    if backup.sdpro_photos is not None:
+        enabled = sum(1 for photo in backup.sdpro_photos.files if photo.enabled)
+        parts.append(
+            f"sdpro_photos={len(backup.sdpro_photos.files)} files,"
+            f"{enabled} enabled,interval:{backup.sdpro_photos.interval}"
+        )
+    if backup.sdpro_themes is not None:
+        enabled = sum(1 for theme in backup.sdpro_themes.themes if theme.enabled)
+        parts.append(
+            f"sdpro_themes={len(backup.sdpro_themes.themes)} themes,"
+            f"{enabled} enabled,interval:{backup.sdpro_themes.interval}"
+        )
+    if backup.sdpro_active_theme is not None:
+        parts.append(f"sdpro_active_theme={backup.sdpro_active_theme}")
+    return ", ".join(parts) if parts else "nothing readable"
+
+
+async def _detect(device: GeekMagicDevice) -> None:
+    """Detect model and print identity."""
+    print("Step 1: detect model")
+    model = await device.detect_model()
+    print(f"  detected: {_identity_text(device)}")
+    print(f"  profile: {model}")
+
+
+async def _run_probe(device: GeekMagicDevice) -> int:
+    """Run non-mutating probe command."""
+    await _detect(device)
+
+    print("Step 2: read storage")
+    try:
+        space = await device.get_space()
+        used = space.total - space.free
+        print(f"  storage: {used} used / {space.total} total ({space.free} free)")
+    except Exception as err:
+        print(f"  storage: unavailable ({err})")
+
+    print("Step 3: read brightness")
+    try:
+        brightness = await device.get_brightness()
+        print(f"  brightness: {brightness}")
+    except Exception as err:
+        print(f"  brightness: unavailable ({err})")
+
+    print("Step 4: capabilities")
+    supports_rendering = _supports_rendering(device)
+    print(f"  rendered dashboard: {supports_rendering}")
+    if supports_rendering:
+        print(f"  custom image theme: {device.custom_theme}")
+        print(f"  built-in modes: {', '.join(device.builtin_modes)}")
+    else:
+        print("  custom image theme: unavailable")
+        print("  built-in modes: unavailable")
+    return 0
+
+
+def _supports_rendering(device: GeekMagicDevice) -> bool:
+    """Return whether the stock render/upload/display path is supported."""
+    return device.model in SUPPORTED_RENDER_MODELS
+
+
+async def _backup_settings(device: GeekMagicDevice, step: int) -> DeviceSettingsBackup:
+    """Back up settings before mutating a live device."""
+    print(f"Step {step}: back up device settings")
+    backup = await device.backup_settings()
+    print(f"  backup: {_format_backup(backup)}")
+    return backup
+
+
+async def _hold_for_viewing(hold_seconds: float, sleep: SleepFunc, step: int) -> None:
+    """Keep the test visible long enough for human verification."""
+    if hold_seconds <= 0:
+        return
+    print(f"Step {step}: hold test image for {hold_seconds:g}s")
+    await sleep(hold_seconds)
+    print("  hold: complete")
+
+
+async def _restore_settings(
+    device: GeekMagicDevice,
+    backup: DeviceSettingsBackup,
+    step: int,
+) -> None:
+    """Restore settings captured before a mutating test."""
+    print(f"Step {step}: restore original settings")
+    await device.restore_settings(backup)
+    print("  restore: success")
+
+
+async def _maybe_takeover_album(
+    device: GeekMagicDevice,
+    backup: DeviceSettingsBackup,
+    takeover_album: bool,
+    step: int,
+) -> None:
+    """Optionally clear the device album before uploading."""
+    if takeover_album:
+        print(f"Step {step}: back up and clear image album")
+        if device.model == MODEL_PRO:
+            backup.pro_album_files = await device.backup_pro_album_files()
+            print(f"  backed up: {len(backup.pro_album_files)} album files")
+            await device.clear_pro_album_files()
+            print("  cleared: all existing device images were removed")
+        elif device.model == MODEL_SD_PRO:
+            print("  SD_PRO: using slideshow toggles instead of deleting photos")
+        else:
+            await device.clear_images()
+            print("  cleared: all existing device images were removed")
+    elif device.model == MODEL_PRO:
+        print("Note: Pro Picture mode cycles the device album.")
+        print("      Use --takeover-album for deterministic display on a Pro.")
+    elif device.model == MODEL_SD_PRO:
+        print(
+            "Note: SD_PRO test temporarily makes the uploaded photo the only active slideshow item."
+        )
+
+
+async def _run_render_test(
+    device: GeekMagicDevice,
+    dashboard: str,
+    filename: str,
+    takeover_album: bool,
+    hold_seconds: float,
+    restore: bool,
+    sleep: SleepFunc,
+) -> int:
+    """Render a test dashboard and display it."""
+    await _detect(device)
+
+    if not _supports_rendering(device):
+        print("Step 2: stop before mutation")
+        print(f"  unsupported: profile '{device.model}' has no stock upload/display path")
+        return 2
+
+    backup = await _backup_settings(device, 2)
+    try:
+        print(f"Step 3: render dashboard '{dashboard}'")
+        renderer = Renderer()
+        _, render_func = DASHBOARDS[dashboard]
+        image_data = render_func(renderer)
+        print(f"  rendered: {len(image_data)} bytes")
+
+        await _maybe_takeover_album(device, backup, takeover_album, 4)
+
+        print(f"Step 5: upload and display as {filename}")
+        print(f"  custom image theme: {device.custom_theme}")
+        await device.upload_and_display(
+            image_data,
+            filename,
+            manage_album=takeover_album,
+            enter_picture=True,
+        )
+        print("  success: device should now show the rendered dashboard")
+        if device.model == MODEL_PRO:
+            print("  note: if it is not visible, manually select the Picture app on the device")
+
+        await _hold_for_viewing(hold_seconds, sleep, 6)
+    finally:
+        if restore:
+            await _restore_settings(device, backup, 7)
+            if device.model == MODEL_SD_PRO:
+                names = (
+                    {photo.name for photo in backup.sdpro_photos.files}
+                    if backup.sdpro_photos is not None
+                    else set()
+                )
+                if filename not in names:
+                    print("Step 8: remove uploaded SD_PRO test photo")
+                    try:
+                        await device.delete_sdpro_photo(filename)
+                    except Exception as err:
+                        print(f"  cleanup warning: {err}")
+                    else:
+                        print("  cleanup: success")
+        else:
+            print("Step 7: restore skipped (--no-restore)")
+    return 0
+
+
+async def _run_upload_file(
+    device: GeekMagicDevice,
+    path: Path,
+    takeover_album: bool,
+    hold_seconds: float,
+    restore: bool,
+    sleep: SleepFunc,
+) -> int:
+    """Upload an existing image and display it."""
+    await _detect(device)
+
+    if not _supports_rendering(device):
+        print("Step 2: stop before mutation")
+        print(f"  unsupported: profile '{device.model}' has no stock upload/display path")
+        return 2
+
+    backup = await _backup_settings(device, 2)
+    try:
+        print(f"Step 3: read image file {path}")
+        image_data = await asyncio.to_thread(path.read_bytes)
+        print(f"  read: {len(image_data)} bytes")
+
+        await _maybe_takeover_album(device, backup, takeover_album, 4)
+
+        print(f"Step 5: upload and display as {path.name}")
+        print(f"  custom image theme: {device.custom_theme}")
+        await device.upload_and_display(
+            image_data,
+            path.name,
+            manage_album=takeover_album,
+            enter_picture=True,
+        )
+        print("  success: device should now show the uploaded image")
+        if device.model == MODEL_PRO:
+            print("  note: if it is not visible, manually select the Picture app on the device")
+
+        await _hold_for_viewing(hold_seconds, sleep, 6)
+    finally:
+        if restore:
+            await _restore_settings(device, backup, 7)
+            if device.model == MODEL_SD_PRO:
+                names = (
+                    {photo.name for photo in backup.sdpro_photos.files}
+                    if backup.sdpro_photos is not None
+                    else set()
+                )
+                if path.name not in names:
+                    print("Step 8: remove uploaded SD_PRO test photo")
+                    try:
+                        await device.delete_sdpro_photo(path.name)
+                    except Exception as err:
+                        print(f"  cleanup warning: {err}")
+                    else:
+                        print("  cleanup: success")
+        else:
+            print("Step 7: restore skipped (--no-restore)")
+    return 0
+
+
+async def _run_brightness(device: GeekMagicDevice, args: argparse.Namespace) -> int:
+    """Run brightness get/set command."""
+    await _detect(device)
+
+    if args.brightness_command == "get":
+        print("Step 2: read brightness")
+        brightness = await device.get_brightness()
+        print(f"  brightness: {brightness}")
+        return 0
+
+    print(f"Step 2: set brightness to {args.value}")
+    await device.set_brightness(args.value)
+    print("  success")
+    return 0
+
+
+async def run(
+    args: argparse.Namespace,
+    device_factory: DeviceFactory = GeekMagicDevice,
+    sleep: SleepFunc = asyncio.sleep,
+) -> int:
+    """Run a parsed CLI command."""
+    device = device_factory(args.host)
+    try:
+        if args.command == "probe":
+            return await _run_probe(device)
+        if args.command == "render-test":
+            return await _run_render_test(
+                device,
+                args.dashboard,
+                args.filename,
+                args.takeover_album,
+                args.hold_seconds,
+                not args.no_restore,
+                sleep,
+            )
+        if args.command == "upload-file":
+            return await _run_upload_file(
+                device,
+                args.path,
+                args.takeover_album,
+                args.hold_seconds,
+                not args.no_restore,
+                sleep,
+            )
+        if args.command == "brightness":
+            return await _run_brightness(device, args)
+        raise ValueError(f"Unknown command: {args.command}")
+    finally:
+        await device.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run the CLI."""
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(run(args))
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        return 130
+    except Exception as err:
+        print(f"Error: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/entities/test_entities.py
+++ b/tests/entities/test_entities.py
@@ -22,6 +22,10 @@ def mock_coordinator():
     coordinator.builtin_theme = 0
     coordinator.current_screen = 0
     coordinator.device = MagicMock()
+    coordinator.device.builtin_modes = {
+        "Weather Clock Today": 1,
+        "Weather Forecast": 2,
+    }
     coordinator.device.set_theme = AsyncMock()
     coordinator.set_display_mode = MagicMock()
     coordinator.async_request_refresh = AsyncMock()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,9 @@ Uses aioclient_mock to mock HTTP responses at the boundary, letting the
 real GeekMagicDevice client run inside the config flow.
 """
 
+import json
 import re
+from pathlib import Path
 
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -65,6 +67,24 @@ class TestConfigFlowImports:
         assert hasattr(GeekMagicConfigFlow, "VERSION")
         assert hasattr(GeekMagicConfigFlow, "async_step_user")
         assert hasattr(GeekMagicConfigFlow, "async_get_options_flow")
+
+    def test_pro_album_warning_strings_are_available_for_config_and_options(self):
+        """Test destructive Pro album checkbox has labels in both flows."""
+        strings_path = (
+            Path(__file__).resolve().parents[1] / "custom_components" / "geekmagic" / "strings.json"
+        )
+        strings = json.loads(strings_path.read_text())
+
+        config_step = strings["config"]["step"]["pro_managed_album"]
+        options_step = strings["options"]["step"]["pro_managed_album"]
+
+        for step in (config_step, options_step):
+            assert "delete existing pictures" in step["description"]
+            assert "manually select the Picture app" in step["description"]
+            assert CONF_MANAGE_PRO_ALBUM in step["data"]
+            assert "keep one managed dashboard image" in step["data"][CONF_MANAGE_PRO_ALBUM]
+
+        assert "confirm_required" in strings["options"]["error"]
 
 
 class TestConfigFlowUser:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,6 +17,8 @@ from custom_components.geekmagic.config_flow import (
 from custom_components.geekmagic.const import (
     CONF_LAYOUT,
     CONF_MANAGE_PRO_ALBUM,
+    CONF_MODEL_NAME,
+    CONF_PROFILE_ID,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
     CONF_SCREENS,
@@ -25,6 +27,7 @@ from custom_components.geekmagic.const import (
     DEFAULT_SCREEN_CYCLE_INTERVAL,
     DOMAIN,
     LAYOUT_GRID_2X2,
+    MODEL_PRO,
 )
 
 # Base URL for mocked device
@@ -126,6 +129,8 @@ class TestConfigFlowUser:
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["title"] == "Test Display"
         assert result["data"]["host"] == DEVICE_HOST
+        assert result["data"][CONF_PROFILE_ID] == "ultra"
+        assert result["data"][CONF_MODEL_NAME] == "SmallTV Ultra"
 
         # Check default options were created
         assert CONF_SCREENS in result["options"]
@@ -184,6 +189,8 @@ class TestConfigFlowUser:
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["title"] == "Pro Display"
+        assert result["data"][CONF_PROFILE_ID] == MODEL_PRO
+        assert result["data"][CONF_MODEL_NAME] == "GeekMagic SmallTV-PRO"
         assert result["options"][CONF_MANAGE_PRO_ALBUM] is True
 
     async def test_user_flow_creates_full_integration(self, hass: HomeAssistant, aioclient_mock):
@@ -218,7 +225,11 @@ class TestOptionsFlowInit:
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="Pro Display",
-            data={"host": DEVICE_HOST, "name": "Pro Display"},
+            data={
+                "host": DEVICE_HOST,
+                "name": "Pro Display",
+                CONF_PROFILE_ID: MODEL_PRO,
+            },
             options={CONF_REFRESH_INTERVAL: DEFAULT_REFRESH_INTERVAL},
         )
         entry.add_to_hass(hass)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,7 @@ import re
 
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.geekmagic.config_flow import (
     GeekMagicConfigFlow,
@@ -15,6 +16,7 @@ from custom_components.geekmagic.config_flow import (
 )
 from custom_components.geekmagic.const import (
     CONF_LAYOUT,
+    CONF_MANAGE_PRO_ALBUM,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
     CONF_SCREENS,
@@ -36,6 +38,7 @@ def _mock_device_success(aioclient_mock, host: str = DEVICE_HOST):
     # test_connection calls get_space
     aioclient_mock.get(f"{base}/space.json", json={"total": 1048576, "free": 524288})
     # Model detection
+    aioclient_mock.get(f"{base}/v.json", status=404)
     aioclient_mock.get(f"{base}/.sys/app.json", status=404)
     aioclient_mock.get(f"{base}/app.json", json={"theme": 0, "brt": 50, "img": None})
     # Brightness, upload, set commands (for full setup after entry creation)
@@ -147,6 +150,42 @@ class TestConfigFlowUser:
         # Data stores original user input
         assert result["data"]["host"] == f"http://{DEVICE_HOST}"
 
+    async def test_user_flow_pro_requires_managed_album_confirmation(
+        self, hass: HomeAssistant, aioclient_mock
+    ):
+        """Test Pro setup warns before enabling destructive managed album mode."""
+        aioclient_mock.get(f"{BASE_URL}/space.json", json={"total": 1048576, "free": 524288})
+        aioclient_mock.get(
+            f"{BASE_URL}/v.json",
+            json={"m": "GeekMagic SmallTV-PRO", "v": "V3.3.76EN"},
+        )
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"host": DEVICE_HOST, "name": "Pro Display"},
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "pro_managed_album"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_MANAGE_PRO_ALBUM: False},
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": "confirm_required"}
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_MANAGE_PRO_ALBUM: True},
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == "Pro Display"
+        assert result["options"][CONF_MANAGE_PRO_ALBUM] is True
+
     async def test_user_flow_creates_full_integration(self, hass: HomeAssistant, aioclient_mock):
         """Test that successful config flow leads to a fully working integration."""
         _mock_device_success(aioclient_mock)
@@ -173,6 +212,92 @@ class TestOptionsFlowInit:
         """Test GeekMagicOptionsFlow can be instantiated."""
         flow = GeekMagicOptionsFlow()
         assert flow is not None
+
+    async def test_options_flow_can_enable_managed_pro_album(self, hass: HomeAssistant):
+        """Test existing entries can opt into managed Pro album mode."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Pro Display",
+            data={"host": DEVICE_HOST, "name": "Pro Display"},
+            options={CONF_REFRESH_INTERVAL: DEFAULT_REFRESH_INTERVAL},
+        )
+        entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"action": "enable_pro_managed_album"},
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "pro_managed_album"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_MANAGE_PRO_ALBUM: False},
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": "confirm_required"}
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_MANAGE_PRO_ALBUM: True},
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_REFRESH_INTERVAL] == DEFAULT_REFRESH_INTERVAL
+        assert result["data"][CONF_MANAGE_PRO_ALBUM] is True
+
+    async def test_options_flow_can_disable_managed_pro_album(self, hass: HomeAssistant):
+        """Test managed Pro album mode can be turned off."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Pro Display",
+            data={"host": DEVICE_HOST, "name": "Pro Display"},
+            options={
+                CONF_REFRESH_INTERVAL: DEFAULT_REFRESH_INTERVAL,
+                CONF_MANAGE_PRO_ALBUM: True,
+            },
+        )
+        entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"action": "disable_pro_managed_album"},
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_REFRESH_INTERVAL] == DEFAULT_REFRESH_INTERVAL
+        assert result["data"][CONF_MANAGE_PRO_ALBUM] is False
+
+    async def test_reset_defaults_preserves_managed_pro_album(self, hass: HomeAssistant):
+        """Test resetting screens does not undo the destructive-album opt-in."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Pro Display",
+            data={"host": DEVICE_HOST, "name": "Pro Display"},
+            options={CONF_MANAGE_PRO_ALBUM: True},
+        )
+        entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"action": "reset_defaults"},
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"confirm": True},
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_MANAGE_PRO_ALBUM] is True
 
 
 class TestDefaultOptions:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -19,8 +19,12 @@ from custom_components.geekmagic.const import (
     MAX_BACKOFF_MULTIPLIER,
     MODEL_PRO,
 )
-from custom_components.geekmagic.coordinator import GeekMagicCoordinator
-from custom_components.geekmagic.device import ConnectionResult, RenderedDashboardRequest
+from custom_components.geekmagic.coordinator import CONF_ASSIGNED_VIEWS, GeekMagicCoordinator
+from custom_components.geekmagic.device import (
+    ConnectionResult,
+    DeviceState,
+    RenderedDashboardRequest,
+)
 
 
 @pytest.fixture
@@ -659,6 +663,8 @@ class TestCoordinatorBackoff:
         device.test_connection = AsyncMock(
             return_value=ConnectionResult(success=True, error="none", message="OK")
         )
+        device.is_builtin_theme = MagicMock(return_value=False)
+        device.set_theme_custom = AsyncMock()
         return device
 
     @pytest.fixture
@@ -925,6 +931,69 @@ class TestCoordinatorBackoff:
             allow_destructive_album_management=True,
             try_menu_navigation=False,
         )
+
+    @pytest.mark.asyncio
+    async def test_startup_builtin_state_skips_render_without_custom_request(
+        self, hass, backoff_device, simple_options
+    ):
+        """Test startup still respects a device already showing a built-in theme."""
+        backoff_device.get_state = AsyncMock(
+            return_value=DeviceState(theme=1, brightness=50, current_image=None)
+        )
+        backoff_device.is_builtin_theme = MagicMock(return_value=True)
+        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
+
+        with patch.object(coordinator, "_render_display", return_value=(b"jpeg", b"png")):
+            result = await coordinator._async_update_data()
+
+        assert result["builtin_mode"] is True
+        assert coordinator.display_mode == "builtin"
+        backoff_device.display_rendered_dashboard.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_custom_selection_renders_even_when_device_reports_builtin_theme(
+        self, hass, backoff_device, simple_options
+    ):
+        """Test selected HA views are not blocked by the device's current theme."""
+        backoff_device.get_state = AsyncMock(
+            return_value=DeviceState(theme=1, brightness=50, current_image=None)
+        )
+        backoff_device.is_builtin_theme = MagicMock(return_value=True)
+        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
+        coordinator.set_display_mode("custom", 0)
+
+        with patch.object(coordinator, "_render_display", return_value=(b"jpeg", b"png")):
+            result = await coordinator._async_update_data()
+
+        assert result["success"] is True
+        assert coordinator.display_mode == "custom"
+        backoff_device.display_rendered_dashboard.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_assigned_views_switch_from_builtin_to_custom_rendering(
+        self, hass, backoff_device, simple_options
+    ):
+        """Test panel view checkboxes make HA rendering authoritative."""
+        backoff_device.get_state = AsyncMock(
+            return_value=DeviceState(theme=1, brightness=50, current_image=None)
+        )
+        backoff_device.is_builtin_theme = MagicMock(return_value=True)
+        coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
+        coordinator.set_display_mode("builtin", 1)
+
+        coordinator.update_options(
+            {
+                **simple_options,
+                CONF_ASSIGNED_VIEWS: ["view_1"],
+            }
+        )
+
+        with patch.object(coordinator, "_render_display", return_value=(b"jpeg", b"png")):
+            result = await coordinator._async_update_data()
+
+        assert result["success"] is True
+        assert coordinator.display_mode == "custom"
+        backoff_device.display_rendered_dashboard.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_pro_picture_entry_is_not_automated(self, hass, backoff_device, simple_options):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -20,14 +20,14 @@ from custom_components.geekmagic.const import (
     MODEL_PRO,
 )
 from custom_components.geekmagic.coordinator import GeekMagicCoordinator
-from custom_components.geekmagic.device import ConnectionResult
+from custom_components.geekmagic.device import ConnectionResult, RenderedDashboardRequest
 
 
 @pytest.fixture
 def coordinator_device():
     """Create mock GeekMagic device for coordinator tests."""
     device = MagicMock()
-    device.upload_and_display = AsyncMock()
+    device.display_rendered_dashboard = AsyncMock()
     device.set_brightness = AsyncMock()
     return device
 
@@ -651,7 +651,7 @@ class TestCoordinatorBackoff:
         device = MagicMock()
         device.host = "192.168.1.100"
         device.model = "unknown"
-        device.upload_and_display = AsyncMock()
+        device.display_rendered_dashboard = AsyncMock()
         device.set_brightness = AsyncMock()
         device.get_brightness = AsyncMock(return_value=50)
         device.get_state = AsyncMock(return_value=None)
@@ -869,7 +869,7 @@ class TestCoordinatorBackoff:
         assert "Device offline" in str(exc_info.value)
 
         # Verify expensive operations were NOT called
-        backoff_device.upload_and_display.assert_not_called()
+        backoff_device.display_rendered_dashboard.assert_not_called()
 
         # Verify connectivity check WAS called
         backoff_device.test_connection.assert_called_once()
@@ -917,11 +917,13 @@ class TestCoordinatorBackoff:
             result = await coordinator._async_update_data()
 
         assert result["success"] is True
-        backoff_device.upload_and_display.assert_awaited_once_with(
-            b"jpeg",
-            "dashboard.jpg",
-            manage_album=True,
-            enter_picture=False,
+        backoff_device.display_rendered_dashboard.assert_awaited_once()
+        request = backoff_device.display_rendered_dashboard.await_args.args[0]
+        assert request == RenderedDashboardRequest(
+            image_data=b"jpeg",
+            filename="dashboard.jpg",
+            allow_destructive_album_management=True,
+            try_menu_navigation=False,
         )
 
     @pytest.mark.asyncio
@@ -938,8 +940,11 @@ class TestCoordinatorBackoff:
             await coordinator._async_update_data()
             await coordinator._async_update_data()
 
-        assert backoff_device.upload_and_display.await_args_list[0].kwargs["enter_picture"] is False
-        assert backoff_device.upload_and_display.await_args_list[1].kwargs["enter_picture"] is False
+        requests = [
+            call.args[0] for call in backoff_device.display_rendered_dashboard.await_args_list
+        ]
+        assert requests[0].try_menu_navigation is False
+        assert requests[1].try_menu_navigation is False
 
     @pytest.mark.asyncio
     async def test_first_failure_marks_offline(self, hass, backoff_device, simple_options):
@@ -949,7 +954,9 @@ class TestCoordinatorBackoff:
         coordinator = GeekMagicCoordinator(hass, backoff_device, simple_options)
 
         # Mock upload to fail
-        backoff_device.upload_and_display = AsyncMock(side_effect=Exception("Connection refused"))
+        backoff_device.display_rendered_dashboard = AsyncMock(
+            side_effect=Exception("Connection refused")
+        )
 
         # Mock the rendering to succeed but upload fails
         with (
@@ -995,7 +1002,7 @@ class TestCoordinatorBackoff:
         assert coordinator._device_offline is True
 
         # Verify expensive operations were NOT called
-        backoff_device.upload_and_display.assert_not_called()
+        backoff_device.display_rendered_dashboard.assert_not_called()
 
 
 class TestCoordinatorPause:
@@ -1012,7 +1019,7 @@ class TestCoordinatorPause:
         device = MagicMock()
         device.host = "192.168.1.100"
         device.model = "unknown"
-        device.upload_and_display = AsyncMock()
+        device.display_rendered_dashboard = AsyncMock()
         device.set_brightness = AsyncMock()
         device.get_brightness = AsyncMock(return_value=75)
         device.get_state = AsyncMock(return_value=None)
@@ -1049,7 +1056,7 @@ class TestCoordinatorPause:
         result = await coordinator._async_update_data()
 
         assert result == {"success": True, "paused": True}
-        pause_device.upload_and_display.assert_not_called()
+        pause_device.display_rendered_dashboard.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_set_active_false_dims_screen_and_pauses(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,6 +8,7 @@ import pytest
 from custom_components.geekmagic.const import (
     BACKOFF_LOG_INTERVAL,
     CONF_LAYOUT,
+    CONF_MANAGE_PRO_ALBUM,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
     CONF_SCREENS,
@@ -16,6 +17,7 @@ from custom_components.geekmagic.const import (
     LAYOUT_GRID_2X2,
     LAYOUT_SPLIT_H,
     MAX_BACKOFF_MULTIPLIER,
+    MODEL_PRO,
 )
 from custom_components.geekmagic.coordinator import GeekMagicCoordinator
 from custom_components.geekmagic.device import ConnectionResult
@@ -898,6 +900,46 @@ class TestCoordinatorBackoff:
 
         # Verify update succeeded
         assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_managed_pro_album_option_passed_to_device(
+        self, hass, backoff_device, simple_options
+    ):
+        """Test coordinator asks the device to keep only the managed Pro image."""
+        backoff_device.model = MODEL_PRO
+        coordinator = GeekMagicCoordinator(
+            hass,
+            backoff_device,
+            {**simple_options, CONF_MANAGE_PRO_ALBUM: True},
+        )
+
+        with patch.object(coordinator, "_render_display", return_value=(b"jpeg", b"png")):
+            result = await coordinator._async_update_data()
+
+        assert result["success"] is True
+        backoff_device.upload_and_display.assert_awaited_once_with(
+            b"jpeg",
+            "dashboard.jpg",
+            manage_album=True,
+            enter_picture=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_pro_picture_entry_is_not_automated(self, hass, backoff_device, simple_options):
+        """Test Pro button navigation is never attempted by HA refreshes."""
+        backoff_device.model = MODEL_PRO
+        coordinator = GeekMagicCoordinator(
+            hass,
+            backoff_device,
+            {**simple_options, CONF_MANAGE_PRO_ALBUM: True},
+        )
+
+        with patch.object(coordinator, "_render_display", return_value=(b"jpeg", b"png")):
+            await coordinator._async_update_data()
+            await coordinator._async_update_data()
+
+        assert backoff_device.upload_and_display.await_args_list[0].kwargs["enter_picture"] is False
+        assert backoff_device.upload_and_display.await_args_list[1].kwargs["enter_picture"] is False
 
     @pytest.mark.asyncio
     async def test_first_failure_marks_offline(self, hass, backoff_device, simple_options):

--- a/tests/test_coordinator_media_images.py
+++ b/tests/test_coordinator_media_images.py
@@ -37,7 +37,7 @@ COORDINATOR_LOGGER = "custom_components.geekmagic.coordinator"
 def device():
     """Mock GeekMagic device — coordinator only uses it for upload/brightness."""
     d = MagicMock()
-    d.upload_and_display = AsyncMock()
+    d.display_rendered_dashboard = AsyncMock()
     d.set_brightness = AsyncMock()
     return d
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -16,8 +16,10 @@ from custom_components.geekmagic.device import (
     DeviceSettingsBackup,
     DeviceState,
     GeekMagicDevice,
+    RenderedDashboardRequest,
     SpaceInfo,
 )
+from custom_components.geekmagic.live_transaction import restore_settings
 
 
 @pytest.fixture
@@ -233,7 +235,7 @@ class TestGeekMagicDevice:
         from custom_components.geekmagic.const import MODEL_PRO
 
         device = GeekMagicDevice("192.168.1.100", session=mock_session, model=MODEL_PRO)
-        with patch("custom_components.geekmagic.device.asyncio.sleep", new_callable=AsyncMock):
+        with patch("custom_components.geekmagic.profiles.asyncio.sleep", new_callable=AsyncMock):
             await device.set_image("dashboard.jpg", enter_picture=True)
 
         calls = mock_session.get.call_args_list
@@ -252,18 +254,22 @@ class TestGeekMagicDevice:
         from custom_components.geekmagic.const import MODEL_PRO
 
         device = GeekMagicDevice("192.168.1.100", model=MODEL_PRO)
-        device.get_pro_image_files = AsyncMock(
+        get_image_files = AsyncMock(
             return_value=[
                 DeviceFile("boot.gif", "/image/boot.gif", 294),
                 DeviceFile("dashboard.jpg", "/image/dashboard.jpg", 10),
                 DeviceFile("old.jpg", "/image/old.jpg", 20),
             ]
         )
-        device.delete_file = AsyncMock()
+        delete_file = AsyncMock()
 
-        await device.keep_only_pro_image("dashboard.jpg")
+        with (
+            patch.object(device.profile, "get_image_files", get_image_files),
+            patch.object(device.profile, "delete_file", delete_file),
+        ):
+            await device.keep_only_pro_image("dashboard.jpg")
 
-        device.delete_file.assert_has_awaits(
+        delete_file.assert_has_awaits(
             [
                 call("/image/boot.gif"),
                 call("/image/old.jpg"),
@@ -276,15 +282,53 @@ class TestGeekMagicDevice:
         from custom_components.geekmagic.const import MODEL_PRO
 
         device = GeekMagicDevice("192.168.1.100", model=MODEL_PRO)
-        device.upload = AsyncMock()
-        device.keep_only_pro_image = AsyncMock()
-        device.set_image = AsyncMock()
+        upload = AsyncMock()
+        keep_only_image = AsyncMock()
+        set_image = AsyncMock()
 
-        await device.upload_and_display(b"jpeg", "dashboard.jpg", manage_album=True)
+        with (
+            patch.object(device.profile, "upload", upload),
+            patch.object(device.profile, "keep_only_image", keep_only_image),
+            patch.object(device.profile, "set_image", set_image),
+        ):
+            await device.upload_and_display(b"jpeg", "dashboard.jpg", manage_album=True)
 
-        device.upload.assert_awaited_once_with(b"jpeg", "dashboard.jpg")
-        device.keep_only_pro_image.assert_awaited_once_with("dashboard.jpg")
-        device.set_image.assert_awaited_once_with("dashboard.jpg", enter_picture=False)
+        upload.assert_awaited_once_with(b"jpeg", "dashboard.jpg")
+        keep_only_image.assert_awaited_once_with("dashboard.jpg")
+        set_image.assert_awaited_once_with(
+            "dashboard.jpg",
+            try_menu_navigation=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_display_rendered_dashboard_request_pro_respects_menu_flag(self):
+        """Test rendered dashboard requests keep Pro menu navigation explicit."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        device = GeekMagicDevice("192.168.1.100", model=MODEL_PRO)
+        upload = AsyncMock()
+        keep_only_image = AsyncMock()
+        set_image = AsyncMock()
+
+        with (
+            patch.object(device.profile, "upload", upload),
+            patch.object(device.profile, "keep_only_image", keep_only_image),
+            patch.object(device.profile, "set_image", set_image),
+        ):
+            await device.display_rendered_dashboard(
+                RenderedDashboardRequest(
+                    image_data=b"jpeg",
+                    filename="dashboard.jpg",
+                    allow_destructive_album_management=True,
+                    try_menu_navigation=True,
+                )
+            )
+
+        keep_only_image.assert_awaited_once_with("dashboard.jpg")
+        set_image.assert_awaited_once_with(
+            "dashboard.jpg",
+            try_menu_navigation=True,
+        )
 
     @pytest.mark.asyncio
     async def test_get_album_settings_pro_uses_sys_path(self, mock_session, mock_response):
@@ -315,7 +359,7 @@ class TestGeekMagicDevice:
             album=None,
         )
 
-        await device.restore_settings(backup)
+        await restore_settings(device, backup)
 
         calls = [call.args[0] for call in mock_session.get.call_args_list]
         assert calls == [
@@ -336,7 +380,7 @@ class TestGeekMagicDevice:
             album=AlbumSettings(interval=5, gif_loop=2, autoplay=0),
         )
 
-        await device.restore_settings(backup)
+        await restore_settings(device, backup)
 
         calls = [call.args[0] for call in mock_session.get.call_args_list]
         assert calls == [
@@ -584,20 +628,25 @@ class TestDeviceModelDetection:
         from custom_components.geekmagic.const import MODEL_PRO
 
         # Create mock response for Pro path
+        not_found = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=404,
+            message="Not Found",
+        )
         mock_response = MagicMock()
-        mock_response.status = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json = AsyncMock(return_value={"theme": "4"})
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock()
-        mock_session.get = MagicMock(return_value=mock_response)
+        mock_session.get = MagicMock(side_effect=[not_found, mock_response])
 
         device = GeekMagicDevice("192.168.1.100", session=mock_session)
         result = await device.detect_model()
 
         assert result == MODEL_PRO
         assert device.model == MODEL_PRO
-        # Should have tried Pro path first
-        mock_session.get.assert_called()
-        call_url = mock_session.get.call_args[0][0]
+        call_url = mock_session.get.call_args_list[-1][0][0]
         assert "/.sys/app.json" in call_url
 
     @pytest.mark.asyncio
@@ -606,7 +655,7 @@ class TestDeviceModelDetection:
         from custom_components.geekmagic.const import MODEL_PRO
 
         mock_response = MagicMock()
-        mock_response.status = 200
+        mock_response.raise_for_status = MagicMock()
         mock_response.json = AsyncMock(
             return_value={"m": "GeekMagic SmallTV-PRO", "v": "V3.3.76EN"}
         )
@@ -630,24 +679,26 @@ class TestDeviceModelDetection:
         from custom_components.geekmagic.const import MODEL_ULTRA
 
         # /v.json and Pro path fail, Ultra path succeeds
-        mock_response_v_fail = MagicMock()
-        mock_response_v_fail.status = 404
-        mock_response_v_fail.__aenter__ = AsyncMock(return_value=mock_response_v_fail)
-        mock_response_v_fail.__aexit__ = AsyncMock()
-
-        mock_response_pro_fail = MagicMock()
-        mock_response_pro_fail.status = 404
-        mock_response_pro_fail.__aenter__ = AsyncMock(return_value=mock_response_pro_fail)
-        mock_response_pro_fail.__aexit__ = AsyncMock()
+        v_not_found = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=404,
+            message="Not Found",
+        )
+        pro_not_found = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=404,
+            message="Not Found",
+        )
 
         mock_response_ok = MagicMock()
-        mock_response_ok.status = 200
+        mock_response_ok.raise_for_status = MagicMock()
+        mock_response_ok.json = AsyncMock(return_value={"theme": "3"})
         mock_response_ok.__aenter__ = AsyncMock(return_value=mock_response_ok)
         mock_response_ok.__aexit__ = AsyncMock()
 
-        mock_session.get = MagicMock(
-            side_effect=[mock_response_v_fail, mock_response_pro_fail, mock_response_ok]
-        )
+        mock_session.get = MagicMock(side_effect=[v_not_found, pro_not_found, mock_response_ok])
 
         device = GeekMagicDevice("192.168.1.100", session=mock_session)
         result = await device.detect_model()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -5,12 +5,15 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import aiohttp
 import pytest
 
 from custom_components.geekmagic.device import (
+    AlbumSettings,
+    DeviceFile,
+    DeviceSettingsBackup,
     DeviceState,
     GeekMagicDevice,
     SpaceInfo,
@@ -23,7 +26,7 @@ def mock_response():
     response = MagicMock()
     response.raise_for_status = MagicMock()
     response.__aenter__ = AsyncMock(return_value=response)
-    response.__aexit__ = AsyncMock()
+    response.__aexit__ = AsyncMock(return_value=False)
     return response
 
 
@@ -49,8 +52,8 @@ class TestDeviceState:
 
     def test_state_with_none_values(self):
         """Test creating a state with None values."""
-        state = DeviceState(theme=0, brightness=None, current_image=None)
-        assert state.theme == 0
+        state = DeviceState(theme=None, brightness=None, current_image=None)
+        assert state.theme is None
         assert state.brightness is None
         assert state.current_image is None
 
@@ -143,6 +146,34 @@ class TestGeekMagicDevice:
         mock_session.get.assert_called_once_with("http://192.168.1.100/brt.json")
 
     @pytest.mark.asyncio
+    async def test_get_brightness_pro_uses_sys_path(self, mock_session, mock_response):
+        """Test Pro brightness is read from the firmware's /.sys path."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        mock_response.json = AsyncMock(return_value={"brt": "85"})
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session, model=MODEL_PRO)
+        brightness = await device.get_brightness()
+
+        assert brightness == 85
+        mock_session.get.assert_called_once_with("http://192.168.1.100/.sys/brt.json")
+
+    @pytest.mark.asyncio
+    async def test_get_state_pro_uses_sys_app_json(self, mock_session, mock_response):
+        """Test Pro state is read from the firmware's /.sys path when present."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        mock_response.json = AsyncMock(return_value={"theme": "4"})
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session, model=MODEL_PRO)
+        state = await device.get_state()
+
+        assert state.theme == 4
+        assert state.brightness is None
+        assert state.current_image is None
+        mock_session.get.assert_called_once_with("http://192.168.1.100/.sys/app.json")
+
+    @pytest.mark.asyncio
     async def test_set_brightness(self, mock_session, mock_response):
         """Test setting brightness."""
         device = GeekMagicDevice("192.168.1.100", session=mock_session)
@@ -180,6 +211,149 @@ class TestGeekMagicDevice:
         assert len(calls) == 2
         assert "theme=3" in str(calls[0])
         assert "img=/image/dashboard.jpg" in str(calls[1])
+
+    @pytest.mark.asyncio
+    async def test_set_image_pro_uses_picture_theme(self, mock_session, mock_response):
+        """Test Pro devices use album settings and picture theme without buttons."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session, model=MODEL_PRO)
+        await device.set_image("dashboard.jpg")
+
+        calls = mock_session.get.call_args_list
+        assert len(calls) == 2
+        assert "i_i=1" in str(calls[0])
+        assert "gif_loop=1" in str(calls[0])
+        assert "autoplay=1" in str(calls[0])
+        assert "theme=4" in str(calls[1])
+
+    @pytest.mark.asyncio
+    async def test_set_image_pro_can_explicitly_enter_picture(self, mock_session, mock_response):
+        """Test Pro button navigation is opt-in for live diagnostics."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session, model=MODEL_PRO)
+        with patch("custom_components.geekmagic.device.asyncio.sleep", new_callable=AsyncMock):
+            await device.set_image("dashboard.jpg", enter_picture=True)
+
+        calls = mock_session.get.call_args_list
+        assert len(calls) == 5
+        assert "i_i=1" in str(calls[0])
+        assert "gif_loop=1" in str(calls[0])
+        assert "autoplay=1" in str(calls[0])
+        assert "theme=4" in str(calls[1])
+        assert "enter=-1" in str(calls[2])
+        assert "page=1" in str(calls[3])
+        assert "enter=-1" in str(calls[4])
+
+    @pytest.mark.asyncio
+    async def test_keep_only_pro_image_deletes_other_album_files(self):
+        """Test managed Pro album deletes every file except the HA dashboard."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        device = GeekMagicDevice("192.168.1.100", model=MODEL_PRO)
+        device.get_pro_image_files = AsyncMock(
+            return_value=[
+                DeviceFile("boot.gif", "/image/boot.gif", 294),
+                DeviceFile("dashboard.jpg", "/image/dashboard.jpg", 10),
+                DeviceFile("old.jpg", "/image/old.jpg", 20),
+            ]
+        )
+        device.delete_file = AsyncMock()
+
+        await device.keep_only_pro_image("dashboard.jpg")
+
+        device.delete_file.assert_has_awaits(
+            [
+                call("/image/boot.gif"),
+                call("/image/old.jpg"),
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_upload_and_display_pro_managed_album_keeps_single_file(self):
+        """Test managed Pro upload keeps only the uploaded dashboard image."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        device = GeekMagicDevice("192.168.1.100", model=MODEL_PRO)
+        device.upload = AsyncMock()
+        device.keep_only_pro_image = AsyncMock()
+        device.set_image = AsyncMock()
+
+        await device.upload_and_display(b"jpeg", "dashboard.jpg", manage_album=True)
+
+        device.upload.assert_awaited_once_with(b"jpeg", "dashboard.jpg")
+        device.keep_only_pro_image.assert_awaited_once_with("dashboard.jpg")
+        device.set_image.assert_awaited_once_with("dashboard.jpg", enter_picture=False)
+
+    @pytest.mark.asyncio
+    async def test_get_album_settings_pro_uses_sys_path(self, mock_session, mock_response):
+        """Test Pro album settings are read from the firmware's /.sys path."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        mock_response.json = AsyncMock(return_value={"i_i": "5", "gif_loop": "2", "autoplay": 1})
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session, model=MODEL_PRO)
+        album = await device.get_album_settings()
+
+        assert album.interval == 5
+        assert album.gif_loop == 2
+        assert album.autoplay == 1
+        mock_session.get.assert_called_once_with("http://192.168.1.100/.sys/album.json")
+
+    @pytest.mark.asyncio
+    async def test_restore_settings_ultra_restores_image_when_known(
+        self, mock_session, mock_response
+    ):
+        """Test restore puts Ultra brightness, theme, and image back when known."""
+        from custom_components.geekmagic.const import MODEL_ULTRA
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session, model=MODEL_ULTRA)
+        backup = DeviceSettingsBackup(
+            state=DeviceState(theme=3, brightness=None, current_image="/image/old.jpg"),
+            brightness=71,
+            album=None,
+        )
+
+        await device.restore_settings(backup)
+
+        calls = [call.args[0] for call in mock_session.get.call_args_list]
+        assert calls == [
+            "http://192.168.1.100/set?brt=71",
+            "http://192.168.1.100/set?theme=3",
+            "http://192.168.1.100/set?img=/image/old.jpg",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_restore_settings_pro_restores_album_and_theme(self, mock_session, mock_response):
+        """Test restore puts Pro brightness, album settings, and theme back."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session, model=MODEL_PRO)
+        backup = DeviceSettingsBackup(
+            state=DeviceState(theme=6, brightness=None, current_image=None),
+            brightness=85,
+            album=AlbumSettings(interval=5, gif_loop=2, autoplay=0),
+        )
+
+        await device.restore_settings(backup)
+
+        calls = [call.args[0] for call in mock_session.get.call_args_list]
+        assert calls == [
+            "http://192.168.1.100/set?brt=85",
+            "http://192.168.1.100/set?i_i=5&gif_loop=2&autoplay=0",
+            "http://192.168.1.100/set?theme=6",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_set_image_raises_on_device_fail_body(self, mock_session, mock_response):
+        """Test HTTP 200 with body FAIL is treated as a firmware rejection."""
+        mock_response.text = AsyncMock(return_value="FAIL")
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session)
+
+        with pytest.raises(RuntimeError, match="Device rejected"):
+            await device.set_image("dashboard.jpg")
 
     @pytest.mark.asyncio
     async def test_upload(self, mock_session, mock_response):
@@ -427,28 +601,86 @@ class TestDeviceModelDetection:
         assert "/.sys/app.json" in call_url
 
     @pytest.mark.asyncio
+    async def test_detect_model_pro_v_json(self, mock_session):
+        """Test detecting current Pro firmware via /v.json."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={"m": "GeekMagic SmallTV-PRO", "v": "V3.3.76EN"}
+        )
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session)
+        result = await device.detect_model()
+
+        assert result == MODEL_PRO
+        assert device.model == MODEL_PRO
+        assert device.model_name == "GeekMagic SmallTV-PRO"
+        assert device.firmware_version == "V3.3.76EN"
+        mock_session.get.assert_called_once()
+        assert "/v.json" in mock_session.get.call_args[0][0]
+
+    @pytest.mark.asyncio
     async def test_detect_model_ultra(self, mock_session):
         """Test detecting Ultra model when Pro path fails."""
         from custom_components.geekmagic.const import MODEL_ULTRA
 
-        # First call (Pro path) fails, second call (Ultra path) succeeds
-        mock_response_fail = MagicMock()
-        mock_response_fail.status = 404
-        mock_response_fail.__aenter__ = AsyncMock(return_value=mock_response_fail)
-        mock_response_fail.__aexit__ = AsyncMock()
+        # /v.json and Pro path fail, Ultra path succeeds
+        mock_response_v_fail = MagicMock()
+        mock_response_v_fail.status = 404
+        mock_response_v_fail.__aenter__ = AsyncMock(return_value=mock_response_v_fail)
+        mock_response_v_fail.__aexit__ = AsyncMock()
+
+        mock_response_pro_fail = MagicMock()
+        mock_response_pro_fail.status = 404
+        mock_response_pro_fail.__aenter__ = AsyncMock(return_value=mock_response_pro_fail)
+        mock_response_pro_fail.__aexit__ = AsyncMock()
 
         mock_response_ok = MagicMock()
         mock_response_ok.status = 200
         mock_response_ok.__aenter__ = AsyncMock(return_value=mock_response_ok)
         mock_response_ok.__aexit__ = AsyncMock()
 
-        mock_session.get = MagicMock(side_effect=[mock_response_fail, mock_response_ok])
+        mock_session.get = MagicMock(
+            side_effect=[mock_response_v_fail, mock_response_pro_fail, mock_response_ok]
+        )
 
         device = GeekMagicDevice("192.168.1.100", session=mock_session)
         result = await device.detect_model()
 
         assert result == MODEL_ULTRA
         assert device.model == MODEL_ULTRA
+
+    @pytest.mark.asyncio
+    async def test_get_state_pro_missing_app_json_uses_last_known_state(self, mock_session):
+        """Test Pro devices tolerate missing /app.json."""
+        from custom_components.geekmagic.const import MODEL_PRO
+
+        error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=404,
+            message="Not Found",
+        )
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock(side_effect=error)
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+        mock_session.get = MagicMock(return_value=mock_response)
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session, model=MODEL_PRO)
+        device._last_theme = 4
+        device._last_image = "/image/dashboard.jpg"
+
+        state = await device.get_state()
+
+        assert state.theme == 4
+        assert state.brightness is None
+        assert state.current_image == "/image/dashboard.jpg"
 
     @pytest.mark.asyncio
     async def test_navigate_next(self, mock_session):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -109,6 +109,11 @@ class TestGeekMagicDevice:
         assert device._session == mock_session
         assert device._owns_session is False
 
+    def test_init_with_source_address(self):
+        """Test device initialization can bind live HTTP to a source address."""
+        device = GeekMagicDevice("192.168.1.100", source_address="10.76.9.165")
+        assert device.transport.source_address == "10.76.9.165"
+
     @pytest.mark.asyncio
     async def test_get_state(self, mock_session, mock_response):
         """Test getting device state."""

--- a/tests/test_device_cli.py
+++ b/tests/test_device_cli.py
@@ -9,8 +9,9 @@ import pytest
 from custom_components.geekmagic.const import MODEL_PRO
 from custom_components.geekmagic.device import (
     AlbumSettings,
-    DeviceSettingsBackup,
     DeviceState,
+    FirmwareCapabilities,
+    RenderedDashboardRequest,
     SpaceInfo,
 )
 from scripts import device_cli
@@ -20,27 +21,39 @@ def _mock_device() -> MagicMock:
     """Create a mock GeekMagicDevice-like object."""
     device = MagicMock()
     device.model = MODEL_PRO
+    device.profile_id = MODEL_PRO
     device.model_name = "GeekMagic SmallTV-PRO"
     device.firmware_version = "V3.3.76EN"
     device.custom_theme = 4
     device.builtin_modes = {"Bitcoin": 0, "Clock": 6}
+    device.capabilities = FirmwareCapabilities(
+        profile_id=MODEL_PRO,
+        display_name="GeekMagic SmallTV-PRO",
+        firmware_version="V3.3.76EN",
+        supports_rendered_dashboard=True,
+        builtin_modes={"Bitcoin": 0, "Clock": 6},
+        custom_image_theme=4,
+        display_mechanism="picture_album",
+        requires_managed_album=True,
+    )
     device.detect_model = AsyncMock(return_value=MODEL_PRO)
     device.get_space = AsyncMock(return_value=SpaceInfo(total=1000, free=400))
     device.get_brightness = AsyncMock(return_value=85)
-    device.upload_and_display = AsyncMock()
+    device.get_state = AsyncMock(
+        return_value=DeviceState(theme=4, brightness=None, current_image=None)
+    )
+    device.get_album_settings = AsyncMock(
+        return_value=AlbumSettings(interval=5, gif_loop=1, autoplay=0)
+    )
+    device.display_rendered_dashboard = AsyncMock()
     device.set_brightness = AsyncMock()
+    device.set_album_display = AsyncMock()
+    device.set_theme = AsyncMock()
     device.clear_images = AsyncMock()
     device.backup_pro_album_files = AsyncMock(return_value=[])
+    device.restore_pro_album_files = AsyncMock()
     device.clear_pro_album_files = AsyncMock()
     device.delete_sdpro_photo = AsyncMock()
-    device.backup_settings = AsyncMock(
-        return_value=DeviceSettingsBackup(
-            state=DeviceState(theme=4, brightness=None, current_image=None),
-            brightness=85,
-            album=AlbumSettings(interval=5, gif_loop=1, autoplay=0),
-        )
-    )
-    device.restore_settings = AsyncMock()
     device.close = AsyncMock()
     return device
 
@@ -63,6 +76,16 @@ def test_parser_render_test_defaults() -> None:
     assert args.hold_seconds == device_cli.DEFAULT_HOLD_SECONDS
     assert args.no_restore is False
     assert args.takeover_album is False
+    assert args.try_enter_picture is False
+
+
+def test_parser_render_test_try_enter_picture() -> None:
+    """Test render-test can explicitly opt into Pro button navigation."""
+    args = device_cli.create_parser().parse_args(
+        ["render-test", "192.168.1.50", "--try-enter-picture"]
+    )
+
+    assert args.try_enter_picture is True
 
 
 def test_parser_upload_file() -> None:
@@ -74,6 +97,7 @@ def test_parser_upload_file() -> None:
     assert args.hold_seconds == device_cli.DEFAULT_HOLD_SECONDS
     assert args.takeover_album is False
     assert args.no_restore is False
+    assert args.try_enter_picture is False
 
 
 def test_parser_brightness_set() -> None:
@@ -116,18 +140,18 @@ async def test_run_render_test_uploads_rendered_dashboard() -> None:
 
     assert result == 0
     device.detect_model.assert_awaited_once()
-    device.backup_settings.assert_awaited_once()
-    device.upload_and_display.assert_awaited_once()
-    image_data, filename = device.upload_and_display.await_args.args
-    assert image_data.startswith(b"\xff\xd8")
-    assert filename == "cli-test.jpg"
-    assert device.upload_and_display.await_args.kwargs == {
-        "manage_album": False,
-        "enter_picture": True,
-    }
+    device.get_state.assert_awaited_once()
+    device.display_rendered_dashboard.assert_awaited_once()
+    request = device.display_rendered_dashboard.await_args.args[0]
+    assert isinstance(request, RenderedDashboardRequest)
+    assert request.image_data.startswith(b"\xff\xd8")
+    assert request.filename == "cli-test.jpg"
+    assert request.allow_destructive_album_management is False
+    assert request.try_menu_navigation is False
     device.clear_images.assert_not_awaited()
     sleep.assert_awaited_once_with(device_cli.DEFAULT_HOLD_SECONDS)
-    device.restore_settings.assert_awaited_once()
+    device.set_brightness.assert_awaited_once_with(85)
+    device.set_album_display.assert_awaited_once_with(interval=5, gif_loop=1, autoplay=0)
     device.close.assert_awaited_once()
 
 
@@ -153,12 +177,11 @@ async def test_run_render_test_can_take_over_album() -> None:
     assert result == 0
     device.backup_pro_album_files.assert_awaited_once()
     device.clear_pro_album_files.assert_awaited_once()
-    assert device.upload_and_display.await_args.kwargs == {
-        "manage_album": True,
-        "enter_picture": True,
-    }
+    request = device.display_rendered_dashboard.await_args.args[0]
+    assert request.allow_destructive_album_management is True
+    assert request.try_menu_navigation is False
     sleep.assert_not_awaited()
-    device.restore_settings.assert_awaited_once()
+    device.set_theme.assert_awaited_once_with(4)
 
 
 @pytest.mark.asyncio
@@ -175,15 +198,17 @@ async def test_run_upload_file_uploads_path_bytes(tmp_path) -> None:
     result = await device_cli.run(args, device_factory=lambda host: device, sleep=sleep)
 
     assert result == 0
-    device.backup_settings.assert_awaited_once()
-    device.upload_and_display.assert_awaited_once_with(
-        b"jpeg-data",
-        "image.jpg",
-        manage_album=False,
-        enter_picture=True,
+    device.get_state.assert_awaited_once()
+    device.display_rendered_dashboard.assert_awaited_once()
+    request = device.display_rendered_dashboard.await_args.args[0]
+    assert request == RenderedDashboardRequest(
+        image_data=b"jpeg-data",
+        filename="image.jpg",
+        allow_destructive_album_management=False,
+        try_menu_navigation=False,
     )
     sleep.assert_not_awaited()
-    device.restore_settings.assert_awaited_once()
+    device.set_brightness.assert_awaited_once_with(85)
     device.close.assert_awaited_once()
 
 
@@ -209,13 +234,34 @@ async def test_run_upload_file_can_take_over_album(tmp_path) -> None:
     assert result == 0
     device.backup_pro_album_files.assert_awaited_once()
     device.clear_pro_album_files.assert_awaited_once()
-    device.upload_and_display.assert_awaited_once_with(
-        b"jpeg-data",
-        "image.jpg",
-        manage_album=True,
-        enter_picture=True,
+    request = device.display_rendered_dashboard.await_args.args[0]
+    assert request.allow_destructive_album_management is True
+    assert request.try_menu_navigation is False
+    device.set_album_display.assert_awaited_once_with(interval=5, gif_loop=1, autoplay=0)
+
+
+@pytest.mark.asyncio
+async def test_run_upload_file_can_try_enter_picture(tmp_path) -> None:
+    """Test upload-file forwards the explicit Pro navigation flag."""
+    device = _mock_device()
+    image = tmp_path / "image.jpg"
+    image.write_bytes(b"jpeg-data")
+    args = device_cli.create_parser().parse_args(
+        [
+            "upload-file",
+            "192.168.1.50",
+            str(image),
+            "--hold-seconds",
+            "0",
+            "--try-enter-picture",
+        ]
     )
-    device.restore_settings.assert_awaited_once()
+
+    result = await device_cli.run(args, device_factory=lambda host: device, sleep=AsyncMock())
+
+    assert result == 0
+    request = device.display_rendered_dashboard.await_args.args[0]
+    assert request.try_menu_navigation is True
 
 
 @pytest.mark.asyncio
@@ -223,15 +269,21 @@ async def test_run_render_test_stops_before_unsupported_mutation() -> None:
     """Test unsupported devices are not mutated by render-test."""
     device = _mock_device()
     device.model = "unknown"
+    device.profile_id = "unknown"
+    device.capabilities = FirmwareCapabilities(
+        profile_id="unknown",
+        display_name="SmallTV",
+        supports_rendered_dashboard=False,
+    )
     args = device_cli.create_parser().parse_args(["render-test", "192.168.1.50"])
 
     result = await device_cli.run(args, device_factory=lambda host: device, sleep=AsyncMock())
 
     assert result == 2
-    device.backup_settings.assert_not_awaited()
+    device.get_state.assert_not_awaited()
     device.clear_images.assert_not_awaited()
-    device.upload_and_display.assert_not_awaited()
-    device.restore_settings.assert_not_awaited()
+    device.display_rendered_dashboard.assert_not_awaited()
+    device.set_brightness.assert_not_awaited()
     device.close.assert_awaited_once()
 
 
@@ -248,14 +300,9 @@ async def test_run_upload_file_can_skip_restore(tmp_path) -> None:
     result = await device_cli.run(args, device_factory=lambda host: device, sleep=AsyncMock())
 
     assert result == 0
-    device.backup_settings.assert_awaited_once()
-    device.upload_and_display.assert_awaited_once_with(
-        b"jpeg-data",
-        "image.jpg",
-        manage_album=False,
-        enter_picture=True,
-    )
-    device.restore_settings.assert_not_awaited()
+    device.get_state.assert_awaited_once()
+    device.display_rendered_dashboard.assert_awaited_once()
+    device.set_brightness.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_cli.py
+++ b/tests/test_device_cli.py
@@ -64,6 +64,18 @@ def test_parser_probe() -> None:
 
     assert args.command == "probe"
     assert args.host == "192.168.1.50"
+    assert args.bind_address is None
+
+
+def test_parser_probe_bind_address() -> None:
+    """Test probe command can bind to a local source address."""
+    args = device_cli.create_parser().parse_args(
+        ["probe", "--bind-address", "10.76.9.165", "192.168.1.50"]
+    )
+
+    assert args.command == "probe"
+    assert args.host == "192.168.1.50"
+    assert args.bind_address == "10.76.9.165"
 
 
 def test_parser_render_test_defaults() -> None:

--- a/tests/test_device_cli.py
+++ b/tests/test_device_cli.py
@@ -1,0 +1,271 @@
+"""Tests for live-device CLI wiring."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.geekmagic.const import MODEL_PRO
+from custom_components.geekmagic.device import (
+    AlbumSettings,
+    DeviceSettingsBackup,
+    DeviceState,
+    SpaceInfo,
+)
+from scripts import device_cli
+
+
+def _mock_device() -> MagicMock:
+    """Create a mock GeekMagicDevice-like object."""
+    device = MagicMock()
+    device.model = MODEL_PRO
+    device.model_name = "GeekMagic SmallTV-PRO"
+    device.firmware_version = "V3.3.76EN"
+    device.custom_theme = 4
+    device.builtin_modes = {"Bitcoin": 0, "Clock": 6}
+    device.detect_model = AsyncMock(return_value=MODEL_PRO)
+    device.get_space = AsyncMock(return_value=SpaceInfo(total=1000, free=400))
+    device.get_brightness = AsyncMock(return_value=85)
+    device.upload_and_display = AsyncMock()
+    device.set_brightness = AsyncMock()
+    device.clear_images = AsyncMock()
+    device.backup_pro_album_files = AsyncMock(return_value=[])
+    device.clear_pro_album_files = AsyncMock()
+    device.delete_sdpro_photo = AsyncMock()
+    device.backup_settings = AsyncMock(
+        return_value=DeviceSettingsBackup(
+            state=DeviceState(theme=4, brightness=None, current_image=None),
+            brightness=85,
+            album=AlbumSettings(interval=5, gif_loop=1, autoplay=0),
+        )
+    )
+    device.restore_settings = AsyncMock()
+    device.close = AsyncMock()
+    return device
+
+
+def test_parser_probe() -> None:
+    """Test probe command parsing."""
+    args = device_cli.create_parser().parse_args(["probe", "192.168.1.50"])
+
+    assert args.command == "probe"
+    assert args.host == "192.168.1.50"
+
+
+def test_parser_render_test_defaults() -> None:
+    """Test render-test command parsing."""
+    args = device_cli.create_parser().parse_args(["render-test", "192.168.1.50"])
+
+    assert args.command == "render-test"
+    assert args.dashboard == "clock"
+    assert args.filename == "cli-test.jpg"
+    assert args.hold_seconds == device_cli.DEFAULT_HOLD_SECONDS
+    assert args.no_restore is False
+    assert args.takeover_album is False
+
+
+def test_parser_upload_file() -> None:
+    """Test upload-file command parsing."""
+    args = device_cli.create_parser().parse_args(["upload-file", "192.168.1.50", "dashboard.jpg"])
+
+    assert args.command == "upload-file"
+    assert args.path.name == "dashboard.jpg"
+    assert args.hold_seconds == device_cli.DEFAULT_HOLD_SECONDS
+    assert args.takeover_album is False
+    assert args.no_restore is False
+
+
+def test_parser_brightness_set() -> None:
+    """Test brightness set command parsing."""
+    args = device_cli.create_parser().parse_args(["brightness", "192.168.1.50", "set", "80"])
+
+    assert args.command == "brightness"
+    assert args.brightness_command == "set"
+    assert args.value == 80
+
+
+@pytest.mark.asyncio
+async def test_run_probe_uses_device_methods(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test probe calls detection, storage, and brightness methods."""
+    device = _mock_device()
+    args = device_cli.create_parser().parse_args(["probe", "192.168.1.50"])
+
+    result = await device_cli.run(args, device_factory=lambda host: device)
+
+    assert result == 0
+    device.detect_model.assert_awaited_once()
+    device.get_space.assert_awaited_once()
+    device.get_brightness.assert_awaited_once()
+    device.close.assert_awaited_once()
+    output = capsys.readouterr().out
+    assert "GeekMagic SmallTV-PRO" in output
+    assert "custom image theme: 4" in output
+
+
+@pytest.mark.asyncio
+async def test_run_render_test_uploads_rendered_dashboard() -> None:
+    """Test render-test uploads through GeekMagicDevice."""
+    device = _mock_device()
+    sleep = AsyncMock()
+    args = device_cli.create_parser().parse_args(
+        ["render-test", "192.168.1.50", "--dashboard", "clock"]
+    )
+
+    result = await device_cli.run(args, device_factory=lambda host: device, sleep=sleep)
+
+    assert result == 0
+    device.detect_model.assert_awaited_once()
+    device.backup_settings.assert_awaited_once()
+    device.upload_and_display.assert_awaited_once()
+    image_data, filename = device.upload_and_display.await_args.args
+    assert image_data.startswith(b"\xff\xd8")
+    assert filename == "cli-test.jpg"
+    assert device.upload_and_display.await_args.kwargs == {
+        "manage_album": False,
+        "enter_picture": True,
+    }
+    device.clear_images.assert_not_awaited()
+    sleep.assert_awaited_once_with(device_cli.DEFAULT_HOLD_SECONDS)
+    device.restore_settings.assert_awaited_once()
+    device.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_render_test_can_take_over_album() -> None:
+    """Test render-test can explicitly clear the device album first."""
+    device = _mock_device()
+    sleep = AsyncMock()
+    args = device_cli.create_parser().parse_args(
+        [
+            "render-test",
+            "192.168.1.50",
+            "--dashboard",
+            "clock",
+            "--takeover-album",
+            "--hold-seconds",
+            "0",
+        ]
+    )
+
+    result = await device_cli.run(args, device_factory=lambda host: device, sleep=sleep)
+
+    assert result == 0
+    device.backup_pro_album_files.assert_awaited_once()
+    device.clear_pro_album_files.assert_awaited_once()
+    assert device.upload_and_display.await_args.kwargs == {
+        "manage_album": True,
+        "enter_picture": True,
+    }
+    sleep.assert_not_awaited()
+    device.restore_settings.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_upload_file_uploads_path_bytes(tmp_path) -> None:
+    """Test upload-file reads a path and uploads through GeekMagicDevice."""
+    device = _mock_device()
+    sleep = AsyncMock()
+    image = tmp_path / "image.jpg"
+    image.write_bytes(b"jpeg-data")
+    args = device_cli.create_parser().parse_args(
+        ["upload-file", "192.168.1.50", str(image), "--hold-seconds", "0"]
+    )
+
+    result = await device_cli.run(args, device_factory=lambda host: device, sleep=sleep)
+
+    assert result == 0
+    device.backup_settings.assert_awaited_once()
+    device.upload_and_display.assert_awaited_once_with(
+        b"jpeg-data",
+        "image.jpg",
+        manage_album=False,
+        enter_picture=True,
+    )
+    sleep.assert_not_awaited()
+    device.restore_settings.assert_awaited_once()
+    device.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_upload_file_can_take_over_album(tmp_path) -> None:
+    """Test upload-file takeover also exercises managed album upload."""
+    device = _mock_device()
+    image = tmp_path / "image.jpg"
+    image.write_bytes(b"jpeg-data")
+    args = device_cli.create_parser().parse_args(
+        [
+            "upload-file",
+            "192.168.1.50",
+            str(image),
+            "--takeover-album",
+            "--hold-seconds",
+            "0",
+        ]
+    )
+
+    result = await device_cli.run(args, device_factory=lambda host: device, sleep=AsyncMock())
+
+    assert result == 0
+    device.backup_pro_album_files.assert_awaited_once()
+    device.clear_pro_album_files.assert_awaited_once()
+    device.upload_and_display.assert_awaited_once_with(
+        b"jpeg-data",
+        "image.jpg",
+        manage_album=True,
+        enter_picture=True,
+    )
+    device.restore_settings.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_render_test_stops_before_unsupported_mutation() -> None:
+    """Test unsupported devices are not mutated by render-test."""
+    device = _mock_device()
+    device.model = "unknown"
+    args = device_cli.create_parser().parse_args(["render-test", "192.168.1.50"])
+
+    result = await device_cli.run(args, device_factory=lambda host: device, sleep=AsyncMock())
+
+    assert result == 2
+    device.backup_settings.assert_not_awaited()
+    device.clear_images.assert_not_awaited()
+    device.upload_and_display.assert_not_awaited()
+    device.restore_settings.assert_not_awaited()
+    device.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_upload_file_can_skip_restore(tmp_path) -> None:
+    """Test upload-file can intentionally leave settings changed."""
+    device = _mock_device()
+    image = tmp_path / "image.jpg"
+    image.write_bytes(b"jpeg-data")
+    args = device_cli.create_parser().parse_args(
+        ["upload-file", "192.168.1.50", str(image), "--hold-seconds", "0", "--no-restore"]
+    )
+
+    result = await device_cli.run(args, device_factory=lambda host: device, sleep=AsyncMock())
+
+    assert result == 0
+    device.backup_settings.assert_awaited_once()
+    device.upload_and_display.assert_awaited_once_with(
+        b"jpeg-data",
+        "image.jpg",
+        manage_album=False,
+        enter_picture=True,
+    )
+    device.restore_settings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_brightness_set_uses_device_method() -> None:
+    """Test brightness set calls GeekMagicDevice."""
+    device = _mock_device()
+    args = device_cli.create_parser().parse_args(["brightness", "192.168.1.50", "set", "80"])
+
+    result = await device_cli.run(args, device_factory=lambda host: device)
+
+    assert result == 0
+    device.set_brightness.assert_awaited_once_with(80)
+    device.close.assert_awaited_once()

--- a/tests/test_ha_integration.py
+++ b/tests/test_ha_integration.py
@@ -405,6 +405,21 @@ class TestDeviceRegistry:
         assert len(main_device) == 1
         assert "Ultra" in (main_device[0].model or "")
 
+    async def test_preview_entity_joins_main_device(self, hass: HomeAssistant, aioclient_mock):
+        """Test the preview image does not create a second physical device."""
+        from homeassistant.helpers import device_registry as dr
+
+        entry = await setup_integration(hass, aioclient_mock, model="ultra")
+
+        dev_reg = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+        geekmagic_devices = [d for d in devices if d.manufacturer == "GeekMagic"]
+
+        assert len(geekmagic_devices) == 1
+        device = geekmagic_devices[0]
+        assert (DOMAIN, entry.entry_id) in device.identifiers
+        assert (DOMAIN, DEVICE_HOST) not in device.identifiers
+
 
 class TestOptionsUpdate:
     """Test that options updates propagate correctly."""

--- a/tests/test_ha_integration.py
+++ b/tests/test_ha_integration.py
@@ -420,6 +420,36 @@ class TestDeviceRegistry:
         assert (DOMAIN, entry.entry_id) in device.identifiers
         assert (DOMAIN, DEVICE_HOST) not in device.identifiers
 
+    async def test_setup_removes_legacy_preview_host_device(
+        self, hass: HomeAssistant, aioclient_mock
+    ):
+        """Test setup removes duplicate devices from the old preview entity id."""
+        from homeassistant.helpers import device_registry as dr
+
+        setup_device_http_mocks(aioclient_mock, model="ultra")
+        entry = create_entry()
+        entry.add_to_hass(hass)
+
+        dev_reg = dr.async_get(hass)
+        legacy_device = dev_reg.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, DEVICE_HOST)},
+            manufacturer="GeekMagic",
+            model="SmallTV Pro",
+            name=entry.title,
+        )
+        assert legacy_device is not None
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        devices = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+        geekmagic_devices = [d for d in devices if d.manufacturer == "GeekMagic"]
+
+        assert dev_reg.async_get_device(identifiers={(DOMAIN, DEVICE_HOST)}) is None
+        assert len(geekmagic_devices) == 1
+        assert (DOMAIN, entry.entry_id) in geekmagic_devices[0].identifiers
+
 
 class TestOptionsUpdate:
     """Test that options updates propagate correctly."""

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -20,7 +20,7 @@ from custom_components.geekmagic.layouts.hero_simple import HeroSimpleLayout
 def coordinator_device():
     """Create mock GeekMagic device."""
     device = MagicMock()
-    device.upload_and_display = AsyncMock()
+    device.display_rendered_dashboard = AsyncMock()
     device.set_brightness = AsyncMock()
     device.get_brightness = AsyncMock(return_value=50)
     device.get_state = AsyncMock(return_value=None)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,209 @@
+"""Tests for firmware profile adapters."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from custom_components.geekmagic.const import MODEL_PRO, MODEL_SD_PRO, MODEL_ULTRA
+from custom_components.geekmagic.models import RenderedDashboardRequest
+from custom_components.geekmagic.profiles import (
+    SdProProfile,
+    StockProProfile,
+    StockUltraProfile,
+    detect_firmware_profile,
+)
+from custom_components.geekmagic.transport import DeviceTransport
+
+
+class FakeTransport(DeviceTransport):
+    """Minimal transport fake for profile adapter tests."""
+
+    def __init__(self, json_by_path: dict[str, dict[str, object]] | None = None) -> None:
+        """Initialize fake transport responses."""
+        self.host = "192.168.1.100"
+        self.base_url = "http://192.168.1.100"
+        self._session = None
+        self._owns_session = True
+        self.json_by_path = json_by_path or {}
+        self.checked: list[tuple[str, str]] = []
+        self.uploads: list[tuple[str, str, bytes, str, str]] = []
+
+    async def get_json(
+        self,
+        path: str,
+        request_timeout: aiohttp.ClientTimeout | None = None,
+    ) -> dict[str, object]:
+        """Return configured JSON or raise 404."""
+        if path not in self.json_by_path:
+            raise aiohttp.ClientResponseError(
+                request_info=MagicMock(),
+                history=(),
+                status=404,
+                message="Not Found",
+            )
+        return self.json_by_path[path]
+
+    async def get_checked(self, path: str, action: str) -> None:
+        """Record checked GET requests."""
+        self.checked.append((path, action))
+
+    async def post_file(
+        self,
+        path: str,
+        field_name: str,
+        image_data: bytes,
+        filename: str,
+        content_type: str,
+    ) -> None:
+        """Record multipart uploads."""
+        self.uploads.append((path, field_name, image_data, filename, content_type))
+
+
+@pytest.mark.asyncio
+async def test_ultra_profile_uploads_and_selects_direct_image() -> None:
+    """Ultra stock profile uses theme 3 and direct image selection."""
+    transport = FakeTransport(
+        {
+            "/app.json": {"theme": "3", "brt": "71", "img": "/image/old.jpg"},
+            "/space.json": {"total": 1000, "free": 400},
+            "/brt.json": {"brt": "71"},
+        }
+    )
+    profile = StockUltraProfile(transport)
+
+    assert profile.capabilities.profile_id == MODEL_ULTRA
+    assert profile.capabilities.custom_image_theme == 3
+    assert profile.capabilities.display_mechanism == "direct_image"
+
+    state = await profile.get_state()
+    assert state.theme == 3
+    assert state.brightness == 71
+    assert state.current_image == "/image/old.jpg"
+    assert await profile.get_brightness() == 71
+
+    space = await profile.get_space()
+    assert space.total == 1000
+    assert space.free == 400
+
+    await profile.display_rendered_dashboard(
+        RenderedDashboardRequest(image_data=b"jpeg", filename="dashboard.jpg")
+    )
+
+    assert transport.uploads == [
+        ("/doUpload?dir=/image/", "file", b"jpeg", "dashboard.jpg", "image/jpeg")
+    ]
+    assert transport.checked == [
+        ("/set?theme=3", "theme update"),
+        ("/set?img=/image/dashboard.jpg", "image selection for /image/dashboard.jpg"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pro_profile_uses_picture_theme_without_buttons_by_default() -> None:
+    """Pro stock profile uses theme 4 and does not press menu buttons by default."""
+    transport = FakeTransport(
+        {
+            "/.sys/brt.json": {"brt": "85"},
+            "/.sys/album.json": {"i_i": "5", "gif_loop": "2", "autoplay": "1"},
+        }
+    )
+    profile = StockProProfile(transport)
+
+    assert profile.capabilities.profile_id == MODEL_PRO
+    assert profile.capabilities.custom_image_theme == 4
+    assert profile.capabilities.display_mechanism == "picture_album"
+    assert profile.capabilities.requires_managed_album is True
+    assert await profile.get_brightness() == 85
+
+    album = await profile.get_album_settings()
+    assert album.interval == 5
+    assert album.gif_loop == 2
+    assert album.autoplay == 1
+
+    await profile.set_image("dashboard.jpg")
+    assert transport.checked == [
+        ("/set?i_i=1&gif_loop=1&autoplay=1", "album display update"),
+        ("/set?theme=4", "theme update"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pro_profile_menu_navigation_is_explicit() -> None:
+    """Pro stock profile only presses buttons when the request opts in."""
+    transport = FakeTransport()
+    profile = StockProProfile(transport)
+
+    with patch("custom_components.geekmagic.profiles.asyncio.sleep", new_callable=AsyncMock):
+        await profile.set_image("dashboard.jpg", try_menu_navigation=True)
+
+    assert [path for path, _action in transport.checked] == [
+        "/set?i_i=1&gif_loop=1&autoplay=1",
+        "/set?theme=4",
+        "/set?enter=-1",
+        "/set?page=1",
+        "/set?enter=-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sdpro_profile_uses_photo_slideshow_operations() -> None:
+    """SD_PRO profile owns config, upload, and slideshow toggles."""
+    transport = FakeTransport(
+        {
+            "/config": {"theme": 1, "brightness": 100},
+            "/photo/list": {
+                "total": 10,
+                "used": 2,
+                "interval": 7,
+                "files": [
+                    {"name": "old.jpg", "size": 123, "enabled": True},
+                    {"name": "dashboard.jpg", "size": 456, "enabled": False},
+                ],
+            },
+            "/theme/list": {
+                "interval": 30,
+                "themes": [
+                    {"id": 1, "name": "Weather", "enabled": True},
+                    {"id": 2, "name": "Photo", "enabled": False},
+                ],
+            },
+        }
+    )
+    profile = SdProProfile(transport)
+
+    assert profile.capabilities.profile_id == MODEL_SD_PRO
+    assert profile.capabilities.custom_image_theme == 2
+    assert profile.capabilities.display_mechanism == "photo_slideshow"
+
+    state = await profile.get_state()
+    assert state.theme == 1
+    assert state.brightness == 100
+
+    await profile.set_brightness(150)
+    await profile.display_rendered_dashboard(
+        RenderedDashboardRequest(image_data=b"jpeg", filename="dashboard.jpg")
+    )
+
+    assert transport.uploads == [("/photo/upload", "file", b"jpeg", "dashboard.jpg", "image/jpeg")]
+    assert [path for path, _action in transport.checked] == [
+        "/api/set?key=lcd_brightness&value=99",
+        "/photo/toggle?name=old.jpg&state=0",
+        "/photo/toggle?name=dashboard.jpg&state=1",
+        "/theme/toggle?id=1&state=0",
+        "/theme/toggle?id=2&state=1",
+        "/photo/interval?val=1",
+        "/api/set?key=theme&value=2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_detects_sdpro_profile_from_theme_list() -> None:
+    """Detection falls through to SD_PRO when stock paths are absent."""
+    transport = FakeTransport({"/theme/list": {"themes": [{"id": 2, "name": "Photo"}]}})
+
+    profile = await detect_firmware_profile(transport)
+
+    assert profile.capabilities.profile_id == MODEL_SD_PRO


### PR DESCRIPTION
## Summary

Adds first-class support for the three observed GeekMagic firmware families behind explicit firmware profiles:

- stock SmallTV Ultra firmware
- stock SmallTV Pro firmware
- SD_PRO / Smart Weather Clock community firmware

The public `GeekMagicDevice` facade stays stable for Home Assistant, scripts, and tests, while firmware-specific detection, capabilities, uploads, display behavior, brightness/state/storage paths, and failure tolerance now live in profile adapters.

## Issue Impact

Fixes #37: stock Ultra devices are no longer surfaced as Pro due to hardcoded/incorrect model metadata.

Fixes #59: stock SmallTV Pro now has a dedicated Picture-album render flow, managed-album option, and live-device validation path.

Fixes #89: stale duplicate preview devices are cleaned up automatically, and the preview image entity now joins the main HA device.

Related / partially addressed:

- #108: adds support for the different SD_PRO-style firmware family and improves profile-specific connection/render behavior, but the issue has multiple device symptoms that may need confirmation after release.
- #126: fixes the duplicate-device part and improves custom-view rendering after built-in mode selection; Arabic text shaping is still outside this PR.
- #135: Pro rendering no longer relies on `/set?img=...`, but the reported V3.4.82EN `open_app=Picture` behavior was not directly verified in this PR.

## Key Changes

- Split device behavior into firmware profiles plus a shared HTTP transport layer.
- Added capability reporting for profile id, display name, firmware version, built-ins, custom render mode, brightness range, warnings, and album requirements.
- Added Pro Picture mode support:
  - detect `GeekMagic SmallTV-PRO`
  - use `/.sys/brt.json` brightness
  - use `/set?theme=4` for Picture mode
  - upload to `/doUpload?dir=/image/`
  - display through managed Picture album state instead of `/set?img=...`
  - tolerate missing `/app.json`
- Added SD_PRO support through photo/theme slideshow APIs:
  - `/config`, `/theme/list`, `/photo/list`
  - `/api/set`, `/photo/upload`, `/photo/toggle`, `/theme/toggle`
- Updated HA rendering behavior so assigned custom views stay authoritative even when SD_PRO reports a rotating built-in firmware theme.
- Added explicit Pro managed-album consent copy in config/options flows.
- Fixed preview image device identity and added setup-time cleanup for stale legacy duplicate preview devices.
- Added repo-local live-device CLI commands for probing, render tests, uploads, brightness, source-address binding, backup/restore, and SD_PRO cleanup.

## Live Verification

Verified against the three local devices:

- stock Ultra firmware: probe + rendered upload/display succeeded
- stock Pro firmware: managed album upload/display succeeded after Picture mode validation
- SD_PRO / Smart Weather Clock firmware: rendered dashboard display succeeded by temporarily making the uploaded photo the active slideshow item, then restoring original settings

Also verified the live SD_PRO device from the repo with the CLI, including backup, display hold, restore, and uploaded test-photo cleanup.

## Tests

Passed:

- `.venv/bin/pytest` — 644 passed
- `.venv/bin/pytest tests/test_ha_integration.py` — 29 passed
- `.venv/bin/pytest tests/test_coordinator.py` — 64 passed
- touched-file `ruff check` / `ruff format --check`

Notes:

- Full pre-commit still reports unrelated existing ruff/ty diagnostics in `.claude/skills/geekmagic-reverse-engineer/reverse_engineer_device.py`, `custom_components/geekmagic/widgets/state.py`, and `tests/widgets/test_widgets.py`; the pytest/frontend/translation hooks pass.