### PR TITLE
feat: add forecast_start_tomorrow option to weather widget

### DIFF
--- a/custom_components/geekmagic/widgets/weather.py
+++ b/custom_components/geekmagic/widgets/weather.py
@@ -125,9 +125,21 @@ class WeatherDisplay(Component):
     show_humidity: bool = True
     show_high_low: bool = True
     forecast_days: int = 3
+    forecast_start_tomorrow: bool = False
 
     def measure(self, ctx: RenderContext, max_width: int, max_height: int) -> tuple[int, int]:
         return (max_width, max_height)
+
+    def _visible_forecast(self) -> list[dict]:
+        """Return the forecast list to display.
+
+        Daily forecasts include today as the first entry. When
+        ``forecast_start_tomorrow`` is set we drop it so the row begins
+        at tomorrow instead.
+        """
+        if self.forecast_start_tomorrow:
+            return self.forecast[1:]
+        return self.forecast
 
     def render(self, ctx: RenderContext, x: int, y: int, width: int, height: int) -> None:
         """Render weather."""
@@ -138,7 +150,7 @@ class WeatherDisplay(Component):
 
         if size in (SizeCategory.MEDIUM, SizeCategory.LARGE) and self.show_forecast:
             component = self._build_full(width, height, icon_name, icon_tint)
-        elif size == SizeCategory.SMALL and self.show_forecast and self.forecast:
+        elif size == SizeCategory.SMALL and self.show_forecast and self._visible_forecast():
             component = self._build_semi_compact(width, height, icon_name, icon_tint)
         else:
             component = self._build_compact(width, height, icon_name, icon_tint)
@@ -202,7 +214,7 @@ class WeatherDisplay(Component):
         # Forecast items
         forecast_component = None
         if self.forecast and self.show_forecast:
-            forecast_items = self.forecast[: self.forecast_days]
+            forecast_items = self._visible_forecast()[: self.forecast_days]
             if forecast_items:
                 forecast_icon_size = max(10, int(height * 0.10))
                 forecast_columns = []
@@ -308,7 +320,7 @@ class WeatherDisplay(Component):
         # narrow cells get icons only (forecast columns become Icons,
         # space-around).
         bottom_row: Component | None = None
-        forecast_items = self.forecast[: min(3, self.forecast_days)]
+        forecast_items = self._visible_forecast()[: min(3, self.forecast_days)]
         if forecast_items:
             if is_wide:
                 forecast_columns: list[Component] = []
@@ -448,6 +460,12 @@ class WeatherWidget(Widget):
                 "min": 1,
                 "max": 5,
             },
+            {
+                "key": "forecast_start_tomorrow",
+                "type": "boolean",
+                "label": "Forecast Starts Tomorrow",
+                "default": False,
+            },
             {"key": "show_humidity", "type": "boolean", "label": "Show Humidity", "default": True},
             {"key": "show_high_low", "type": "boolean", "label": "Show High/Low", "default": True},
         ],
@@ -458,6 +476,7 @@ class WeatherWidget(Widget):
         super().__init__(config)
         self.show_forecast = config.options.get("show_forecast", True)
         self.forecast_days = config.options.get("forecast_days", 3)
+        self.forecast_start_tomorrow = config.options.get("forecast_start_tomorrow", False)
         self.show_humidity = config.options.get("show_humidity", True)
         self.show_high_low = config.options.get("show_high_low", True)
 
@@ -477,4 +496,5 @@ class WeatherWidget(Widget):
             show_humidity=self.show_humidity,
             show_high_low=self.show_high_low,
             forecast_days=self.forecast_days,
+            forecast_start_tomorrow=self.forecast_start_tomorrow,
         )

--- a/tests/widgets/test_widgets.py
+++ b/tests/widgets/test_widgets.py
@@ -31,7 +31,7 @@ from custom_components.geekmagic.widgets.progress import MultiProgressWidget, Pr
 from custom_components.geekmagic.widgets.state import EntityState, WidgetState
 from custom_components.geekmagic.widgets.status import StatusListWidget, StatusWidget
 from custom_components.geekmagic.widgets.text import TextWidget
