### PR TITLE
fix: tolerate image selection failures on some firmware

### DIFF
--- a/custom_components/geekmagic/profiles.py
+++ b/custom_components/geekmagic/profiles.py
@@ -25,7 +25,7 @@ from .models import (
     SdProThemeSettings,
     SpaceInfo,
 )
-from .transport import DeviceTransport
+from .transport import DeviceRejectedError, DeviceTransport
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,6 +122,7 @@ class FirmwareProfile:
         self.firmware_version = firmware_version
         self._last_theme: int | None = None
         self._last_image: str | None = None
+        self._image_select_rejected = False
 
     @property
     def capabilities(self) -> FirmwareCapabilities:
@@ -332,10 +333,22 @@ class FirmwareProfile:
 
     async def select_image_path(self, image_path: str) -> None:
         """Select an uploaded image path on firmware that supports it."""
-        await self.transport.get_checked(
-            f"/set?img={image_path}",
-            f"image selection for {image_path}",
-        )
+        try:
+            await self.transport.get_checked(
+                f"/set?img={image_path}",
+                f"image selection for {image_path}",
+            )
+        except DeviceRejectedError as err:
+            # Some firmwares (e.g. SmallTV-PRO V3.4.82EN) answer FAIL to
+            # /set?img= even in custom image mode, where uploading to the
+            # same filename already refreshes the display. Keep the update
+            # loop alive instead of failing setup (issue #155).
+            _LOGGER.log(
+                logging.DEBUG if self._image_select_rejected else logging.WARNING,
+                "%s; continuing because the upload already replaced the displayed image",
+                err,
+            )
+            self._image_select_rejected = True
         self._last_image = image_path
         _LOGGER.debug("Set image path to %s", image_path)
 

--- a/custom_components/geekmagic/transport.py
+++ b/custom_components/geekmagic/transport.py
@@ -10,6 +10,10 @@ import aiohttp
 TIMEOUT = aiohttp.ClientTimeout(total=30)
 
 
+class DeviceRejectedError(RuntimeError):
+    """Raised when firmware answers a request with a FAIL body."""
+
+
 class DeviceTransport:
     """Small HTTP transport used by firmware profile adapters."""
 
@@ -76,7 +80,7 @@ class DeviceTransport:
             return
 
         if text.upper() == "FAIL":
-            raise RuntimeError(f"Device rejected {action}: {text}")
+            raise DeviceRejectedError(f"Device rejected {action}: {text}")
 
     async def get_json(
         self,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -395,14 +395,46 @@ class TestGeekMagicDevice:
         ]
 
     @pytest.mark.asyncio
-    async def test_set_image_raises_on_device_fail_body(self, mock_session, mock_response):
-        """Test HTTP 200 with body FAIL is treated as a firmware rejection."""
+    async def test_set_image_tolerates_image_selection_fail_body(
+        self, mock_session, mock_response, caplog
+    ):
+        """Test FAIL on /set?img= is non-fatal (regression test for issue #155).
+
+        Some firmwares reject /set?img= while uploads to the same filename
+        still refresh the display, so the update loop must keep running.
+        """
+        fail_response = MagicMock()
+        fail_response.raise_for_status = MagicMock()
+        fail_response.text = AsyncMock(return_value="FAIL")
+        fail_response.__aenter__ = AsyncMock(return_value=fail_response)
+        fail_response.__aexit__ = AsyncMock(return_value=False)
+        mock_session.get = MagicMock(
+            side_effect=lambda url, **kwargs: fail_response if "img=" in url else mock_response
+        )
+
+        device = GeekMagicDevice("192.168.1.100", session=mock_session)
+        await device.set_image("dashboard.jpg")
+        await device.set_image("dashboard.jpg")
+
+        calls = mock_session.get.call_args_list
+        assert "img=/image/dashboard.jpg" in str(calls[1])
+        assert "img=/image/dashboard.jpg" in str(calls[3])
+        warnings = [
+            record
+            for record in caplog.records
+            if record.levelname == "WARNING" and "Device rejected" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+
+    @pytest.mark.asyncio
+    async def test_set_theme_raises_on_device_fail_body(self, mock_session, mock_response):
+        """Test HTTP 200 with body FAIL is still a firmware rejection for themes."""
         mock_response.text = AsyncMock(return_value="FAIL")
 
         device = GeekMagicDevice("192.168.1.100", session=mock_session)
 
         with pytest.raises(RuntimeError, match="Device rejected"):
-            await device.set_image("dashboard.jpg")
+            await device.set_theme(3)
 
     @pytest.mark.asyncio
     async def test_upload(self, mock_session, mock_response):


### PR DESCRIPTION
## Summary
Handle firmware that rejects `/set?img=` requests while still allowing image uploads to refresh the display. This fixes issue #155 where some devices (e.g., SmallTV-PRO V3.4.82EN) answer FAIL to image selection commands even in custom image mode.

## Changes
- **transport.py**: Introduced `DeviceRejectedError` exception class to distinguish firmware rejections from other errors
- **profiles.py**: Modified `select_image_path()` to catch `DeviceRejectedError` and log a warning instead of failing. Added `_image_select_rejected` flag to log subsequent failures at DEBUG level. The update loop continues running since the image upload itself already refreshes the display.
- **test_device.py**: 
  - Renamed `test_set_image_raises_on_device_fail_body` → `test_set_image_tolerates_image_selection_fail_body` to reflect new behavior
  - Updated test to verify that multiple `set_image()` calls succeed despite FAIL responses to `/set?img=`
  - Added new `test_set_theme_raises_on_device_fail_body` to ensure theme selection still raises on FAIL (different code path)

## Implementation Details
- The fix is specific to image selection (`/set?img=`); theme selection (`/set?theme=`) still raises on FAIL since it has no fallback mechanism
- First rejection logs at WARNING level; subsequent rejections log at DEBUG to avoid log spam
- The device continues operating because uploading to the same filename already triggers a display refresh

https://claude.ai/code/session_01LrS3u5XN1A1znnJoUKPdzL