### PR TITLE
fix: handle malformed firmware responses in get_json

### DIFF
--- a/custom_components/geekmagic/transport.py
+++ b/custom_components/geekmagic/transport.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from urllib.parse import urlparse
 
 import aiohttp
@@ -86,12 +87,19 @@ class DeviceTransport:
         """Fetch a JSON object from the device."""
         session = await self.get_session()
         kwargs = {"timeout": request_timeout} if request_timeout is not None else {}
-        async with session.get(f"{self.base_url}{path}", **kwargs) as response:
-            response.raise_for_status()
-            data = await response.json(content_type=None)
-            if not isinstance(data, dict):
-                raise TypeError(f"Expected JSON object from {path}")
-            return data
+        try:
+            async with session.get(f"{self.base_url}{path}", **kwargs) as response:
+                response.raise_for_status()
+                data = await response.json(content_type=None)
+        except aiohttp.ClientResponseError as err:
+            if self.is_malformed_firmware_response(err):
+                raw = await self.raw_http_get(path)
+                data = json.loads(raw.decode(errors="replace"))
+            else:
+                raise
+        if not isinstance(data, dict):
+            raise TypeError(f"Expected JSON object from {path}")
+        return data
 
     async def get_text(self, path: str) -> str:
         """Fetch text from the device."""

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,112 @@
+"""Tests for the HTTP transport, focused on firmware quirk handling."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from custom_components.geekmagic.const import MODEL_PRO
+from custom_components.geekmagic.profiles import detect_firmware_profile
+from custom_components.geekmagic.transport import DeviceTransport
+
+
+def _malformed_error(message: str) -> aiohttp.ClientResponseError:
+    """Build a 400 error mimicking GeekMagic firmware's malformed HTTP."""
+    return aiohttp.ClientResponseError(
+        request_info=MagicMock(),
+        history=(),
+        status=400,
+        message=message,
+    )
+
+
+def _session_raising(error: Exception) -> MagicMock:
+    """Return a mock session whose GET raises ``error`` on enter."""
+    response = MagicMock()
+    response.__aenter__ = AsyncMock(side_effect=error)
+    response.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=response)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_get_json_falls_back_on_data_after_close() -> None:
+    """Pro firmware's 'Data after Connection: close' must not break get_json.
+
+    Regression test for issue #155: a stricter bundled aiohttp started
+    rejecting the Pro firmware's malformed responses, which broke firmware
+    detection because get_json (unlike get_text/get_bytes) had no raw fallback.
+    """
+    transport = DeviceTransport("192.168.1.100")
+    transport.session = _session_raising(_malformed_error("Data after `Connection: close`"))
+
+    with patch.object(
+        transport,
+        "raw_http_get",
+        AsyncMock(return_value=b'{"m": "SmallTV-PRO", "v": "V3.4.82EN"}'),
+    ) as raw_get:
+        data = await transport.get_json("/v.json")
+
+    raw_get.assert_awaited_once_with("/v.json")
+    assert data == {"m": "SmallTV-PRO", "v": "V3.4.82EN"}
+
+
+@pytest.mark.asyncio
+async def test_get_json_falls_back_on_duplicate_content_length() -> None:
+    """Ultra firmware's 'Duplicate Content-Length' must also fall back cleanly."""
+    transport = DeviceTransport("192.168.1.100")
+    transport.session = _session_raising(_malformed_error("Duplicate Content-Length header"))
+
+    with patch.object(
+        transport,
+        "raw_http_get",
+        AsyncMock(return_value=b'{"theme": "3"}'),
+    ):
+        data = await transport.get_json("/app.json")
+
+    assert data == {"theme": "3"}
+
+
+@pytest.mark.asyncio
+async def test_get_json_reraises_unrelated_response_error() -> None:
+    """A genuine HTTP error (e.g. 404) must still propagate, not silently fall back."""
+    transport = DeviceTransport("192.168.1.100")
+    not_found = aiohttp.ClientResponseError(
+        request_info=MagicMock(),
+        history=(),
+        status=404,
+        message="Not Found",
+    )
+    transport.session = _session_raising(not_found)
+
+    with (
+        patch.object(transport, "raw_http_get", AsyncMock()) as raw_get,
+        pytest.raises(aiohttp.ClientResponseError),
+    ):
+        await transport.get_json("/missing.json")
+
+    raw_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_detection_identifies_pro_through_malformed_response() -> None:
+    """Detection must still recognize a Pro device when /v.json is malformed.
+
+    Without the get_json fallback the Pro firmware would be misdetected as a
+    non-Pro profile, which then issues /set?img= and gets a FAIL from the
+    device (the user-visible symptom in issue #155).
+    """
+    transport = DeviceTransport("192.168.1.100")
+    transport.session = _session_raising(_malformed_error("Data after `Connection: close`"))
+
+    with patch.object(
+        transport,
+        "raw_http_get",
+        AsyncMock(return_value=b'{"m": "SmallTV-PRO", "v": "V3.4.82EN"}'),
+    ):
+        profile = await detect_firmware_profile(transport)
+
+    assert profile.capabilities.profile_id == MODEL_PRO


### PR DESCRIPTION
## Summary
Adds fallback handling in `DeviceTransport.get_json()` to gracefully recover from malformed HTTP responses sent by some GeekMagic firmware versions (Pro and Ultra). This fixes firmware detection failures when stricter aiohttp versions reject these responses.

## Changes
- **transport.py**: Modified `get_json()` to catch `ClientResponseError` exceptions and fall back to `raw_http_get()` when the error indicates a known firmware quirk ("Data after `Connection: close`" or "Duplicate Content-Length header"). Genuine HTTP errors (e.g., 404) are still raised immediately.
- **tests/test_transport.py**: Added comprehensive test coverage:
  - `test_get_json_falls_back_on_data_after_close()` — Pro firmware's malformed response handling
  - `test_get_json_falls_back_on_duplicate_content_length()` — Ultra firmware's malformed response handling
  - `test_get_json_reraises_unrelated_response_error()` — Ensures real HTTP errors still propagate
  - `test_detection_identifies_pro_through_malformed_response()` — End-to-end firmware detection with malformed responses

## Implementation Details
- The fallback only triggers for known firmware quirks identified by error message content, preventing silent failures on genuine network issues
- Raw bytes are decoded with `errors="replace"` to handle any encoding issues gracefully
- Fixes regression in issue #155 where stricter bundled aiohttp broke firmware detection for Pro devices

https://claude.ai/code/session_01BX5x1xzoqZwxYdtN2cL7HD