-from custom_components.geekmagic.widgets.weather import WeatherWidget
+from custom_components.geekmagic.widgets.weather import WeatherDisplay, WeatherWidget
 
 
 def find_value_text(comp: Any) -> str | None:
@@ -1370,6 +1370,7 @@ class TestWeatherWidget:
         assert widget.show_forecast is True
         assert widget.forecast_days == 3
         assert widget.show_humidity is True
+        assert widget.forecast_start_tomorrow is False
 
     def test_init_with_options(self):
         """Test weather widget with custom options."""
@@ -1377,12 +1378,38 @@ class TestWeatherWidget:
             widget_type="weather",
             slot=0,
             entity_id="weather.home",
-            options={"show_forecast": False, "forecast_days": 5, "show_humidity": False},
+            options={
+                "show_forecast": False,
+                "forecast_days": 5,
+                "show_humidity": False,
+                "forecast_start_tomorrow": True,
+            },
         )
         widget = WeatherWidget(config)
         assert widget.show_forecast is False
         assert widget.forecast_days == 5
         assert widget.show_humidity is False
+        assert widget.forecast_start_tomorrow is True
+
+    def test_visible_forecast_starts_today_by_default(self):
+        """By default the forecast row includes today as the first entry."""
+        forecast = [
+            {"datetime": "2025-12-29T00:00:00+00:00", "condition": "sunny", "temperature": 24},
+            {"datetime": "2025-12-30T00:00:00+00:00", "condition": "cloudy", "temperature": 20},
+            {"datetime": "2025-12-31T00:00:00+00:00", "condition": "rainy", "temperature": 18},
+        ]
+        display = WeatherDisplay(forecast=forecast)
+        assert display._visible_forecast() == forecast
+
+    def test_visible_forecast_can_start_tomorrow(self):
+        """When forecast_start_tomorrow is set, today's entry is dropped."""
+        forecast = [
+            {"datetime": "2025-12-29T00:00:00+00:00", "condition": "sunny", "temperature": 24},
+            {"datetime": "2025-12-30T00:00:00+00:00", "condition": "cloudy", "temperature": 20},
+            {"datetime": "2025-12-31T00:00:00+00:00", "condition": "rainy", "temperature": 18},
+        ]
+        display = WeatherDisplay(forecast=forecast, forecast_start_tomorrow=True)
+        assert display._visible_forecast() == forecast[1:]
 
     def test_render_without_entity(self, renderer, canvas, rect):
         """Test rendering without entity shows placeholder."""


### PR DESCRIPTION
## Summary
Add a new `forecast_start_tomorrow` configuration option to the WeatherWidget that allows users to exclude today's forecast entry and start the forecast row from tomorrow instead.

## Changes
- **WeatherDisplay component**: Added `forecast_start_tomorrow` boolean field and new `_visible_forecast()` method that filters the forecast list based on this setting
- **WeatherWidget**: Added `forecast_start_tomorrow` option to the widget configuration schema with a boolean UI control (default: `False`)
- **Forecast rendering**: Updated all forecast rendering paths (`_build_full()` and `_build_semi_compact()`) to use `_visible_forecast()` instead of directly accessing `self.forecast`
- **Tests**: Added comprehensive test coverage for the new feature:
  - Verify default behavior (forecast includes today)
  - Verify option can be set to `True` in widget config
  - Test `_visible_forecast()` returns full list by default
  - Test `_visible_forecast()` drops first entry when `forecast_start_tomorrow=True`

## Implementation Details
The `_visible_forecast()` method provides a single point of control for forecast filtering, ensuring consistent behavior across all rendering code paths. When `forecast_start_tomorrow` is enabled, the method returns `forecast[1:]` to skip today's entry; otherwise it returns the full forecast list.

https://claude.ai/code/session_01MZsNSGYeQxv5YjWwjAXs22