### PR TITLE
feat: custom layout, background options, text opacity & per-widget scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,37 @@ Display OHLC (Open/High/Low/Close) candlestick charts from any numeric entity's 
   <img src="https://raw.githubusercontent.com/adrienbrault/geekmagic-hacs/main/samples/layouts/layout_sidebar_right.png" alt="Sidebar Right" width="200">
 </p>
 
+### Custom Layout
+
+The `custom` layout lets you place widgets freely instead of using a fixed slot grid. Each widget defines its own `x`, `y`, `width`, and `height` in pixels (the display is 240×240). Widgets are drawn in list order, so later widgets can overlap earlier ones if desired.
+
+```yaml
+geekmagic:
+  views:
+    - name: Custom Dashboard
+      layout: custom
+      widgets:
+        - type: clock
+          x: 0
+          y: 0
+          width: 240
+          height: 80
+        - type: entity_plain
+          entity_id: sensor.temperature
+          x: 0
+          y: 80
+          width: 120
+          height: 160
+        - type: entity_icon
+          entity_id: binary_sensor.motion
+          x: 120
+          y: 80
+          width: 120
+          height: 160
+```
+
+Out-of-bounds coordinates are silently clamped to the display size, so a quick `width: 300` will not crash — it just stops at the edge.
+
 ## Themes
 
 Choose from **11 built-in themes** that go beyond just colors — they apply a complete design system: typography (rounded Nunito font on most themes), spacing, shapes, tinted gauge tracks, and visual effects.
@@ -168,7 +199,7 @@ The default `watchOS` theme is inspired by Apple's watchOS Human Interface Guide
 ## Features
 
 - **15 widget types**: Clock, entity, attribute list, media, chart, candlestick, text, gauge, progress, weather, status, climate, camera, and more
-- **19 layout options**: Fullscreen, grids, splits, hero variants, sidebars, and more
+- **20 layout options**: Fullscreen, grids, splits, hero variants, sidebars, custom free-form placement, and more
 - **11 visual themes**: watchOS (default), Classic, Minimal, Neon, Retro, Soft, Light, Ocean, Sunset, Forest, Candy
 - **Visual configuration**: Custom sidebar panel with live preview
 - **Global views**: Create views once, assign to multiple devices

--- a/custom_components/geekmagic/const.py
+++ b/custom_components/geekmagic/const.py
@@ -43,6 +43,20 @@ CONF_SCREEN_NAME = "screen_name"
 CONF_SCREEN_CYCLE_INTERVAL = "screen_cycle_interval"
 CONF_CURRENT_SCREEN = "current_screen"
 CONF_SCREEN_THEME = "theme"
+CONF_BACKGROUND_IMAGE = "background_image"
+CONF_BACKGROUND_MODE = "background_mode"
+CONF_BACKGROUND_ENTITY = "background_entity"
+CONF_WIDGET_CONTRAST = "widget_contrast"
+CONF_TEXT_SCALE = "text_scale"
+CONF_TEXT_OPACITY = "text_opacity"
+BACKGROUND_MODE_STRETCH = "stretch"
+BACKGROUND_MODE_CONTAIN = "contain"
+BACKGROUND_MODE_COVER = "cover"
+BACKGROUND_MODES = [
+    BACKGROUND_MODE_STRETCH,
+    BACKGROUND_MODE_CONTAIN,
+    BACKGROUND_MODE_COVER,
+]
 DEFAULT_SCREEN_CYCLE_INTERVAL = 0  # 0 = manual only, >0 = seconds between screens
 
 # Theme types
@@ -95,6 +109,7 @@ LAYOUT_HERO_BL = "hero_corner_bl"  # 2x2 hero bottom-left
 LAYOUT_HERO_BR = "hero_corner_br"  # 2x2 hero bottom-right
 LAYOUT_HERO_SIMPLE = "hero_simple"  # 1 large hero + 1 footer
 LAYOUT_FULLSCREEN = "fullscreen"  # Single widget, full display, no padding
+LAYOUT_CUSTOM = "custom"  # Free-form widget placement
 
 # Widget types
 WIDGET_CAMERA = "camera"
@@ -131,6 +146,7 @@ LAYOUT_SLOT_COUNTS = {
     LAYOUT_HERO_BR: 6,
     LAYOUT_HERO_SIMPLE: 2,
     LAYOUT_FULLSCREEN: 1,
+    LAYOUT_CUSTOM: 0,
 }
 
 # Widget type display names for UI

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import time
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
@@ -20,6 +21,9 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     BACKOFF_LOG_INTERVAL,
+    CONF_BACKGROUND_ENTITY,
+    CONF_BACKGROUND_IMAGE,
+    CONF_BACKGROUND_MODE,
     CONF_DISPLAY_ROTATION,
     CONF_JPEG_QUALITY,
     CONF_LAYOUT,
@@ -28,12 +32,15 @@ from .const import (
     CONF_SCREEN_CYCLE_INTERVAL,
     CONF_SCREEN_THEME,
     CONF_SCREENS,
+    CONF_TEXT_OPACITY,
+    CONF_WIDGET_CONTRAST,
     CONF_WIDGETS,
     DEFAULT_DISPLAY_ROTATION,
     DEFAULT_JPEG_QUALITY,
     DEFAULT_REFRESH_INTERVAL,
     DEFAULT_SCREEN_CYCLE_INTERVAL,
     DOMAIN,
+    LAYOUT_CUSTOM,
     LAYOUT_FULLSCREEN,
     LAYOUT_GRID_2X2,
     LAYOUT_GRID_2X3,
@@ -58,6 +65,7 @@ from .const import (
 )
 from .device import DeviceState, GeekMagicDevice, RenderedDashboardRequest, SpaceInfo
 from .layouts.corner_hero import HeroCornerBL, HeroCornerBR, HeroCornerTL, HeroCornerTR
+from .layouts.custom import CustomLayout
 from .layouts.fullscreen import FullscreenLayout
 from .layouts.grid import Grid2x2, Grid2x3, Grid3x2, Grid3x3
 from .layouts.hero import HeroLayout
@@ -118,6 +126,7 @@ LAYOUT_CLASSES = {
     LAYOUT_HERO_BL: HeroCornerBL,
     LAYOUT_HERO_BR: HeroCornerBR,
     LAYOUT_FULLSCREEN: FullscreenLayout,
+    LAYOUT_CUSTOM: CustomLayout,
 }
 
 
@@ -568,21 +577,80 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
         """
         layout_type = screen_config.get(CONF_LAYOUT, LAYOUT_GRID_2X2)
         layout_class = LAYOUT_CLASSES.get(layout_type, Grid2x2)
-        layout = layout_class()
+
+        widgets_config: list[dict[str, Any]] = screen_config.get(CONF_WIDGETS, [])
+
+        # If no widgets configured, add a sensible default.
+        if not widgets_config:
+            if layout_type == LAYOUT_CUSTOM:
+                widgets_config = [
+                    {"type": "clock", "x": 0, "y": 0, "width": 240, "height": 240}
+                ]
+            else:
+                widgets_config = [{"type": "clock", "slot": 0}]
+
+        # Extract background image settings per screen
+        background_image = screen_config.get(CONF_BACKGROUND_IMAGE)
+        if isinstance(background_image, str):
+            background_image = background_image.strip() or None
+
+        # Optionally resolve background path from a Home Assistant entity
+        background_entity = screen_config.get(CONF_BACKGROUND_ENTITY)
+        if background_entity and self.hass is not None:
+            try:
+                state = self.hass.states.get(background_entity)
+                if state and isinstance(state.state, str):
+                    resolved = state.state.strip()
+                    if resolved and resolved.lower() not in ("unavailable", "unknown", "none", ""):
+                        # Allow templates that return a path relative to /config
+                        if not resolved.startswith("/"):
+                            resolved = f"/config/{resolved}"
+                        if os.path.isfile(resolved):
+                            background_image = resolved
+            except Exception:
+                _LOGGER.exception("Failed to resolve background entity %s", background_entity)
+
+        background_mode = screen_config.get(CONF_BACKGROUND_MODE, "stretch")
+        if background_mode not in ("stretch", "contain", "cover"):
+            background_mode = "stretch"
+
+        widget_contrast = screen_config.get(CONF_WIDGET_CONTRAST, 0.5)
+        try:
+            widget_contrast = float(widget_contrast)
+        except (TypeError, ValueError):
+            widget_contrast = 0.5
+        widget_contrast = max(0.0, min(1.0, widget_contrast))
+
+        text_opacity = screen_config.get(CONF_TEXT_OPACITY, 1.0)
+        try:
+            text_opacity = float(text_opacity)
+        except (TypeError, ValueError):
+            text_opacity = 1.0
+        text_opacity = max(0.0, min(1.0, text_opacity))
+
+        layout_kwargs = dict(
+            background_image=background_image,
+            background_mode=background_mode,
+            widget_contrast=widget_contrast,
+            text_scale=1.0,
+            text_opacity=text_opacity,
+        )
+        if layout_type == LAYOUT_CUSTOM:
+            layout_kwargs["widgets"] = widgets_config
+
+        layout = layout_class(**layout_kwargs)
 
         # Set theme on layout
         theme_name = screen_config.get(CONF_SCREEN_THEME, THEME_WATCHOS)
         layout.theme = get_theme(theme_name)
 
-        widgets_config = screen_config.get(CONF_WIDGETS, [])
-
-        # If no widgets configured, add default clock widget
-        if not widgets_config:
-            widgets_config = [{"type": "clock", "slot": 0}]
-
-        for widget_config in widgets_config:
+        for widget_index, widget_config in enumerate(widgets_config):
             widget_type = str(widget_config.get("type", "text"))
-            slot = int(widget_config.get("slot", 0))
+            if layout_type == LAYOUT_CUSTOM:
+                # Custom layouts derive slots from widget order, not a "slot" key.
+                slot = widget_index
+            else:
+                slot = int(widget_config.get("slot", 0))
 
             if slot >= layout.get_slot_count():
                 continue
@@ -601,12 +669,20 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
             if isinstance(raw_color, list | tuple) and len(raw_color) == 3:
                 parsed_color = (int(raw_color[0]), int(raw_color[1]), int(raw_color[2]))
 
+            widget_text_scale = 1.0
+            try:
+                widget_text_scale = float(widget_config.get("text_scale", 1.0))
+            except (TypeError, ValueError):
+                widget_text_scale = 1.0
+            widget_text_scale = max(0.5, min(3.0, widget_text_scale))
+
             config = WidgetConfig(
                 widget_type=widget_type,
                 slot=slot,
                 entity_id=str(entity_id) if entity_id is not None else None,
                 label=str(label) if label is not None else None,
                 color=parsed_color,
+                text_scale=widget_text_scale,
                 options=cast("dict[str, Any]", widget_options),
             )
 

--- a/custom_components/geekmagic/frontend/dist/geekmagic-panel.js
+++ b/custom_components/geekmagic/frontend/dist/geekmagic-panel.js
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 const D = globalThis, K = D.ShadowRoot && (D.ShadyCSS === void 0 || D.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, G = Symbol(), Q = /* @__PURE__ */ new WeakMap();
-let de = class {
-  constructor(e, t, i) {
-    if (this._$cssResult$ = !0, i !== G) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+let pe = class {
+  constructor(e, t, s) {
+    if (this._$cssResult$ = !0, s !== G) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = e, this.t = t;
   }
   get styleSheet() {
     let e = this.o;
     const t = this.t;
     if (K && e === void 0) {
-      const i = t !== void 0 && t.length === 1;
-      i && (e = Q.get(t)), e === void 0 && ((this.o = e = new CSSStyleSheet()).replaceSync(this.cssText), i && Q.set(t, e));
+      const s = t !== void 0 && t.length === 1;
+      s && (e = Q.get(t)), e === void 0 && ((this.o = e = new CSSStyleSheet()).replaceSync(this.cssText), s && Q.set(t, e));
     }
     return e;
   }
@@ -22,120 +22,120 @@ let de = class {
     return this.cssText;
   }
 };
-const me = (s) => new de(typeof s == "string" ? s : s + "", void 0, G), fe = (s, ...e) => {
-  const t = s.length === 1 ? s[0] : e.reduce((i, r, a) => i + ((o) => {
-    if (o._$cssResult$ === !0) return o.cssText;
-    if (typeof o == "number") return o;
-    throw Error("Value passed to 'css' function must be a 'css' function result: " + o + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-  })(r) + s[a + 1], s[0]);
-  return new de(t, s, G);
-}, _e = (s, e) => {
-  if (K) s.adoptedStyleSheets = e.map((t) => t instanceof CSSStyleSheet ? t : t.styleSheet);
+const fe = (o) => new pe(typeof o == "string" ? o : o + "", void 0, G), ye = (o, ...e) => {
+  const t = o.length === 1 ? o[0] : e.reduce((s, i, r) => s + ((a) => {
+    if (a._$cssResult$ === !0) return a.cssText;
+    if (typeof a == "number") return a;
+    throw Error("Value passed to 'css' function must be a 'css' function result: " + a + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
+  })(i) + o[r + 1], o[0]);
+  return new pe(t, o, G);
+}, we = (o, e) => {
+  if (K) o.adoptedStyleSheets = e.map((t) => t instanceof CSSStyleSheet ? t : t.styleSheet);
   else for (const t of e) {
-    const i = document.createElement("style"), r = D.litNonce;
-    r !== void 0 && i.setAttribute("nonce", r), i.textContent = t.cssText, s.appendChild(i);
+    const s = document.createElement("style"), i = D.litNonce;
+    i !== void 0 && s.setAttribute("nonce", i), s.textContent = t.cssText, o.appendChild(s);
   }
-}, X = K ? (s) => s : (s) => s instanceof CSSStyleSheet ? ((e) => {
+}, ee = K ? (o) => o : (o) => o instanceof CSSStyleSheet ? ((e) => {
   let t = "";
-  for (const i of e.cssRules) t += i.cssText;
-  return me(t);
-})(s) : s;
+  for (const s of e.cssRules) t += s.cssText;
+  return fe(t);
+})(o) : o;
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const { is: ye, defineProperty: we, getOwnPropertyDescriptor: $e, getOwnPropertyNames: be, getOwnPropertySymbols: xe, getPrototypeOf: Ae } = Object, w = globalThis, ee = w.trustedTypes, Ee = ee ? ee.emptyScript : "", R = w.reactiveElementPolyfillSupport, S = (s, e) => s, j = { toAttribute(s, e) {
+const { is: $e, defineProperty: be, getOwnPropertyDescriptor: xe, getOwnPropertyNames: Ve, getOwnPropertySymbols: Ae, getPrototypeOf: ke } = Object, w = globalThis, te = w.trustedTypes, Ee = te ? te.emptyScript : "", F = w.reactiveElementPolyfillSupport, C = (o, e) => o, j = { toAttribute(o, e) {
   switch (e) {
     case Boolean:
-      s = s ? Ee : null;
+      o = o ? Ee : null;
       break;
     case Object:
     case Array:
-      s = s == null ? s : JSON.stringify(s);
+      o = o == null ? o : JSON.stringify(o);
   }
-  return s;
-}, fromAttribute(s, e) {
-  let t = s;
+  return o;
+}, fromAttribute(o, e) {
+  let t = o;
   switch (e) {
     case Boolean:
-      t = s !== null;
+      t = o !== null;
       break;
     case Number:
-      t = s === null ? null : Number(s);
+      t = o === null ? null : Number(o);
       break;
     case Object:
     case Array:
       try {
-        t = JSON.parse(s);
+        t = JSON.parse(o);
       } catch {
         t = null;
       }
   }
   return t;
-} }, J = (s, e) => !ye(s, e), te = { attribute: !0, type: String, converter: j, reflect: !1, useDefault: !1, hasChanged: J };
+} }, J = (o, e) => !$e(o, e), ie = { attribute: !0, type: String, converter: j, reflect: !1, useDefault: !1, hasChanged: J };
 Symbol.metadata ?? (Symbol.metadata = Symbol("metadata")), w.litPropertyMetadata ?? (w.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
-let E = class extends HTMLElement {
+let A = class extends HTMLElement {
   static addInitializer(e) {
     this._$Ei(), (this.l ?? (this.l = [])).push(e);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(e, t = te) {
+  static createProperty(e, t = ie) {
     if (t.state && (t.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(e) && ((t = Object.create(t)).wrapped = !0), this.elementProperties.set(e, t), !t.noAccessor) {
-      const i = Symbol(), r = this.getPropertyDescriptor(e, i, t);
-      r !== void 0 && we(this.prototype, e, r);
+      const s = Symbol(), i = this.getPropertyDescriptor(e, s, t);
+      i !== void 0 && be(this.prototype, e, i);
     }
   }
-  static getPropertyDescriptor(e, t, i) {
-    const { get: r, set: a } = $e(this.prototype, e) ?? { get() {
+  static getPropertyDescriptor(e, t, s) {
+    const { get: i, set: r } = xe(this.prototype, e) ?? { get() {
       return this[t];
-    }, set(o) {
-      this[t] = o;
+    }, set(a) {
+      this[t] = a;
     } };
-    return { get: r, set(o) {
-      const l = r == null ? void 0 : r.call(this);
-      a == null || a.call(this, o), this.requestUpdate(e, l, i);
+    return { get: i, set(a) {
+      const n = i == null ? void 0 : i.call(this);
+      r == null || r.call(this, a), this.requestUpdate(e, n, s);
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(e) {
-    return this.elementProperties.get(e) ?? te;
+    return this.elementProperties.get(e) ?? ie;
   }
   static _$Ei() {
-    if (this.hasOwnProperty(S("elementProperties"))) return;
-    const e = Ae(this);
+    if (this.hasOwnProperty(C("elementProperties"))) return;
+    const e = ke(this);
     e.finalize(), e.l !== void 0 && (this.l = [...e.l]), this.elementProperties = new Map(e.elementProperties);
   }
   static finalize() {
-    if (this.hasOwnProperty(S("finalized"))) return;
-    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(S("properties"))) {
-      const t = this.properties, i = [...be(t), ...xe(t)];
-      for (const r of i) this.createProperty(r, t[r]);
+    if (this.hasOwnProperty(C("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(C("properties"))) {
+      const t = this.properties, s = [...Ve(t), ...Ae(t)];
+      for (const i of s) this.createProperty(i, t[i]);
     }
     const e = this[Symbol.metadata];
     if (e !== null) {
       const t = litPropertyMetadata.get(e);
-      if (t !== void 0) for (const [i, r] of t) this.elementProperties.set(i, r);
+      if (t !== void 0) for (const [s, i] of t) this.elementProperties.set(s, i);
     }
     this._$Eh = /* @__PURE__ */ new Map();
-    for (const [t, i] of this.elementProperties) {
-      const r = this._$Eu(t, i);
-      r !== void 0 && this._$Eh.set(r, t);
+    for (const [t, s] of this.elementProperties) {
+      const i = this._$Eu(t, s);
+      i !== void 0 && this._$Eh.set(i, t);
     }
     this.elementStyles = this.finalizeStyles(this.styles);
   }
   static finalizeStyles(e) {
     const t = [];
     if (Array.isArray(e)) {
-      const i = new Set(e.flat(1 / 0).reverse());
-      for (const r of i) t.unshift(X(r));
-    } else e !== void 0 && t.push(X(e));
+      const s = new Set(e.flat(1 / 0).reverse());
+      for (const i of s) t.unshift(ee(i));
+    } else e !== void 0 && t.push(ee(e));
     return t;
   }
   static _$Eu(e, t) {
-    const i = t.attribute;
-    return i === !1 ? void 0 : typeof i == "string" ? i : typeof e == "string" ? e.toLowerCase() : void 0;
+    const s = t.attribute;
+    return s === !1 ? void 0 : typeof s == "string" ? s : typeof e == "string" ? e.toLowerCase() : void 0;
   }
   constructor() {
     super(), this._$Ep = void 0, this.isUpdatePending = !1, this.hasUpdated = !1, this._$Em = null, this._$Ev();
@@ -154,18 +154,18 @@ let E = class extends HTMLElement {
   }
   _$E_() {
     const e = /* @__PURE__ */ new Map(), t = this.constructor.elementProperties;
-    for (const i of t.keys()) this.hasOwnProperty(i) && (e.set(i, this[i]), delete this[i]);
+    for (const s of t.keys()) this.hasOwnProperty(s) && (e.set(s, this[s]), delete this[s]);
     e.size > 0 && (this._$Ep = e);
   }
   createRenderRoot() {
     const e = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return _e(e, this.constructor.elementStyles), e;
+    return we(e, this.constructor.elementStyles), e;
   }
   connectedCallback() {
     var e;
     this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(!0), (e = this._$EO) == null || e.forEach((t) => {
-      var i;
-      return (i = t.hostConnected) == null ? void 0 : i.call(t);
+      var s;
+      return (s = t.hostConnected) == null ? void 0 : s.call(t);
     });
   }
   enableUpdating(e) {
@@ -173,42 +173,42 @@ let E = class extends HTMLElement {
   disconnectedCallback() {
     var e;
     (e = this._$EO) == null || e.forEach((t) => {
-      var i;
-      return (i = t.hostDisconnected) == null ? void 0 : i.call(t);
+      var s;
+      return (s = t.hostDisconnected) == null ? void 0 : s.call(t);
     });
   }
-  attributeChangedCallback(e, t, i) {
-    this._$AK(e, i);
+  attributeChangedCallback(e, t, s) {
+    this._$AK(e, s);
   }
   _$ET(e, t) {
-    var a;
-    const i = this.constructor.elementProperties.get(e), r = this.constructor._$Eu(e, i);
-    if (r !== void 0 && i.reflect === !0) {
-      const o = (((a = i.converter) == null ? void 0 : a.toAttribute) !== void 0 ? i.converter : j).toAttribute(t, i.type);
-      this._$Em = e, o == null ? this.removeAttribute(r) : this.setAttribute(r, o), this._$Em = null;
+    var r;
+    const s = this.constructor.elementProperties.get(e), i = this.constructor._$Eu(e, s);
+    if (i !== void 0 && s.reflect === !0) {
+      const a = (((r = s.converter) == null ? void 0 : r.toAttribute) !== void 0 ? s.converter : j).toAttribute(t, s.type);
+      this._$Em = e, a == null ? this.removeAttribute(i) : this.setAttribute(i, a), this._$Em = null;
     }
   }
   _$AK(e, t) {
-    var a, o;
-    const i = this.constructor, r = i._$Eh.get(e);
-    if (r !== void 0 && this._$Em !== r) {
-      const l = i.getPropertyOptions(r), n = typeof l.converter == "function" ? { fromAttribute: l.converter } : ((a = l.converter) == null ? void 0 : a.fromAttribute) !== void 0 ? l.converter : j;
-      this._$Em = r;
-      const h = n.fromAttribute(t, l.type);
-      this[r] = h ?? ((o = this._$Ej) == null ? void 0 : o.get(r)) ?? h, this._$Em = null;
+    var r, a;
+    const s = this.constructor, i = s._$Eh.get(e);
+    if (i !== void 0 && this._$Em !== i) {
+      const n = s.getPropertyOptions(i), l = typeof n.converter == "function" ? { fromAttribute: n.converter } : ((r = n.converter) == null ? void 0 : r.fromAttribute) !== void 0 ? n.converter : j;
+      this._$Em = i;
+      const d = l.fromAttribute(t, n.type);
+      this[i] = d ?? ((a = this._$Ej) == null ? void 0 : a.get(i)) ?? d, this._$Em = null;
     }
   }
-  requestUpdate(e, t, i) {
-    var r;
+  requestUpdate(e, t, s) {
+    var i;
     if (e !== void 0) {
-      const a = this.constructor, o = this[e];
-      if (i ?? (i = a.getPropertyOptions(e)), !((i.hasChanged ?? J)(o, t) || i.useDefault && i.reflect && o === ((r = this._$Ej) == null ? void 0 : r.get(e)) && !this.hasAttribute(a._$Eu(e, i)))) return;
-      this.C(e, t, i);
+      const r = this.constructor, a = this[e];
+      if (s ?? (s = r.getPropertyOptions(e)), !((s.hasChanged ?? J)(a, t) || s.useDefault && s.reflect && a === ((i = this._$Ej) == null ? void 0 : i.get(e)) && !this.hasAttribute(r._$Eu(e, s)))) return;
+      this.C(e, t, s);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
   }
-  C(e, t, { useDefault: i, reflect: r, wrapped: a }, o) {
-    i && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(e) && (this._$Ej.set(e, o ?? t ?? this[e]), a !== !0 || o !== void 0) || (this._$AL.has(e) || (this.hasUpdated || i || (t = void 0), this._$AL.set(e, t)), r === !0 && this._$Em !== e && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(e));
+  C(e, t, { useDefault: s, reflect: i, wrapped: r }, a) {
+    s && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(e) && (this._$Ej.set(e, a ?? t ?? this[e]), r !== !0 || a !== void 0) || (this._$AL.has(e) || (this.hasUpdated || s || (t = void 0), this._$AL.set(e, t)), i === !0 && this._$Em !== e && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(e));
   }
   async _$EP() {
     this.isUpdatePending = !0;
@@ -224,28 +224,28 @@ let E = class extends HTMLElement {
     return this.performUpdate();
   }
   performUpdate() {
-    var i;
+    var s;
     if (!this.isUpdatePending) return;
     if (!this.hasUpdated) {
       if (this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this._$Ep) {
-        for (const [a, o] of this._$Ep) this[a] = o;
+        for (const [r, a] of this._$Ep) this[r] = a;
         this._$Ep = void 0;
       }
-      const r = this.constructor.elementProperties;
-      if (r.size > 0) for (const [a, o] of r) {
-        const { wrapped: l } = o, n = this[a];
-        l !== !0 || this._$AL.has(a) || n === void 0 || this.C(a, void 0, o, n);
+      const i = this.constructor.elementProperties;
+      if (i.size > 0) for (const [r, a] of i) {
+        const { wrapped: n } = a, l = this[r];
+        n !== !0 || this._$AL.has(r) || l === void 0 || this.C(r, void 0, a, l);
       }
     }
     let e = !1;
     const t = this._$AL;
     try {
-      e = this.shouldUpdate(t), e ? (this.willUpdate(t), (i = this._$EO) == null || i.forEach((r) => {
-        var a;
-        return (a = r.hostUpdate) == null ? void 0 : a.call(r);
+      e = this.shouldUpdate(t), e ? (this.willUpdate(t), (s = this._$EO) == null || s.forEach((i) => {
+        var r;
+        return (r = i.hostUpdate) == null ? void 0 : r.call(i);
       }), this.update(t)) : this._$EM();
-    } catch (r) {
-      throw e = !1, this._$EM(), r;
+    } catch (i) {
+      throw e = !1, this._$EM(), i;
     }
     e && this._$AE(t);
   }
@@ -253,9 +253,9 @@ let E = class extends HTMLElement {
   }
   _$AE(e) {
     var t;
-    (t = this._$EO) == null || t.forEach((i) => {
-      var r;
-      return (r = i.hostUpdated) == null ? void 0 : r.call(i);
+    (t = this._$EO) == null || t.forEach((s) => {
+      var i;
+      return (i = s.hostUpdated) == null ? void 0 : i.call(s);
     }), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(e)), this.updated(e);
   }
   _$EM() {
@@ -278,76 +278,76 @@ let E = class extends HTMLElement {
   firstUpdated(e) {
   }
 };
-E.elementStyles = [], E.shadowRootOptions = { mode: "open" }, E[S("elementProperties")] = /* @__PURE__ */ new Map(), E[S("finalized")] = /* @__PURE__ */ new Map(), R == null || R({ ReactiveElement: E }), (w.reactiveElementVersions ?? (w.reactiveElementVersions = [])).push("2.1.1");
+A.elementStyles = [], A.shadowRootOptions = { mode: "open" }, A[C("elementProperties")] = /* @__PURE__ */ new Map(), A[C("finalized")] = /* @__PURE__ */ new Map(), F == null || F({ ReactiveElement: A }), (w.reactiveElementVersions ?? (w.reactiveElementVersions = [])).push("2.1.1");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const C = globalThis, W = C.trustedTypes, ie = W ? W.createPolicy("lit-html", { createHTML: (s) => s }) : void 0, he = "$lit$", y = `lit$${Math.random().toFixed(9).slice(2)}$`, pe = "?" + y, Ve = `<${pe}>`, A = document, I = () => A.createComment(""), M = (s) => s === null || typeof s != "object" && typeof s != "function", Y = Array.isArray, ke = (s) => Y(s) || typeof (s == null ? void 0 : s[Symbol.iterator]) == "function", F = `[ 	
-\f\r]`, P = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, se = /-->/g, re = />/g, $ = RegExp(`>|${F}(?:([^\\s"'>=/]+)(${F}*=${F}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), ae = /'/g, oe = /"/g, ue = /^(?:script|style|textarea|title)$/i, Pe = (s) => (e, ...t) => ({ _$litType$: s, strings: e, values: t }), c = Pe(1), V = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), ne = /* @__PURE__ */ new WeakMap(), b = A.createTreeWalker(A, 129);
-function ge(s, e) {
-  if (!Y(s) || !s.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return ie !== void 0 ? ie.createHTML(e) : e;
+const H = globalThis, z = H.trustedTypes, se = z ? z.createPolicy("lit-html", { createHTML: (o) => o }) : void 0, ue = "$lit$", y = `lit$${Math.random().toFixed(9).slice(2)}$`, ge = "?" + y, Se = `<${ge}>`, V = document, I = () => V.createComment(""), L = (o) => o === null || typeof o != "object" && typeof o != "function", Y = Array.isArray, Pe = (o) => Y(o) || typeof (o == null ? void 0 : o[Symbol.iterator]) == "function", B = `[ 	
+\f\r]`, S = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, re = /-->/g, ae = />/g, $ = RegExp(`>|${B}(?:([^\\s"'>=/]+)(${B}*=${B}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), oe = /'/g, ne = /"/g, ve = /^(?:script|style|textarea|title)$/i, Ce = (o) => (e, ...t) => ({ _$litType$: o, strings: e, values: t }), h = Ce(1), k = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), le = /* @__PURE__ */ new WeakMap(), b = V.createTreeWalker(V, 129);
+function me(o, e) {
+  if (!Y(o) || !o.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return se !== void 0 ? se.createHTML(e) : e;
 }
-const Se = (s, e) => {
-  const t = s.length - 1, i = [];
-  let r, a = e === 2 ? "<svg>" : e === 3 ? "<math>" : "", o = P;
-  for (let l = 0; l < t; l++) {
-    const n = s[l];
-    let h, v, d = -1, f = 0;
-    for (; f < n.length && (o.lastIndex = f, v = o.exec(n), v !== null); ) f = o.lastIndex, o === P ? v[1] === "!--" ? o = se : v[1] !== void 0 ? o = re : v[2] !== void 0 ? (ue.test(v[2]) && (r = RegExp("</" + v[2], "g")), o = $) : v[3] !== void 0 && (o = $) : o === $ ? v[0] === ">" ? (o = r ?? P, d = -1) : v[1] === void 0 ? d = -2 : (d = o.lastIndex - v[2].length, h = v[1], o = v[3] === void 0 ? $ : v[3] === '"' ? oe : ae) : o === oe || o === ae ? o = $ : o === se || o === re ? o = P : (o = $, r = void 0);
-    const _ = o === $ && s[l + 1].startsWith("/>") ? " " : "";
-    a += o === P ? n + Ve : d >= 0 ? (i.push(h), n.slice(0, d) + he + n.slice(d) + y + _) : n + y + (d === -2 ? l : _);
+const He = (o, e) => {
+  const t = o.length - 1, s = [];
+  let i, r = e === 2 ? "<svg>" : e === 3 ? "<math>" : "", a = S;
+  for (let n = 0; n < t; n++) {
+    const l = o[n];
+    let d, g, c = -1, u = 0;
+    for (; u < l.length && (a.lastIndex = u, g = a.exec(l), g !== null); ) u = a.lastIndex, a === S ? g[1] === "!--" ? a = re : g[1] !== void 0 ? a = ae : g[2] !== void 0 ? (ve.test(g[2]) && (i = RegExp("</" + g[2], "g")), a = $) : g[3] !== void 0 && (a = $) : a === $ ? g[0] === ">" ? (a = i ?? S, c = -1) : g[1] === void 0 ? c = -2 : (c = a.lastIndex - g[2].length, d = g[1], a = g[3] === void 0 ? $ : g[3] === '"' ? ne : oe) : a === ne || a === oe ? a = $ : a === re || a === ae ? a = S : (a = $, i = void 0);
+    const f = a === $ && o[n + 1].startsWith("/>") ? " " : "";
+    r += a === S ? l + Se : c >= 0 ? (s.push(d), l.slice(0, c) + ue + l.slice(c) + y + f) : l + y + (c === -2 ? n : f);
   }
-  return [ge(s, a + (s[t] || "<?>") + (e === 2 ? "</svg>" : e === 3 ? "</math>" : "")), i];
+  return [me(o, r + (o[t] || "<?>") + (e === 2 ? "</svg>" : e === 3 ? "</math>" : "")), s];
 };
-class L {
-  constructor({ strings: e, _$litType$: t }, i) {
-    let r;
+class O {
+  constructor({ strings: e, _$litType$: t }, s) {
+    let i;
     this.parts = [];
-    let a = 0, o = 0;
-    const l = e.length - 1, n = this.parts, [h, v] = Se(e, t);
-    if (this.el = L.createElement(h, i), b.currentNode = this.el.content, t === 2 || t === 3) {
-      const d = this.el.content.firstChild;
-      d.replaceWith(...d.childNodes);
+    let r = 0, a = 0;
+    const n = e.length - 1, l = this.parts, [d, g] = He(e, t);
+    if (this.el = O.createElement(d, s), b.currentNode = this.el.content, t === 2 || t === 3) {
+      const c = this.el.content.firstChild;
+      c.replaceWith(...c.childNodes);
     }
-    for (; (r = b.nextNode()) !== null && n.length < l; ) {
-      if (r.nodeType === 1) {
-        if (r.hasAttributes()) for (const d of r.getAttributeNames()) if (d.endsWith(he)) {
-          const f = v[o++], _ = r.getAttribute(d).split(y), U = /([.?@])?(.*)/.exec(f);
-          n.push({ type: 1, index: a, name: U[2], strings: _, ctor: U[1] === "." ? Oe : U[1] === "?" ? Ie : U[1] === "@" ? Me : z }), r.removeAttribute(d);
-        } else d.startsWith(y) && (n.push({ type: 6, index: a }), r.removeAttribute(d));
-        if (ue.test(r.tagName)) {
-          const d = r.textContent.split(y), f = d.length - 1;
-          if (f > 0) {
-            r.textContent = W ? W.emptyScript : "";
-            for (let _ = 0; _ < f; _++) r.append(d[_], I()), b.nextNode(), n.push({ type: 2, index: ++a });
-            r.append(d[f], I());
+    for (; (i = b.nextNode()) !== null && l.length < n; ) {
+      if (i.nodeType === 1) {
+        if (i.hasAttributes()) for (const c of i.getAttributeNames()) if (c.endsWith(ue)) {
+          const u = g[a++], f = i.getAttribute(c).split(y), W = /([.?@])?(.*)/.exec(u);
+          l.push({ type: 1, index: r, name: W[2], strings: f, ctor: W[1] === "." ? Ie : W[1] === "?" ? Le : W[1] === "@" ? Oe : R }), i.removeAttribute(c);
+        } else c.startsWith(y) && (l.push({ type: 6, index: r }), i.removeAttribute(c));
+        if (ve.test(i.tagName)) {
+          const c = i.textContent.split(y), u = c.length - 1;
+          if (u > 0) {
+            i.textContent = z ? z.emptyScript : "";
+            for (let f = 0; f < u; f++) i.append(c[f], I()), b.nextNode(), l.push({ type: 2, index: ++r });
+            i.append(c[u], I());
           }
         }
-      } else if (r.nodeType === 8) if (r.data === pe) n.push({ type: 2, index: a });
+      } else if (i.nodeType === 8) if (i.data === ge) l.push({ type: 2, index: r });
       else {
-        let d = -1;
-        for (; (d = r.data.indexOf(y, d + 1)) !== -1; ) n.push({ type: 7, index: a }), d += y.length - 1;
+        let c = -1;
+        for (; (c = i.data.indexOf(y, c + 1)) !== -1; ) l.push({ type: 7, index: r }), c += y.length - 1;
       }
-      a++;
+      r++;
     }
   }
   static createElement(e, t) {
-    const i = A.createElement("template");
-    return i.innerHTML = e, i;
+    const s = V.createElement("template");
+    return s.innerHTML = e, s;
   }
 }
-function k(s, e, t = s, i) {
-  var o, l;
-  if (e === V) return e;
-  let r = i !== void 0 ? (o = t._$Co) == null ? void 0 : o[i] : t._$Cl;
-  const a = M(e) ? void 0 : e._$litDirective$;
-  return (r == null ? void 0 : r.constructor) !== a && ((l = r == null ? void 0 : r._$AO) == null || l.call(r, !1), a === void 0 ? r = void 0 : (r = new a(s), r._$AT(s, t, i)), i !== void 0 ? (t._$Co ?? (t._$Co = []))[i] = r : t._$Cl = r), r !== void 0 && (e = k(s, r._$AS(s, e.values), r, i)), e;
+function E(o, e, t = o, s) {
+  var a, n;
+  if (e === k) return e;
+  let i = s !== void 0 ? (a = t._$Co) == null ? void 0 : a[s] : t._$Cl;
+  const r = L(e) ? void 0 : e._$litDirective$;
+  return (i == null ? void 0 : i.constructor) !== r && ((n = i == null ? void 0 : i._$AO) == null || n.call(i, !1), r === void 0 ? i = void 0 : (i = new r(o), i._$AT(o, t, s)), s !== void 0 ? (t._$Co ?? (t._$Co = []))[s] = i : t._$Cl = i), i !== void 0 && (e = E(o, i._$AS(o, e.values), i, s)), e;
 }
-class Ce {
+class Me {
   constructor(e, t) {
     this._$AV = [], this._$AN = void 0, this._$AD = e, this._$AM = t;
   }
@@ -358,30 +358,30 @@ class Ce {
     return this._$AM._$AU;
   }
   u(e) {
-    const { el: { content: t }, parts: i } = this._$AD, r = ((e == null ? void 0 : e.creationScope) ?? A).importNode(t, !0);
-    b.currentNode = r;
-    let a = b.nextNode(), o = 0, l = 0, n = i[0];
-    for (; n !== void 0; ) {
-      if (o === n.index) {
-        let h;
-        n.type === 2 ? h = new H(a, a.nextSibling, this, e) : n.type === 1 ? h = new n.ctor(a, n.name, n.strings, this, e) : n.type === 6 && (h = new Le(a, this, e)), this._$AV.push(h), n = i[++l];
+    const { el: { content: t }, parts: s } = this._$AD, i = ((e == null ? void 0 : e.creationScope) ?? V).importNode(t, !0);
+    b.currentNode = i;
+    let r = b.nextNode(), a = 0, n = 0, l = s[0];
+    for (; l !== void 0; ) {
+      if (a === l.index) {
+        let d;
+        l.type === 2 ? d = new T(r, r.nextSibling, this, e) : l.type === 1 ? d = new l.ctor(r, l.name, l.strings, this, e) : l.type === 6 && (d = new Te(r, this, e)), this._$AV.push(d), l = s[++n];
       }
-      o !== (n == null ? void 0 : n.index) && (a = b.nextNode(), o++);
+      a !== (l == null ? void 0 : l.index) && (r = b.nextNode(), a++);
     }
-    return b.currentNode = A, r;
+    return b.currentNode = V, i;
   }
   p(e) {
     let t = 0;
-    for (const i of this._$AV) i !== void 0 && (i.strings !== void 0 ? (i._$AI(e, i, t), t += i.strings.length - 2) : i._$AI(e[t])), t++;
+    for (const s of this._$AV) s !== void 0 && (s.strings !== void 0 ? (s._$AI(e, s, t), t += s.strings.length - 2) : s._$AI(e[t])), t++;
   }
 }
-class H {
+class T {
   get _$AU() {
     var e;
     return ((e = this._$AM) == null ? void 0 : e._$AU) ?? this._$Cv;
   }
-  constructor(e, t, i, r) {
-    this.type = 2, this._$AH = p, this._$AN = void 0, this._$AA = e, this._$AB = t, this._$AM = i, this.options = r, this._$Cv = (r == null ? void 0 : r.isConnected) ?? !0;
+  constructor(e, t, s, i) {
+    this.type = 2, this._$AH = p, this._$AN = void 0, this._$AA = e, this._$AB = t, this._$AM = s, this.options = i, this._$Cv = (i == null ? void 0 : i.isConnected) ?? !0;
   }
   get parentNode() {
     let e = this._$AA.parentNode;
@@ -395,7 +395,7 @@ class H {
     return this._$AB;
   }
   _$AI(e, t = this) {
-    e = k(this, e, t), M(e) ? e === p || e == null || e === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : e !== this._$AH && e !== V && this._(e) : e._$litType$ !== void 0 ? this.$(e) : e.nodeType !== void 0 ? this.T(e) : ke(e) ? this.k(e) : this._(e);
+    e = E(this, e, t), L(e) ? e === p || e == null || e === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : e !== this._$AH && e !== k && this._(e) : e._$litType$ !== void 0 ? this.$(e) : e.nodeType !== void 0 ? this.T(e) : Pe(e) ? this.k(e) : this._(e);
   }
   O(e) {
     return this._$AA.parentNode.insertBefore(e, this._$AB);
@@ -404,33 +404,33 @@ class H {
     this._$AH !== e && (this._$AR(), this._$AH = this.O(e));
   }
   _(e) {
-    this._$AH !== p && M(this._$AH) ? this._$AA.nextSibling.data = e : this.T(A.createTextNode(e)), this._$AH = e;
+    this._$AH !== p && L(this._$AH) ? this._$AA.nextSibling.data = e : this.T(V.createTextNode(e)), this._$AH = e;
   }
   $(e) {
-    var a;
-    const { values: t, _$litType$: i } = e, r = typeof i == "number" ? this._$AC(e) : (i.el === void 0 && (i.el = L.createElement(ge(i.h, i.h[0]), this.options)), i);
-    if (((a = this._$AH) == null ? void 0 : a._$AD) === r) this._$AH.p(t);
+    var r;
+    const { values: t, _$litType$: s } = e, i = typeof s == "number" ? this._$AC(e) : (s.el === void 0 && (s.el = O.createElement(me(s.h, s.h[0]), this.options)), s);
+    if (((r = this._$AH) == null ? void 0 : r._$AD) === i) this._$AH.p(t);
     else {
-      const o = new Ce(r, this), l = o.u(this.options);
-      o.p(t), this.T(l), this._$AH = o;
+      const a = new Me(i, this), n = a.u(this.options);
+      a.p(t), this.T(n), this._$AH = a;
     }
   }
   _$AC(e) {
-    let t = ne.get(e.strings);
-    return t === void 0 && ne.set(e.strings, t = new L(e)), t;
+    let t = le.get(e.strings);
+    return t === void 0 && le.set(e.strings, t = new O(e)), t;
   }
   k(e) {
     Y(this._$AH) || (this._$AH = [], this._$AR());
     const t = this._$AH;
-    let i, r = 0;
-    for (const a of e) r === t.length ? t.push(i = new H(this.O(I()), this.O(I()), this, this.options)) : i = t[r], i._$AI(a), r++;
-    r < t.length && (this._$AR(i && i._$AB.nextSibling, r), t.length = r);
+    let s, i = 0;
+    for (const r of e) i === t.length ? t.push(s = new T(this.O(I()), this.O(I()), this, this.options)) : s = t[i], s._$AI(r), i++;
+    i < t.length && (this._$AR(s && s._$AB.nextSibling, i), t.length = i);
   }
   _$AR(e = this._$AA.nextSibling, t) {
-    var i;
-    for ((i = this._$AP) == null ? void 0 : i.call(this, !1, !0, t); e !== this._$AB; ) {
-      const r = e.nextSibling;
-      e.remove(), e = r;
+    var s;
+    for ((s = this._$AP) == null ? void 0 : s.call(this, !1, !0, t); e !== this._$AB; ) {
+      const i = e.nextSibling;
+      e.remove(), e = i;
     }
   }
   setConnected(e) {
@@ -438,32 +438,32 @@ class H {
     this._$AM === void 0 && (this._$Cv = e, (t = this._$AP) == null || t.call(this, e));
   }
 }
-class z {
+class R {
   get tagName() {
     return this.element.tagName;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
-  constructor(e, t, i, r, a) {
-    this.type = 1, this._$AH = p, this._$AN = void 0, this.element = e, this.name = t, this._$AM = r, this.options = a, i.length > 2 || i[0] !== "" || i[1] !== "" ? (this._$AH = Array(i.length - 1).fill(new String()), this.strings = i) : this._$AH = p;
+  constructor(e, t, s, i, r) {
+    this.type = 1, this._$AH = p, this._$AN = void 0, this.element = e, this.name = t, this._$AM = i, this.options = r, s.length > 2 || s[0] !== "" || s[1] !== "" ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = p;
   }
-  _$AI(e, t = this, i, r) {
-    const a = this.strings;
-    let o = !1;
-    if (a === void 0) e = k(this, e, t, 0), o = !M(e) || e !== this._$AH && e !== V, o && (this._$AH = e);
+  _$AI(e, t = this, s, i) {
+    const r = this.strings;
+    let a = !1;
+    if (r === void 0) e = E(this, e, t, 0), a = !L(e) || e !== this._$AH && e !== k, a && (this._$AH = e);
     else {
-      const l = e;
-      let n, h;
-      for (e = a[0], n = 0; n < a.length - 1; n++) h = k(this, l[i + n], t, n), h === V && (h = this._$AH[n]), o || (o = !M(h) || h !== this._$AH[n]), h === p ? e = p : e !== p && (e += (h ?? "") + a[n + 1]), this._$AH[n] = h;
+      const n = e;
+      let l, d;
+      for (e = r[0], l = 0; l < r.length - 1; l++) d = E(this, n[s + l], t, l), d === k && (d = this._$AH[l]), a || (a = !L(d) || d !== this._$AH[l]), d === p ? e = p : e !== p && (e += (d ?? "") + r[l + 1]), this._$AH[l] = d;
     }
-    o && !r && this.j(e);
+    a && !i && this.j(e);
   }
   j(e) {
     e === p ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, e ?? "");
   }
 }
-class Oe extends z {
+class Ie extends R {
   constructor() {
     super(...arguments), this.type = 3;
   }
@@ -471,7 +471,7 @@ class Oe extends z {
     this.element[this.name] = e === p ? void 0 : e;
   }
 }
-class Ie extends z {
+class Le extends R {
   constructor() {
     super(...arguments), this.type = 4;
   }
@@ -479,41 +479,41 @@ class Ie extends z {
     this.element.toggleAttribute(this.name, !!e && e !== p);
   }
 }
-class Me extends z {
-  constructor(e, t, i, r, a) {
-    super(e, t, i, r, a), this.type = 5;
+class Oe extends R {
+  constructor(e, t, s, i, r) {
+    super(e, t, s, i, r), this.type = 5;
   }
   _$AI(e, t = this) {
-    if ((e = k(this, e, t, 0) ?? p) === V) return;
-    const i = this._$AH, r = e === p && i !== p || e.capture !== i.capture || e.once !== i.once || e.passive !== i.passive, a = e !== p && (i === p || r);
-    r && this.element.removeEventListener(this.name, this, i), a && this.element.addEventListener(this.name, this, e), this._$AH = e;
+    if ((e = E(this, e, t, 0) ?? p) === k) return;
+    const s = this._$AH, i = e === p && s !== p || e.capture !== s.capture || e.once !== s.once || e.passive !== s.passive, r = e !== p && (s === p || i);
+    i && this.element.removeEventListener(this.name, this, s), r && this.element.addEventListener(this.name, this, e), this._$AH = e;
   }
   handleEvent(e) {
     var t;
     typeof this._$AH == "function" ? this._$AH.call(((t = this.options) == null ? void 0 : t.host) ?? this.element, e) : this._$AH.handleEvent(e);
   }
 }
-class Le {
-  constructor(e, t, i) {
-    this.element = e, this.type = 6, this._$AN = void 0, this._$AM = t, this.options = i;
+class Te {
+  constructor(e, t, s) {
+    this.element = e, this.type = 6, this._$AN = void 0, this._$AM = t, this.options = s;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
   _$AI(e) {
-    k(this, e);
+    E(this, e);
   }
 }
-const B = C.litHtmlPolyfillSupport;
-B == null || B(L, H), (C.litHtmlVersions ?? (C.litHtmlVersions = [])).push("3.3.1");
-const He = (s, e, t) => {
-  const i = (t == null ? void 0 : t.renderBefore) ?? e;
-  let r = i._$litPart$;
-  if (r === void 0) {
-    const a = (t == null ? void 0 : t.renderBefore) ?? null;
-    i._$litPart$ = r = new H(e.insertBefore(I(), a), a, void 0, t ?? {});
+const q = H.litHtmlPolyfillSupport;
+q == null || q(O, T), (H.litHtmlVersions ?? (H.litHtmlVersions = [])).push("3.3.1");
+const Ue = (o, e, t) => {
+  const s = (t == null ? void 0 : t.renderBefore) ?? e;
+  let i = s._$litPart$;
+  if (i === void 0) {
+    const r = (t == null ? void 0 : t.renderBefore) ?? null;
+    s._$litPart$ = i = new T(e.insertBefore(I(), r), r, void 0, t ?? {});
   }
-  return r._$AI(s), r;
+  return i._$AI(o), i;
 };
 /**
  * @license
@@ -521,7 +521,7 @@ const He = (s, e, t) => {
  * SPDX-License-Identifier: BSD-3-Clause
  */
 const x = globalThis;
-class O extends E {
+class M extends A {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
@@ -532,7 +532,7 @@ class O extends E {
   }
   update(e) {
     const t = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(e), this._$Do = He(t, this.renderRoot, this.renderOptions);
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(e), this._$Do = Ue(t, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     var e;
@@ -543,113 +543,103 @@ class O extends E {
     super.disconnectedCallback(), (e = this._$Do) == null || e.setConnected(!1);
   }
   render() {
-    return V;
+    return k;
   }
 }
-var ce;
-O._$litElement$ = !0, O.finalized = !0, (ce = x.litElementHydrateSupport) == null || ce.call(x, { LitElement: O });
+var he;
+M._$litElement$ = !0, M.finalized = !0, (he = x.litElementHydrateSupport) == null || he.call(x, { LitElement: M });
 const Z = x.litElementPolyfillSupport;
-Z == null || Z({ LitElement: O });
+Z == null || Z({ LitElement: M });
 (x.litElementVersions ?? (x.litElementVersions = [])).push("4.2.1");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const Te = (s) => (e, t) => {
-  t !== void 0 ? t.addInitializer(() => {
-    customElements.define(s, e);
-  }) : customElements.define(s, e);
-};
-/**
- * @license
- * Copyright 2017 Google LLC
- * SPDX-License-Identifier: BSD-3-Clause
- */
-const Ue = { attribute: !0, type: String, converter: j, reflect: !1, hasChanged: J }, Ne = (s = Ue, e, t) => {
-  const { kind: i, metadata: r } = t;
-  let a = globalThis.litPropertyMetadata.get(r);
-  if (a === void 0 && globalThis.litPropertyMetadata.set(r, a = /* @__PURE__ */ new Map()), i === "setter" && ((s = Object.create(s)).wrapped = !0), a.set(t.name, s), i === "accessor") {
-    const { name: o } = t;
-    return { set(l) {
-      const n = e.get.call(this);
-      e.set.call(this, l), this.requestUpdate(o, n, s);
-    }, init(l) {
-      return l !== void 0 && this.C(o, void 0, s, l), l;
+const We = { attribute: !0, type: String, converter: j, reflect: !1, hasChanged: J }, Ne = (o = We, e, t) => {
+  const { kind: s, metadata: i } = t;
+  let r = globalThis.litPropertyMetadata.get(i);
+  if (r === void 0 && globalThis.litPropertyMetadata.set(i, r = /* @__PURE__ */ new Map()), s === "setter" && ((o = Object.create(o)).wrapped = !0), r.set(t.name, o), s === "accessor") {
+    const { name: a } = t;
+    return { set(n) {
+      const l = e.get.call(this);
+      e.set.call(this, n), this.requestUpdate(a, l, o);
+    }, init(n) {
+      return n !== void 0 && this.C(a, void 0, o, n), n;
     } };
   }
-  if (i === "setter") {
-    const { name: o } = t;
-    return function(l) {
-      const n = this[o];
-      e.call(this, l), this.requestUpdate(o, n, s);
+  if (s === "setter") {
+    const { name: a } = t;
+    return function(n) {
+      const l = this[a];
+      e.call(this, n), this.requestUpdate(a, l, o);
     };
   }
-  throw Error("Unsupported decorator location: " + i);
+  throw Error("Unsupported decorator location: " + s);
 };
-function T(s) {
-  return (e, t) => typeof t == "object" ? Ne(s, e, t) : ((i, r, a) => {
-    const o = r.hasOwnProperty(a);
-    return r.constructor.createProperty(a, i), o ? Object.getOwnPropertyDescriptor(r, a) : void 0;
-  })(s, e, t);
+function U(o) {
+  return (e, t) => typeof t == "object" ? Ne(o, e, t) : ((s, i, r) => {
+    const a = i.hasOwnProperty(r);
+    return i.constructor.createProperty(r, s), a ? Object.getOwnPropertyDescriptor(i, r) : void 0;
+  })(o, e, t);
 }
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-function m(s) {
-  return T({ ...s, state: !0, attribute: !1 });
+function _(o) {
+  return U({ ...o, state: !0, attribute: !1 });
 }
-function N(s) {
-  if (!s || s.length !== 3) return "#000000";
-  const [e, t, i] = s;
-  return `#${[e, t, i].map((r) => Math.max(0, Math.min(255, r)).toString(16).padStart(2, "0")).join("")}`;
+function N(o) {
+  if (!o || o.length !== 3) return "#000000";
+  const [e, t, s] = o;
+  return `#${[e, t, s].map((i) => Math.max(0, Math.min(255, i)).toString(16).padStart(2, "0")).join("")}`;
 }
-function le(s) {
-  const e = s.trim();
+function ce(o) {
+  const e = o.trim();
   if (!e) return null;
   const t = e.match(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
   if (t) {
-    let a = t[1];
-    return a.length === 3 && (a = a[0] + a[0] + a[1] + a[1] + a[2] + a[2]), [
-      parseInt(a.slice(0, 2), 16),
-      parseInt(a.slice(2, 4), 16),
-      parseInt(a.slice(4, 6), 16)
+    let r = t[1];
+    return r.length === 3 && (r = r[0] + r[0] + r[1] + r[1] + r[2] + r[2]), [
+      parseInt(r.slice(0, 2), 16),
+      parseInt(r.slice(2, 4), 16),
+      parseInt(r.slice(4, 6), 16)
     ];
   }
-  const i = e.match(/^(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})$/);
-  if (i) {
-    const a = Math.min(255, parseInt(i[1], 10)), o = Math.min(255, parseInt(i[2], 10)), l = Math.min(255, parseInt(i[3], 10));
-    return [a, o, l];
+  const s = e.match(/^(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})$/);
+  if (s) {
+    const r = Math.min(255, parseInt(s[1], 10)), a = Math.min(255, parseInt(s[2], 10)), n = Math.min(255, parseInt(s[3], 10));
+    return [r, a, n];
   }
-  const r = e.match(
+  const i = e.match(
     /^rgb\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i
   );
-  if (r) {
-    const a = Math.min(255, parseInt(r[1], 10)), o = Math.min(255, parseInt(r[2], 10)), l = Math.min(255, parseInt(r[3], 10));
-    return [a, o, l];
+  if (i) {
+    const r = Math.min(255, parseInt(i[1], 10)), a = Math.min(255, parseInt(i[2], 10)), n = Math.min(255, parseInt(i[3], 10));
+    return [r, a, n];
   }
   return null;
 }
-function q(s, e) {
-  if (s.value !== void 0 && s.value !== null)
-    return s.value;
-  if (s.index !== void 0 && s.index !== null)
-    return e[s.index];
+function P(o, e) {
+  if (o.value !== void 0 && o.value !== null)
+    return o.value;
+  if (o.index !== void 0 && o.index !== null)
+    return e[o.index];
 }
-function ve(s) {
-  return Object.entries(s).map(([e, t]) => ({ value: e, label: t }));
+function _e(o) {
+  return Object.entries(o).map(([e, t]) => ({ value: e, label: t }));
 }
-function De(s, e) {
-  return [{ value: "", label: s }, ...ve(e)];
+function de(o, e) {
+  return [{ value: "", label: o }, ..._e(e)];
 }
-var je = Object.defineProperty, We = Object.getOwnPropertyDescriptor, g = (s, e, t, i) => {
-  for (var r = i > 1 ? void 0 : i ? We(e, t) : e, a = s.length - 1, o; a >= 0; a--)
-    (o = s[a]) && (r = (i ? o(e, t, r) : o(r)) || r);
-  return i && r && je(e, t, r), r;
+var De = Object.defineProperty, m = (o, e, t, s) => {
+  for (var i = void 0, r = o.length - 1, a; r >= 0; r--)
+    (a = o[r]) && (i = a(e, t, i) || i);
+  return i && De(e, t, i), i;
 };
-const ze = (() => {
+const je = (() => {
   try {
     return Intl.supportedValuesOf("timeZone");
   } catch {
@@ -668,29 +658,34 @@ const ze = (() => {
     ];
   }
 })();
-function Re(s, e) {
+function ze(o, e) {
   let t;
-  return (...i) => {
-    clearTimeout(t), t = setTimeout(() => s(...i), e);
+  return (...s) => {
+    clearTimeout(t), t = setTimeout(() => o(...s), e);
   };
 }
-let u = class extends O {
+const X = class X extends M {
   constructor() {
-    super(...arguments), this.narrow = !1, this._page = "main", this._config = null, this._views = [], this._devices = [], this._editingView = null, this._previewImage = null, this._previewLoading = !1, this._loading = !0, this._saving = !1, this._expandedItems = /* @__PURE__ */ new Set(), this._viewPreviews = /* @__PURE__ */ new Map(), this._createViewDialogOpen = !1, this._newViewName = "", this._creatingView = !1, this._createViewError = null, this._refreshPreview = Re(async () => {
+    super(...arguments), this.narrow = !1, this._page = "main", this._config = null, this._views = [], this._devices = [], this._editingView = null, this._previewImage = null, this._previewLoading = !1, this._loading = !0, this._saving = !1, this._expandedItems = /* @__PURE__ */ new Set(), this._viewPreviews = /* @__PURE__ */ new Map(), this._createViewDialogOpen = !1, this._newViewName = "", this._creatingView = !1, this._createViewError = null, this._refreshPreview = ze(async () => {
       if (this._editingView) {
         this._previewLoading = !0;
         try {
-          const s = await this.hass.connection.sendMessagePromise({
+          const e = await this.hass.connection.sendMessagePromise({
             type: "geekmagic/preview/render",
             view_config: {
               layout: this._editingView.layout,
               theme: this._editingView.theme,
-              widgets: this._editingView.widgets
+              widgets: this._editingView.widgets,
+              background_image: this._editingView.background_image || "",
+              background_mode: this._editingView.background_mode || "stretch",
+              background_entity: this._editingView.background_entity || "",
+              widget_contrast: this._editingView.widget_contrast ?? 0,
+              text_opacity: this._editingView.text_opacity ?? 1
             }
           });
-          this._previewImage = s.image;
-        } catch (s) {
-          console.error("Failed to render preview:", s);
+          this._previewImage = e.image;
+        } catch (e) {
+          console.error("Failed to render preview:", e);
         } finally {
           this._previewLoading = !1;
         }
@@ -703,7 +698,7 @@ let u = class extends O {
   async _loadData() {
     this._loading = !0;
     try {
-      const [s, e, t] = await Promise.all([
+      const [e, t, s] = await Promise.all([
         this.hass.connection.sendMessagePromise({
           type: "geekmagic/config"
         }),
@@ -714,77 +709,87 @@ let u = class extends O {
           type: "geekmagic/devices/list"
         })
       ]);
-      this._config = s, this._views = e.views, this._devices = t.devices, this._loadViewPreviews();
-    } catch (s) {
-      console.error("Failed to load GeekMagic config:", s);
+      this._config = e, this._views = t.views, this._devices = s.devices, this._loadViewPreviews();
+    } catch (e) {
+      console.error("Failed to load GeekMagic config:", e);
     } finally {
       this._loading = !1;
     }
   }
   async _loadViewPreviews() {
-    const s = this._views.map(async (i) => {
+    const e = this._views.map(async (i) => {
       try {
         const r = await this.hass.connection.sendMessagePromise({
           type: "geekmagic/preview/render",
           view_config: {
             layout: i.layout,
             theme: i.theme,
-            widgets: i.widgets
+            widgets: i.widgets,
+            background_image: i.background_image || "",
+            background_mode: i.background_mode || "stretch",
+            background_entity: i.background_entity || "",
+            widget_contrast: i.widget_contrast ?? 0,
+            text_opacity: i.text_opacity ?? 1
           }
         });
         return { id: i.id, image: r.image };
       } catch (r) {
         return console.error(`Failed to load preview for view ${i.id}:`, r), { id: i.id, image: null };
       }
-    }), e = await Promise.all(s), t = /* @__PURE__ */ new Map();
-    for (const i of e)
-      i.image && t.set(i.id, i.image);
-    this._viewPreviews = t;
+    }), t = await Promise.all(e), s = /* @__PURE__ */ new Map();
+    for (const i of t)
+      i.image && s.set(i.id, i.image);
+    this._viewPreviews = s;
   }
   _suggestViewName() {
-    const s = new Set(this._views.map((i) => i.name)), e = "New View";
-    if (!s.has(e)) return e;
-    let t = 2;
-    for (; s.has(`${e} ${t}`); )
-      t += 1;
-    return `${e} ${t}`;
+    const e = new Set(this._views.map((i) => i.name)), t = "New View";
+    if (!e.has(t)) return t;
+    let s = 2;
+    for (; e.has(`${t} ${s}`); )
+      s += 1;
+    return `${t} ${s}`;
   }
   async _openCreateViewDialog() {
-    var s;
-    this._newViewName = this._suggestViewName(), this._createViewError = null, this._createViewDialogOpen = !0, await this.updateComplete, (s = this.renderRoot.querySelector(".create-view-name")) == null || s.focus();
+    var e;
+    this._newViewName = this._suggestViewName(), this._createViewError = null, this._createViewDialogOpen = !0, await this.updateComplete, (e = this.renderRoot.querySelector(".create-view-name")) == null || e.focus();
   }
   _closeCreateViewDialog() {
     this._creatingView || (this._createViewDialogOpen = !1, this._createViewError = null);
   }
-  _handleCreateViewDialogKeydown(s) {
-    if (s.key === "Escape") {
-      s.stopPropagation(), this._closeCreateViewDialog();
+  _handleCreateViewDialogKeydown(e) {
+    if (e.key === "Escape") {
+      e.stopPropagation(), this._closeCreateViewDialog();
       return;
     }
-    s.key === "Enter" && !s.shiftKey && (s.preventDefault(), this._createView());
+    e.key === "Enter" && !e.shiftKey && (e.preventDefault(), this._createView());
   }
   async _createView() {
-    const s = this._newViewName.trim();
-    if (!(!s || this._creatingView)) {
+    const e = this._newViewName.trim();
+    if (!(!e || this._creatingView)) {
       this._creatingView = !0, this._createViewError = null;
       try {
-        const e = await this.hass.connection.sendMessagePromise({
+        const t = await this.hass.connection.sendMessagePromise({
           type: "geekmagic/views/create",
-          name: s,
+          name: e,
           layout: "grid_2x2",
           theme: "watchos",
-          widgets: []
+          widgets: [],
+          background_image: "",
+          background_mode: "stretch",
+          background_entity: "",
+          widget_contrast: 0.5,
+          text_opacity: 1
         });
-        this._views = [...this._views, e.view], this._createViewDialogOpen = !1, this._newViewName = "", this._editView(e.view);
-      } catch (e) {
-        console.error("Failed to create view:", e), this._createViewError = "Could not create view. Check Home Assistant logs and try again.";
+        this._views = [...this._views, t.view], this._createViewDialogOpen = !1, this._newViewName = "", this._editView(t.view);
+      } catch (t) {
+        console.error("Failed to create view:", t), this._createViewError = "Could not create view. Check Home Assistant logs and try again.";
       } finally {
         this._creatingView = !1;
       }
     }
   }
-  _editView(s) {
-    this._editingView = { ...s, widgets: [...s.widgets] }, this._page = "editor", this._refreshPreview();
+  _editView(e) {
+    this._editingView = { ...e, widgets: [...e.widgets] }, this._page = "editor", this._refreshPreview();
   }
   async _saveView() {
     if (this._editingView) {
@@ -796,63 +801,105 @@ let u = class extends O {
           name: this._editingView.name,
           layout: this._editingView.layout,
           theme: this._editingView.theme,
-          widgets: this._editingView.widgets
+          widgets: this._editingView.widgets,
+          background_image: this._editingView.background_image || "",
+          background_mode: this._editingView.background_mode || "stretch",
+          background_entity: this._editingView.background_entity || "",
+          widget_contrast: this._editingView.widget_contrast ?? 0,
+          text_opacity: this._editingView.text_opacity ?? 1
         }), this._views = this._views.map(
-          (s) => s.id === this._editingView.id ? this._editingView : s
+          (e) => e.id === this._editingView.id ? this._editingView : e
         ), this._page = "main", this._editingView = null, this._loadViewPreviews();
-      } catch (s) {
-        console.error("Failed to save view:", s);
+      } catch (e) {
+        console.error("Failed to save view:", e);
       } finally {
         this._saving = !1;
       }
     }
   }
-  async _deleteView(s) {
-    if (confirm(`Delete view "${s.name}"?`))
+  async _deleteView(e) {
+    if (confirm(`Delete view "${e.name}"?`))
       try {
         await this.hass.connection.sendMessagePromise({
           type: "geekmagic/views/delete",
-          view_id: s.id
-        }), this._views = this._views.filter((e) => e.id !== s.id);
-      } catch (e) {
-        console.error("Failed to delete view:", e);
+          view_id: e.id
+        }), this._views = this._views.filter((t) => t.id !== e.id);
+      } catch (t) {
+        console.error("Failed to delete view:", t);
       }
   }
-  _updateEditingView(s) {
-    this._editingView && (this._editingView = { ...this._editingView, ...s }, this._refreshPreview());
+  _updateEditingView(e) {
+    if (this._editingView) {
+      if (e.layout !== void 0 && e.layout !== this._editingView.layout) {
+        const t = e.layout === "custom", s = this._editingView.widgets.map((i, r) => ({
+          ...i,
+          slot: t ? r : i.slot ?? r,
+          x: i.x ?? 0,
+          y: i.y ?? 0,
+          width: i.width ?? 240,
+          height: i.height ?? 240
+        }));
+        this._editingView = { ...this._editingView, ...e, widgets: s }, this._refreshPreview();
+        return;
+      }
+      this._editingView = { ...this._editingView, ...e }, this._refreshPreview();
+    }
   }
-  _updateWidget(s, e) {
+  _isCustomLayout() {
+    var e;
+    return ((e = this._editingView) == null ? void 0 : e.layout) === "custom";
+  }
+  _updateWidget(e, t) {
     if (!this._editingView) return;
-    if (e.type === "clock") {
+    if (t.type === "clock") {
       const r = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      e = {
-        ...e,
-        options: { ...e.options, timezone: r }
+      t = {
+        ...t,
+        options: { ...t.options, timezone: r }
       };
     }
-    const t = [...this._editingView.widgets], i = t.findIndex((r) => r.slot === s);
-    i >= 0 ? t[i] = { ...t[i], ...e } : t.push({ slot: s, type: "", ...e }), this._editingView = { ...this._editingView, widgets: [...t] }, this.requestUpdate(), this._refreshPreview();
+    const s = [...this._editingView.widgets];
+    if (this._isCustomLayout())
+      if (e >= 0 && e < s.length)
+        s[e] = { ...s[e], ...t };
+      else {
+        const r = s.length, a = r % 4, n = Math.floor(r / 4);
+        s.push({
+          x: 10 + a * 60,
+          y: 10 + n * 60,
+          width: 50,
+          height: 50,
+          slot: r,
+          type: "",
+          ...t
+        });
+      }
+    else {
+      const r = s.findIndex((a) => a.slot === e);
+      r >= 0 ? s[r] = { ...s[r], ...t } : s.push({ slot: e, type: "", ...t });
+    }
+    this._editingView = { ...this._editingView, widgets: [...s] }, this.requestUpdate(), this._refreshPreview();
   }
-  async _toggleDeviceView(s, e, t) {
-    const i = t ? [...s.assigned_views, e] : s.assigned_views.filter((r) => r !== e);
+  async _toggleDeviceView(e, t, s) {
+    const i = s ? [...e.assigned_views, t] : e.assigned_views.filter((r) => r !== t);
     try {
       await this.hass.connection.sendMessagePromise({
         type: "geekmagic/devices/assign_views",
-        entry_id: s.entry_id,
+        entry_id: e.entry_id,
         view_ids: i
       }), this._devices = this._devices.map(
-        (r) => r.entry_id === s.entry_id ? { ...r, assigned_views: i } : r
+        (r) => r.entry_id === e.entry_id ? { ...r, assigned_views: i } : r
       );
     } catch (r) {
       console.error("Failed to update device views:", r);
     }
   }
   render() {
-    return this._loading ? c`
+    return this._loading ? h`
         <div class="loading">
           <ha-circular-progress indeterminate></ha-circular-progress>
         </div>
-      ` : c`
+      ` : h`
       <div class="header">
         <ha-menu-button
           .hass=${this.hass}
@@ -874,42 +921,42 @@ let u = class extends O {
     }
   }
   _renderMain() {
-    return c`
+    return h`
       <!-- Devices Section -->
       <div class="section">
         <h2 class="section-header">Devices</h2>
-        ${this._devices.length === 0 ? c`
+        ${this._devices.length === 0 ? h`
               <div class="empty-state-inline">
                 <ha-icon icon="mdi:monitor-off"></ha-icon>
                 <span>No devices configured. Add a device through Settings → Devices & Services.</span>
               </div>
-            ` : c`
+            ` : h`
               <div class="devices-list">
                 ${this._devices.map(
-      (s) => c`
+      (e) => h`
                     <ha-card>
                       <div class="card-content" style="padding-top: 16px;">
                         <div class="device-header">
-                          <span class="device-name">${s.name}</span>
-                          <span class="device-status ${s.online ? "online" : "offline"}">
-                            <a href="http://${s.host}" target="_blank" rel="noopener noreferrer">${s.online ? "Online" : "Offline"}</a>
+                          <span class="device-name">${e.name}</span>
+                          <span class="device-status ${e.online ? "online" : "offline"}">
+                            <a href="http://${e.host}" target="_blank" rel="noopener noreferrer">${e.online ? "Online" : "Offline"}</a>
                           </span>
                         </div>
                         <div class="views-checkboxes">
-                          ${this._views.length === 0 ? c`<p style="color: var(--secondary-text-color); margin: 8px 0 0;">
+                          ${this._views.length === 0 ? h`<p style="color: var(--secondary-text-color); margin: 8px 0 0;">
                                 No views available. Create a view below.
                               </p>` : this._views.map(
-        (e) => c`
+        (t) => h`
                                   <label class="view-checkbox">
                                     <ha-checkbox
-                                      .checked=${s.assigned_views.includes(e.id)}
-                                      @change=${(t) => this._toggleDeviceView(
-          s,
-          e.id,
-          t.target.checked
+                                      .checked=${e.assigned_views.includes(t.id)}
+                                      @change=${(s) => this._toggleDeviceView(
+          e,
+          t.id,
+          s.target.checked
         )}
                                     ></ha-checkbox>
-                                    ${e.name}
+                                    ${t.name}
                                   </label>
                                 `
       )}
@@ -927,34 +974,34 @@ let u = class extends O {
         <h2 class="section-header">Views</h2>
         <div class="views-grid">
           ${this._views.map(
-      (s) => {
-        var e, t, i;
-        return c`
-              <ha-card class="view-card" @click=${() => this._editView(s)}>
+      (e) => {
+        var t, s, i;
+        return h`
+              <ha-card class="view-card" @click=${() => this._editView(e)}>
                 <div class="view-card-content">
                   <div class="view-card-preview">
-                    ${this._viewPreviews.has(s.id) ? c`<img
+                    ${this._viewPreviews.has(e.id) ? h`<img
                           class="view-preview-image"
-                          src="data:image/png;base64,${this._viewPreviews.get(s.id)}"
-                          alt="${s.name}"
-                        />` : c`<div class="view-preview-placeholder">
+                          src="data:image/png;base64,${this._viewPreviews.get(e.id)}"
+                          alt="${e.name}"
+                        />` : h`<div class="view-preview-placeholder">
                           <ha-circular-progress indeterminate size="small"></ha-circular-progress>
                         </div>`}
                   </div>
                   <div class="view-card-info">
                     <div class="view-card-header">
-                      <h3>${s.name}</h3>
+                      <h3>${e.name}</h3>
                       <ha-icon-button
                         .path=${"M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"}
                         @click=${(r) => {
-          r.stopPropagation(), this._deleteView(s);
+          r.stopPropagation(), this._deleteView(e);
         }}
                       ></ha-icon-button>
                     </div>
                     <div class="card-meta">
-                      ${((t = (e = this._config) == null ? void 0 : e.layout_types[s.layout]) == null ? void 0 : t.name) || s.layout}
-                      &bull; ${((i = this._config) == null ? void 0 : i.themes[s.theme]) || s.theme}
-                      &bull; ${s.widgets.length} widgets
+                      ${((s = (t = this._config) == null ? void 0 : t.layout_types[e.layout]) == null ? void 0 : s.name) || e.layout}
+                      &bull; ${((i = this._config) == null ? void 0 : i.themes[e.theme]) || e.theme}
+                      &bull; ${e.widgets.length} widgets
                     </div>
                   </div>
                 </div>
@@ -976,19 +1023,19 @@ let u = class extends O {
   }
   _renderCreateViewDialog() {
     if (!this._createViewDialogOpen) return p;
-    const s = this._newViewName.trim();
-    return c`
+    const e = this._newViewName.trim();
+    return h`
       <div
         class="dialog-backdrop"
         @click=${() => this._closeCreateViewDialog()}
-        @keydown=${(e) => this._handleCreateViewDialogKeydown(e)}
+        @keydown=${(t) => this._handleCreateViewDialogKeydown(t)}
       >
         <ha-card
           class="dialog-card"
           role="dialog"
           aria-modal="true"
           aria-labelledby="create-view-title"
-          @click=${(e) => e.stopPropagation()}
+          @click=${(t) => t.stopPropagation()}
         >
           <div class="dialog-content">
             <h2 id="create-view-title">Create View</h2>
@@ -997,12 +1044,12 @@ let u = class extends O {
               class="create-view-name"
               label="View name"
               .value=${this._newViewName}
-              @input=${(e) => {
-      this._newViewName = e.target.value;
+              @input=${(t) => {
+      this._newViewName = t.target.value;
     }}
-              @keydown=${(e) => this._handleCreateViewDialogKeydown(e)}
+              @keydown=${(t) => this._handleCreateViewDialogKeydown(t)}
             ></ha-input>
-            ${this._createViewError ? c`<div class="dialog-error">${this._createViewError}</div>` : p}
+            ${this._createViewError ? h`<div class="dialog-error">${this._createViewError}</div>` : p}
             <div class="dialog-actions">
               <ha-button
                 ?disabled=${this._creatingView}
@@ -1012,7 +1059,7 @@ let u = class extends O {
               </ha-button>
               <ha-button
                 raised
-                ?disabled=${!s || this._creatingView}
+                ?disabled=${!e || this._creatingView}
                 @click=${() => this._createView()}
               >
                 ${this._creatingView ? "Creating..." : "Create"}
@@ -1024,10 +1071,10 @@ let u = class extends O {
     `;
   }
   _renderEditor() {
-    var e;
+    var s;
     if (!this._editingView || !this._config) return p;
-    const s = ((e = this._config.layout_types[this._editingView.layout]) == null ? void 0 : e.slots) || 4;
-    return c`
+    const t = this._isCustomLayout() ? Math.max(1, this._editingView.widgets.length + 1) : ((s = this._config.layout_types[this._editingView.layout]) == null ? void 0 : s.slots) || 4;
+    return h`
       <div class="editor-header">
         <ha-icon-button
           .path=${"M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"}
@@ -1035,8 +1082,8 @@ let u = class extends O {
         ></ha-icon-button>
         <ha-input
           .value=${this._editingView.name}
-          @input=${(t) => this._updateEditingView({
-      name: t.target.value
+          @input=${(i) => this._updateEditingView({
+      name: i.target.value
     })}
           placeholder="View name"
         ></ha-input>
@@ -1057,13 +1104,13 @@ let u = class extends O {
               ></ha-icon-button>
             </div>
             <div class="card-content">
-              ${this._previewLoading ? c`<div class="preview-placeholder">
+              ${this._previewLoading ? h`<div class="preview-placeholder">
                     <ha-circular-progress indeterminate></ha-circular-progress>
-                  </div>` : this._previewImage ? c`<img
+                  </div>` : this._previewImage ? h`<img
                       class="preview-image"
                       src="data:image/png;base64,${this._previewImage}"
                       alt="Preview"
-                    />` : c`<div class="preview-placeholder">No preview</div>`}
+                    />` : h`<div class="preview-placeholder">No preview</div>`}
             </div>
           </ha-card>
         </div>
@@ -1073,15 +1120,15 @@ let u = class extends O {
           <span class="layout-section-label">Layout</span>
           <div class="layout-picker">
             ${Object.entries(this._config.layout_types).map(
-      ([t, i]) => {
-        var r;
-        return c`
+      ([i, r]) => {
+        var a;
+        return h`
                 <button
-                  class="layout-option ${((r = this._editingView) == null ? void 0 : r.layout) === t ? "selected" : ""}"
-                  @click=${() => this._updateEditingView({ layout: t })}
-                  title="${i.name} (${i.slots} slots)"
+                  class="layout-option ${((a = this._editingView) == null ? void 0 : a.layout) === i ? "selected" : ""}"
+                  @click=${() => this._updateEditingView({ layout: i })}
+                  title="${r.name} (${r.slots} slots)"
                 >
-                  ${this._renderLayoutIcon(t)}
+                  ${this._renderLayoutIcon(i)}
                 </button>
               `;
       }
@@ -1089,90 +1136,226 @@ let u = class extends O {
           </div>
         </div>
 
+        <!-- Widget slots -->
+        <div class="section-title">Widgets</div>
+        <div class="slots-grid">
+          ${Array.from(
+      { length: t },
+      (i, r) => this._renderSlotEditor(r, t)
+    )}
+        </div>
+
         <!-- Theme selector -->
         <div class="form-row">
           <ha-select
             label="Theme"
             .value=${this._editingView.theme}
-            .options=${ve(this._config.themes)}
-            @selected=${(t) => {
-      const i = q(
-        t.detail,
+            .options=${_e(this._config.themes)}
+            @selected=${(i) => {
+      const r = P(
+        i.detail,
         Object.keys(this._config.themes)
       );
-      i && this._updateEditingView({ theme: i });
+      r && this._updateEditingView({ theme: r });
     }}
-            @closed=${(t) => t.stopPropagation()}
+            @closed=${(i) => i.stopPropagation()}
           >
             ${Object.entries(this._config.themes).map(
-      ([t, i]) => c`
-                <mwc-list-item value=${t}>${i}</mwc-list-item>
+      ([i, r]) => h`
+                <mwc-list-item value=${i}>${r}</mwc-list-item>
               `
     )}
           </ha-select>
         </div>
 
-        <!-- Widget slots -->
-        <div class="section-title">Widgets</div>
-        <div class="slots-grid">
-          ${Array.from(
-      { length: s },
-      (t, i) => this._renderSlotEditor(i, s)
-    )}
+        <!-- Background settings -->
+        <div class="section-title">Background</div>
+        <div class="background-section">
+          <ha-input
+            label="Background image path (optional)"
+            .value=${this._editingView.background_image || ""}
+            @input=${(i) => this._updateEditingView({
+      background_image: i.target.value
+    })}
+            placeholder="/config/www/geekmagic/background.png"
+          ></ha-input>
+          <ha-select
+            label="Background fit"
+            .value=${this._editingView.background_mode || "stretch"}
+            .options=${[
+      { value: "stretch", label: "Stretch" },
+      { value: "contain", label: "Contain" },
+      { value: "cover", label: "Cover" }
+    ]}
+            @selected=${(i) => {
+      const r = P(
+        i.detail,
+        ["stretch", "contain", "cover"]
+      );
+      r && this._updateEditingView({ background_mode: r });
+    }}
+            @closed=${(i) => i.stopPropagation()}
+          >
+            <mwc-list-item value="stretch">Stretch</mwc-list-item>
+            <mwc-list-item value="contain">Contain</mwc-list-item>
+            <mwc-list-item value="cover">Cover</mwc-list-item>
+          </ha-select>
+          <ha-entity-picker
+            label="Background entity (optional)"
+            .hass=${this.hass}
+            .value=${this._editingView.background_entity || ""}
+            allow-custom-entity
+            @value-changed=${(i) => this._updateEditingView({
+      background_entity: i.detail.value
+    })}
+          ></ha-entity-picker>
+          <div class="field-help">
+            Pick a sensor whose state is an image file path. It overrides the
+            static path above when the state is valid.
+          </div>
+        </div>
+
+        <!-- Display options -->
+        <div class="section-title">Display options</div>
+        <div class="display-options-section">
+          <div class="slider-field">
+            <label>Widget contrast: ${Math.round(
+      (this._editingView.widget_contrast ?? 0.5) * 100
+    )}%</label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              .value=${String(this._editingView.widget_contrast ?? 0.5)}
+              @input=${(i) => this._updateEditingView({
+      widget_contrast: parseFloat(
+        i.target.value
+      )
+    })}
+            />
+            <div class="field-help">
+              Darken the area behind each widget to make text readable over
+              busy backgrounds. 0% = fully transparent, 100% = fully opaque.
+            </div>
+          </div>
+          <div class="slider-field">
+            <label>Text opacity: ${Math.round(
+      (this._editingView.text_opacity ?? 1) * 100
+    )}%</label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              .value=${String(this._editingView.text_opacity ?? 1)}
+              @input=${(i) => this._updateEditingView({
+      text_opacity: parseFloat(
+        i.target.value
+      )
+    })}
+            />
+            <div class="field-help">
+              How solid the text and icons appear. Lower values let the
+              background photo shine through the letters. 100% = fully opaque.
+            </div>
+          </div>
         </div>
       </div>
     `;
   }
-  _renderSlotEditor(s, e) {
-    var o;
+  _renderSlotEditor(e, t) {
+    var g;
     if (!this._config || !this._editingView) return p;
-    const t = this._editingView.widgets.find((l) => l.slot === s), i = (t == null ? void 0 : t.type) || "", r = this._config.widget_types[i], a = this._editingView.layout;
-    return c`
+    const s = this._isCustomLayout(), i = this._editingView.widgets, r = s && e === i.length, a = s ? i[e] : this._editingView.widgets.find((c) => c.slot === e), n = (a == null ? void 0 : a.type) || "", l = this._config.widget_types[n], d = this._editingView.layout;
+    return r ? h`
+        <ha-card class="slot-card">
+          <div class="card-content">
+            <div class="slot-header">
+              <span style="flex: 1;">Add Widget</span>
+            </div>
+            <div class="slot-field">
+              <ha-select
+                label="Widget Type"
+                .value=""
+                .options=${de(
+      "-- Empty --",
+      Object.fromEntries(
+        Object.entries(this._config.widget_types).map(
+          ([c, u]) => [c, u.name]
+        )
+      )
+    )}
+                @selected=${(c) => {
+      const u = ["", ...Object.keys(this._config.widget_types)], f = P(c.detail, u) ?? "";
+      f && this._updateWidget(e, { type: f });
+    }}
+                @closed=${(c) => c.stopPropagation()}
+              >
+                <mwc-list-item value="">-- Empty --</mwc-list-item>
+                ${Object.entries(this._config.widget_types).map(
+      ([c, u]) => h`
+                    <mwc-list-item value=${c}>${u.name}</mwc-list-item>
+                  `
+    )}
+              </ha-select>
+            </div>
+          </div>
+        </ha-card>
+      ` : h`
       <ha-card class="slot-card">
         <div class="card-content">
           <div class="slot-header">
-            ${this._renderPositionGrid(s, e, a)}
-            <span style="flex: 1;">Slot ${s + 1}</span>
+            ${s ? p : this._renderPositionGrid(e, t, d)}
+            <span style="flex: 1;">
+              ${s ? `Widget ${e + 1}` : `Slot ${e + 1}`}
+            </span>
+            ${s ? h`
+                  <ha-icon-button
+                    .path=${"M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"}
+                    @click=${() => this._removeCustomWidget(e)}
+                  ></ha-icon-button>
+                ` : p}
           </div>
 
           <div class="slot-field">
             <ha-select
               label="Widget Type"
-              .value=${i}
-              .options=${De(
+              .value=${n}
+              .options=${de(
       "-- Empty --",
       Object.fromEntries(
         Object.entries(this._config.widget_types).map(
-          ([l, n]) => [l, n.name]
+          ([c, u]) => [c, u.name]
         )
       )
     )}
-              @selected=${(l) => {
-      const n = ["", ...Object.keys(this._config.widget_types)], h = q(l.detail, n) ?? "";
-      this._updateWidget(s, { type: h });
+              @selected=${(c) => {
+      const u = ["", ...Object.keys(this._config.widget_types)], f = P(c.detail, u) ?? "";
+      this._updateWidget(e, { type: f });
     }}
-              @closed=${(l) => l.stopPropagation()}
+              @closed=${(c) => c.stopPropagation()}
             >
               <mwc-list-item value="">-- Empty --</mwc-list-item>
               ${Object.entries(this._config.widget_types).map(
-      ([l, n]) => c`
-                  <mwc-list-item value=${l}>${n.name}</mwc-list-item>
+      ([c, u]) => h`
+                  <mwc-list-item value=${c}>${u.name}</mwc-list-item>
                 `
     )}
             </ha-select>
           </div>
 
-          ${r != null && r.needs_entity ? c`
+          ${l != null && l.needs_entity ? h`
                 <div class="slot-field">
                   <ha-selector
                     .hass=${this.hass}
                     .selector=${{
-      entity: r.entity_domains ? { domain: r.entity_domains } : {}
+      entity: l.entity_domains ? { domain: l.entity_domains } : {}
     }}
-                    .value=${(t == null ? void 0 : t.entity_id) || ""}
+                    .value=${(a == null ? void 0 : a.entity_id) || ""}
                     .label=${"Entity"}
-                    @value-changed=${(l) => this._updateWidget(s, {
-      entity_id: l.detail.value
+                    @value-changed=${(c) => this._updateWidget(e, {
+      entity_id: c.detail.value
     })}
                   ></ha-selector>
                 </div>
@@ -1181,17 +1364,70 @@ let u = class extends O {
           <div class="slot-field">
             <ha-input
               label="Label (optional)"
-              .value=${(t == null ? void 0 : t.label) || ""}
-              @input=${(l) => this._updateWidget(s, {
-      label: l.target.value
+              .value=${(a == null ? void 0 : a.label) || ""}
+              @input=${(c) => this._updateWidget(e, {
+      label: c.target.value
     })}
             ></ha-input>
           </div>
 
-          ${(o = r == null ? void 0 : r.options) != null && o.length ? c`
+          <div class="slot-field">
+            <ha-input
+              label="Text scale"
+              type="number"
+              min="0.5"
+              max="3"
+              step="0.1"
+              .value=${String((a == null ? void 0 : a.text_scale) ?? 1)}
+              @input=${(c) => this._updateWidget(e, {
+      text_scale: parseFloat(c.target.value) || 1
+    })}
+            ></ha-input>
+          </div>
+
+          ${s ? h`
+                <div class="slot-field custom-coords-row">
+                  <ha-input
+                    label="X"
+                    type="number"
+                    .value=${String((a == null ? void 0 : a.x) ?? 0)}
+                    @input=${(c) => this._updateWidget(e, {
+      x: parseInt(c.target.value, 10) || 0
+    })}
+                  ></ha-input>
+                  <ha-input
+                    label="Y"
+                    type="number"
+                    .value=${String((a == null ? void 0 : a.y) ?? 0)}
+                    @input=${(c) => this._updateWidget(e, {
+      y: parseInt(c.target.value, 10) || 0
+    })}
+                  ></ha-input>
+                </div>
+                <div class="slot-field custom-coords-row">
+                  <ha-input
+                    label="W"
+                    type="number"
+                    .value=${String((a == null ? void 0 : a.width) ?? 240)}
+                    @input=${(c) => this._updateWidget(e, {
+      width: parseInt(c.target.value, 10) || 240
+    })}
+                  ></ha-input>
+                  <ha-input
+                    label="H"
+                    type="number"
+                    .value=${String((a == null ? void 0 : a.height) ?? 240)}
+                    @input=${(c) => this._updateWidget(e, {
+      height: parseInt(c.target.value, 10) || 240
+    })}
+                  ></ha-input>
+                </div>
+              ` : p}
+
+          ${(g = l == null ? void 0 : l.options) != null && g.length ? h`
                 <div class="widget-options">
-                  ${r.options.map(
-      (l) => this._renderOptionField(s, t, l)
+                  ${l.options.map(
+      (c) => this._renderOptionField(e, a, c)
     )}
                 </div>
               ` : p}
@@ -1199,60 +1435,68 @@ let u = class extends O {
       </ha-card>
     `;
   }
-  _renderOptionField(s, e, t) {
+  _removeCustomWidget(e) {
+    if (!this._editingView) return;
+    const t = [...this._editingView.widgets];
+    t.splice(e, 1), this._editingView = {
+      ...this._editingView,
+      widgets: t.map((s, i) => ({ ...s, slot: i }))
+    }, this.requestUpdate(), this._refreshPreview();
+  }
+  _renderOptionField(e, t, s) {
     var r, a;
-    const i = ((r = e == null ? void 0 : e.options) == null ? void 0 : r[t.key]) ?? t.default;
-    switch (t.type) {
+    const i = ((r = t == null ? void 0 : t.options) == null ? void 0 : r[s.key]) ?? s.default;
+    switch (s.type) {
       case "boolean":
-        return c`
+        return h`
           <div class="option-row">
-            <label>${t.label}</label>
+            <label>${s.label}</label>
             <ha-switch
               .checked=${!!i}
-              @change=${(o) => this._updateWidgetOption(
-          s,
-          t.key,
-          o.target.checked
+              @change=${(n) => this._updateWidgetOption(
+          e,
+          s.key,
+          n.target.checked
         )}
             ></ha-switch>
           </div>
         `;
       case "select":
-        return c`
+        return h`
           <div class="option-field">
             <ha-select
-              .label=${t.label}
-              .value=${i || t.default || ""}
-              .options=${t.options || []}
-              @selected=${(o) => {
-          const l = q(
-            o.detail,
-            t.options || []
+              .label=${s.label}
+              .value=${i || s.default || ""}
+              .options=${s.options || []}
+              @selected=${(n) => {
+          const l = P(
+            n.detail,
+            s.options || []
           );
-          l !== void 0 && this._updateWidgetOption(s, t.key, l);
+          l !== void 0 && this._updateWidgetOption(e, s.key, l);
         }}
-              @closed=${(o) => o.stopPropagation()}
+              @closed=${(n) => n.stopPropagation()}
             >
-              ${(a = t.options) == null ? void 0 : a.map(
-          (o) => c`<mwc-list-item value=${o}>${o}</mwc-list-item>`
+              ${(a = s.options) == null ? void 0 : a.map(
+          (n) => h`<mwc-list-item value=${n}>${n}</mwc-list-item>`
         )}
             </ha-select>
           </div>
         `;
       case "number":
-        return c`
+        return h`
           <div class="option-field">
             <ha-input
               type="number"
-              .label=${t.label}
+              .label=${s.label}
               .value=${i !== void 0 ? String(i) : ""}
-              .min=${t.min !== void 0 ? String(t.min) : ""}
-              .max=${t.max !== void 0 ? String(t.max) : ""}
-              @input=${(o) => {
-          const l = o.target.value;
+              .min=${s.min !== void 0 ? String(s.min) : ""}
+              .max=${s.max !== void 0 ? String(s.max) : ""}
+              @input=${(n) => {
+          const l = n.target.value;
           this._updateWidgetOption(
-            s,
-            t.key,
+            e,
+            s.key,
             l ? parseFloat(l) : void 0
           );
         }}
@@ -1260,40 +1504,40 @@ let u = class extends O {
           </div>
         `;
       case "text":
-        return c`
+        return h`
           <div class="option-field">
             <ha-input
-              .label=${t.label}
+              .label=${s.label}
               .value=${i || ""}
-              .placeholder=${t.placeholder || ""}
-              @input=${(o) => this._updateWidgetOption(
-          s,
-          t.key,
-          o.target.value
+              .placeholder=${s.placeholder || ""}
+              @input=${(n) => this._updateWidgetOption(
+          e,
+          s.key,
+          n.target.value
         )}
             ></ha-input>
           </div>
         `;
       case "icon":
-        return c`
+        return h`
           <div class="option-field">
             <ha-icon-picker
               .hass=${this.hass}
-              .label=${t.label}
+              .label=${s.label}
               .value=${i || ""}
-              @value-changed=${(o) => this._updateWidgetOption(s, t.key, o.detail.value)}
+              @value-changed=${(n) => this._updateWidgetOption(e, s.key, n.detail.value)}
             ></ha-icon-picker>
           </div>
         `;
       case "color":
-        return c`
+        return h`
           <div class="option-field">
             <ha-selector
               .hass=${this.hass}
               .selector=${{ color_rgb: {} }}
               .value=${i}
-              .label=${t.label}
-              @value-changed=${(o) => this._updateWidgetOption(s, t.key, o.detail.value)}
+              .label=${s.label}
+              @value-changed=${(n) => this._updateWidgetOption(e, s.key, n.detail.value)}
             ></ha-selector>
             <div class="color-hex-input">
               <div
@@ -1304,46 +1548,46 @@ let u = class extends O {
                 .value=${N(i)}
                 .label=${"Hex (fallback)"}
                 placeholder="#FF5500 or 255,85,0"
-                @change=${(o) => {
-          const l = le(
-            o.target.value
+                @change=${(n) => {
+          const l = ce(
+            n.target.value
           );
-          l && this._updateWidgetOption(s, t.key, l);
+          l && this._updateWidgetOption(e, s.key, l);
         }}
               ></ha-input>
             </div>
           </div>
         `;
       case "entity":
-        return c`
+        return h`
           <div class="option-field">
             <ha-selector
               .hass=${this.hass}
               .selector=${{ entity: {} }}
               .value=${i || ""}
-              .label=${t.label}
-              @value-changed=${(o) => this._updateWidgetOption(s, t.key, o.detail.value)}
+              .label=${s.label}
+              @value-changed=${(n) => this._updateWidgetOption(e, s.key, n.detail.value)}
             ></ha-selector>
           </div>
         `;
       case "thresholds":
-        return this._renderThresholdsEditor(s, t.key, i);
+        return this._renderThresholdsEditor(e, s.key, i);
       case "progress_items":
-        return this._renderProgressItemsEditor(s, t.key, i);
+        return this._renderProgressItemsEditor(e, s.key, i);
       case "status_entities":
-        return this._renderStatusEntitiesEditor(s, t.key, i);
+        return this._renderStatusEntitiesEditor(e, s.key, i);
       case "timezone":
-        return c`
+        return h`
           <div class="option-field">
             <ha-combo-box
               .hass=${this.hass}
-              .label=${t.label}
+              .label=${s.label}
               .value=${i || ""}
-              .items=${ze.map((o) => ({ value: o, label: o }))}
+              .items=${je.map((n) => ({ value: n, label: n }))}
               item-value-path="value"
               item-label-path="label"
               allow-custom-value
-              @value-changed=${(o) => this._updateWidgetOption(s, t.key, o.detail.value)}
+              @value-changed=${(n) => this._updateWidgetOption(e, s.key, n.detail.value)}
             ></ha-combo-box>
           </div>
         `;
@@ -1351,26 +1595,26 @@ let u = class extends O {
         return p;
     }
   }
-  _updateWidgetOption(s, e, t) {
+  _updateWidgetOption(e, t, s) {
     if (!this._editingView) return;
-    const i = [...this._editingView.widgets], r = i.findIndex((a) => a.slot === s);
+    const i = [...this._editingView.widgets], r = i.findIndex((a) => a.slot === e);
     if (r >= 0) {
       const a = i[r];
       i[r] = {
         ...a,
-        options: { ...a.options || {}, [e]: t }
+        options: { ...a.options || {}, [t]: s }
       };
     } else
       i.push({
-        slot: s,
+        slot: e,
         type: "",
-        options: { [e]: t }
+        options: { [t]: s }
       });
     this._editingView = { ...this._editingView, widgets: [...i] }, this.requestUpdate(), this._refreshPreview();
   }
-  _renderThresholdsEditor(s, e, t) {
-    const i = t || [];
-    return c`
+  _renderThresholdsEditor(e, t, s) {
+    const i = s || [];
+    return h`
       <div class="option-field">
         <div class="array-editor">
           <div class="array-editor-header">
@@ -1378,7 +1622,7 @@ let u = class extends O {
           </div>
           <div class="array-items">
             ${i.map(
-      (r, a) => c`
+      (r, a) => h`
                 <div class="threshold-item-container">
                   <div class="threshold-item">
                     <ha-input
@@ -1386,28 +1630,28 @@ let u = class extends O {
                       type="number"
                       label="Value"
                       .value=${String(r.value)}
-                      @input=${(o) => {
+                      @input=${(n) => {
         const l = [...i];
         l[a] = {
           ...r,
-          value: parseFloat(o.target.value) || 0
-        }, this._updateWidgetOption(s, e, l);
+          value: parseFloat(n.target.value) || 0
+        }, this._updateWidgetOption(e, t, l);
       }}
                     ></ha-input>
                     <ha-selector
                       .hass=${this.hass}
                       .selector=${{ color_rgb: {} }}
                       .value=${r.color}
-                      @value-changed=${(o) => {
+                      @value-changed=${(n) => {
         const l = [...i];
-        l[a] = { ...r, color: o.detail.value }, this._updateWidgetOption(s, e, l);
+        l[a] = { ...r, color: n.detail.value }, this._updateWidgetOption(e, t, l);
       }}
                     ></ha-selector>
                     <ha-icon-button
                       .path=${"M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"}
                       @click=${() => {
-        const o = i.filter((l, n) => n !== a);
-        this._updateWidgetOption(s, e, o);
+        const n = i.filter((l, d) => d !== a);
+        this._updateWidgetOption(e, t, n);
       }}
                     ></ha-icon-button>
                   </div>
@@ -1421,13 +1665,13 @@ let u = class extends O {
                       .value=${N(r.color)}
                       label="Hex (fallback)"
                       placeholder="#FF5500"
-                      @change=${(o) => {
-        const l = le(
-          o.target.value
+                      @change=${(n) => {
+        const l = ce(
+          n.target.value
         );
         if (l) {
-          const n = [...i];
-          n[a] = { ...r, color: l }, this._updateWidgetOption(s, e, n);
+          const d = [...i];
+          d[a] = { ...r, color: l }, this._updateWidgetOption(e, t, d);
         }
       }}
                     ></ha-input>
@@ -1439,7 +1683,7 @@ let u = class extends O {
               class="add-item-button"
               @click=${() => {
       const r = [...i, { value: 0, color: [255, 255, 0] }];
-      this._updateWidgetOption(s, e, r);
+      this._updateWidgetOption(e, t, r);
     }}
             >
               <ha-icon icon="mdi:plus"></ha-icon>
@@ -1450,9 +1694,9 @@ let u = class extends O {
       </div>
     `;
   }
-  _renderProgressItemsEditor(s, e, t) {
-    const i = t || [];
-    return c`
+  _renderProgressItemsEditor(e, t, s) {
+    const i = s || [];
+    return h`
       <div class="option-field">
         <div class="array-editor">
           <div class="array-editor-header">
@@ -1460,12 +1704,12 @@ let u = class extends O {
           </div>
           <div class="array-items">
             ${i.map((r, a) => {
-      const o = `${s}-progress-${a}`, l = this._expandedItems.has(o);
-      return c`
+      const n = `${e}-progress-${a}`, l = this._expandedItems.has(n);
+      return h`
                 <div class="array-item">
                   <div
                     class="array-item-header"
-                    @click=${() => this._toggleItemExpanded(o)}
+                    @click=${() => this._toggleItemExpanded(n)}
                   >
                     <span class="array-item-title">
                       ${r.label || r.entity_id || `Item ${a + 1}`}
@@ -1473,22 +1717,22 @@ let u = class extends O {
                     <div class="array-item-actions">
                       <ha-icon-button
                         .path=${a > 0 ? "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" : ""}
-                        @click=${(n) => {
-        n.stopPropagation(), a > 0 && this._moveArrayItem(s, e, i, a, -1);
+                        @click=${(d) => {
+        d.stopPropagation(), a > 0 && this._moveArrayItem(e, t, i, a, -1);
       }}
                       ></ha-icon-button>
                       <ha-icon-button
                         .path=${a < i.length - 1 ? "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" : ""}
-                        @click=${(n) => {
-        n.stopPropagation(), a < i.length - 1 && this._moveArrayItem(s, e, i, a, 1);
+                        @click=${(d) => {
+        d.stopPropagation(), a < i.length - 1 && this._moveArrayItem(e, t, i, a, 1);
       }}
                       ></ha-icon-button>
                       <ha-icon-button
                         .path=${"M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"}
-                        @click=${(n) => {
-        n.stopPropagation();
-        const h = i.filter((v, d) => d !== a);
-        this._updateWidgetOption(s, e, h);
+                        @click=${(d) => {
+        d.stopPropagation();
+        const g = i.filter((c, u) => u !== a);
+        this._updateWidgetOption(e, t, g);
       }}
                       ></ha-icon-button>
                     </div>
@@ -1499,31 +1743,31 @@ let u = class extends O {
                       .selector=${{ entity: {} }}
                       .value=${r.entity_id || ""}
                       .label=${"Entity"}
-                      @value-changed=${(n) => this._updateArrayItem(s, e, i, a, {
-        entity_id: n.detail.value
+                      @value-changed=${(d) => this._updateArrayItem(e, t, i, a, {
+        entity_id: d.detail.value
       })}
                     ></ha-selector>
                     <ha-input
                       label="Label"
                       .value=${r.label || ""}
-                      @input=${(n) => this._updateArrayItem(s, e, i, a, {
-        label: n.target.value
+                      @input=${(d) => this._updateArrayItem(e, t, i, a, {
+        label: d.target.value
       })}
                     ></ha-input>
                     <ha-input
                       type="number"
                       label="Target"
                       .value=${r.target !== void 0 ? String(r.target) : "100"}
-                      @input=${(n) => this._updateArrayItem(s, e, i, a, {
-        target: parseFloat(n.target.value) || 100
+                      @input=${(d) => this._updateArrayItem(e, t, i, a, {
+        target: parseFloat(d.target.value) || 100
       })}
                     ></ha-input>
                     <ha-icon-picker
                       .hass=${this.hass}
                       label="Icon"
                       .value=${r.icon || ""}
-                      @value-changed=${(n) => this._updateArrayItem(s, e, i, a, {
-        icon: n.detail.value
+                      @value-changed=${(d) => this._updateArrayItem(e, t, i, a, {
+        icon: d.detail.value
       })}
                     ></ha-icon-picker>
                     <ha-selector
@@ -1531,8 +1775,8 @@ let u = class extends O {
                       .selector=${{ color_rgb: {} }}
                       .value=${r.color}
                       .label=${"Color"}
-                      @value-changed=${(n) => this._updateArrayItem(s, e, i, a, {
-        color: n.detail.value
+                      @value-changed=${(d) => this._updateArrayItem(e, t, i, a, {
+        color: d.detail.value
       })}
                     ></ha-selector>
                   </div>
@@ -1543,7 +1787,7 @@ let u = class extends O {
               class="add-item-button"
               @click=${() => {
       const r = [...i, { entity_id: "", target: 100 }];
-      this._updateWidgetOption(s, e, r), this._expandedItems.add(`${s}-progress-${r.length - 1}`), this.requestUpdate();
+      this._updateWidgetOption(e, t, r), this._expandedItems.add(`${e}-progress-${r.length - 1}`), this.requestUpdate();
     }}
             >
               <ha-icon icon="mdi:plus"></ha-icon>
@@ -1554,9 +1798,9 @@ let u = class extends O {
       </div>
     `;
   }
-  _renderStatusEntitiesEditor(s, e, t) {
-    const i = t || [];
-    return c`
+  _renderStatusEntitiesEditor(e, t, s) {
+    const i = s || [];
+    return h`
       <div class="option-field">
         <div class="array-editor">
           <div class="array-editor-header">
@@ -1564,12 +1808,12 @@ let u = class extends O {
           </div>
           <div class="array-items">
             ${i.map((r, a) => {
-      const o = `${s}-status-${a}`, l = this._expandedItems.has(o);
-      return c`
+      const n = `${e}-status-${a}`, l = this._expandedItems.has(n);
+      return h`
                 <div class="array-item">
                   <div
                     class="array-item-header"
-                    @click=${() => this._toggleItemExpanded(o)}
+                    @click=${() => this._toggleItemExpanded(n)}
                   >
                     <span class="array-item-title">
                       ${r.label || r.entity_id || `Entity ${a + 1}`}
@@ -1577,22 +1821,22 @@ let u = class extends O {
                     <div class="array-item-actions">
                       <ha-icon-button
                         .path=${a > 0 ? "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" : ""}
-                        @click=${(n) => {
-        n.stopPropagation(), a > 0 && this._moveArrayItem(s, e, i, a, -1);
+                        @click=${(d) => {
+        d.stopPropagation(), a > 0 && this._moveArrayItem(e, t, i, a, -1);
       }}
                       ></ha-icon-button>
                       <ha-icon-button
                         .path=${a < i.length - 1 ? "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" : ""}
-                        @click=${(n) => {
-        n.stopPropagation(), a < i.length - 1 && this._moveArrayItem(s, e, i, a, 1);
+                        @click=${(d) => {
+        d.stopPropagation(), a < i.length - 1 && this._moveArrayItem(e, t, i, a, 1);
       }}
                       ></ha-icon-button>
                       <ha-icon-button
                         .path=${"M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"}
-                        @click=${(n) => {
-        n.stopPropagation();
-        const h = i.filter((v, d) => d !== a);
-        this._updateWidgetOption(s, e, h);
+                        @click=${(d) => {
+        d.stopPropagation();
+        const g = i.filter((c, u) => u !== a);
+        this._updateWidgetOption(e, t, g);
       }}
                       ></ha-icon-button>
                     </div>
@@ -1603,23 +1847,23 @@ let u = class extends O {
                       .selector=${{ entity: {} }}
                       .value=${r.entity_id || ""}
                       .label=${"Entity"}
-                      @value-changed=${(n) => this._updateArrayItem(s, e, i, a, {
-        entity_id: n.detail.value
+                      @value-changed=${(d) => this._updateArrayItem(e, t, i, a, {
+        entity_id: d.detail.value
       })}
                     ></ha-selector>
                     <ha-input
                       label="Label"
                       .value=${r.label || ""}
-                      @input=${(n) => this._updateArrayItem(s, e, i, a, {
-        label: n.target.value
+                      @input=${(d) => this._updateArrayItem(e, t, i, a, {
+        label: d.target.value
       })}
                     ></ha-input>
                     <ha-icon-picker
                       .hass=${this.hass}
                       label="Icon"
                       .value=${r.icon || ""}
-                      @value-changed=${(n) => this._updateArrayItem(s, e, i, a, {
-        icon: n.detail.value
+                      @value-changed=${(d) => this._updateArrayItem(e, t, i, a, {
+        icon: d.detail.value
       })}
                     ></ha-icon-picker>
                   </div>
@@ -1630,7 +1874,7 @@ let u = class extends O {
               class="add-item-button"
               @click=${() => {
       const r = [...i, { entity_id: "" }];
-      this._updateWidgetOption(s, e, r), this._expandedItems.add(`${s}-status-${r.length - 1}`), this.requestUpdate();
+      this._updateWidgetOption(e, t, r), this._expandedItems.add(`${e}-status-${r.length - 1}`), this.requestUpdate();
     }}
             >
               <ha-icon icon="mdi:plus"></ha-icon>
@@ -1641,22 +1885,22 @@ let u = class extends O {
       </div>
     `;
   }
-  _toggleItemExpanded(s) {
-    this._expandedItems.has(s) ? this._expandedItems.delete(s) : this._expandedItems.add(s), this._expandedItems = new Set(this._expandedItems);
+  _toggleItemExpanded(e) {
+    this._expandedItems.has(e) ? this._expandedItems.delete(e) : this._expandedItems.add(e), this._expandedItems = new Set(this._expandedItems);
   }
-  _updateArrayItem(s, e, t, i, r) {
-    const a = [...t];
-    a[i] = { ...a[i], ...r }, this._updateWidgetOption(s, e, a);
+  _updateArrayItem(e, t, s, i, r) {
+    const a = [...s];
+    a[i] = { ...a[i], ...r }, this._updateWidgetOption(e, t, a);
   }
-  _moveArrayItem(s, e, t, i, r) {
+  _moveArrayItem(e, t, s, i, r) {
     const a = i + r;
-    if (a < 0 || a >= t.length) return;
-    const o = [...t];
-    [o[i], o[a]] = [o[a], o[i]], this._updateWidgetOption(s, e, o);
+    if (a < 0 || a >= s.length) return;
+    const n = [...s];
+    [n[i], n[a]] = [n[a], n[i]], this._updateWidgetOption(e, t, n);
   }
-  _renderPositionGrid(s, e, t) {
+  _renderPositionGrid(e, t, s) {
     let i = 2, r = !1;
-    switch (t) {
+    switch (s) {
       case "fullscreen":
         i = 1;
         break;
@@ -1683,36 +1927,47 @@ let u = class extends O {
     }
     const a = [];
     if (r) {
-      a.push(c`
+      a.push(h`
         <div
-          class="position-cell hero-main ${s === 0 ? "active" : ""}"
-          @click=${() => this._swapSlots(s, 0)}
+          class="position-cell hero-main ${e === 0 ? "active" : ""}"
+          @click=${() => this._swapSlots(e, 0)}
           title="Hero (main)"
         ></div>
       `);
-      for (let o = 1; o <= 3; o++)
-        a.push(c`
+      for (let n = 1; n <= 3; n++)
+        a.push(h`
           <div
-            class="position-cell ${s === o ? "active" : ""}"
-            @click=${() => this._swapSlots(s, o)}
-            title="Footer ${o}"
+            class="position-cell ${e === n ? "active" : ""}"
+            @click=${() => this._swapSlots(e, n)}
+            title="Footer ${n}"
           ></div>
         `);
     } else
-      for (let o = 0; o < e; o++)
-        a.push(c`
+      for (let n = 0; n < t; n++)
+        a.push(h`
           <div
-            class="position-cell ${s === o ? "active" : ""}"
-            @click=${() => this._swapSlots(s, o)}
-            title="Slot ${o + 1}"
+            class="position-cell ${e === n ? "active" : ""}"
+            @click=${() => this._swapSlots(e, n)}
+            title="Slot ${n + 1}"
           ></div>
         `);
-    return c`
+    return h`
       <div class="position-grid cols-${i}">${a}</div>
     `;
   }
-  _renderLayoutIcon(s) {
-    const t = {
+  _renderLayoutIcon(e) {
+    if (e === "custom")
+      return h`
+        <div class="layout-icon custom-layout-icon">
+          <svg viewBox="0 0 24 24" width="24" height="24">
+            <path
+              fill="currentColor"
+              d="M13,17H17V13H19V17H23V19H19V23H17V19H13V17M11,17V19H9V17H11M7,17V19H5V17H7M19,9V11H17V9H19M19,5V7H17V5H19M15,5V7H13V5H15M11,5V7H9V5H11M7,5V7H5V5H7M7,13V15H5V13H7M7,9V11H5V9H7Z"
+            />
+          </svg>
+        </div>
+      `;
+    const s = {
       fullscreen: { cls: "full", cells: 1 },
       grid_2x2: { cls: "g-2x2", cells: 4 },
       grid_2x3: { cls: "g-2x3", cells: 6 },
@@ -1732,16 +1987,16 @@ let u = class extends O {
       hero_corner_tr: { cls: "hc-tr", cells: 6 },
       hero_corner_bl: { cls: "hc-bl", cells: 6 },
       hero_corner_br: { cls: "hc-br", cells: 6 }
-    }[s] || { cls: "", cells: 4 }, i = Array.from({ length: t.cells }, () => c`<div></div>`);
-    return c`<div class="layout-icon ${t.cls}">${i}</div>`;
+    }[e] || { cls: "", cells: 4 }, i = Array.from({ length: s.cells }, () => h`<div></div>`);
+    return h`<div class="layout-icon ${s.cls}">${i}</div>`;
   }
-  _swapSlots(s, e) {
-    if (s === e || !this._editingView) return;
-    const t = [...this._editingView.widgets], i = t.find((a) => a.slot === s), r = t.find((a) => a.slot === e);
-    i && (i.slot = e), r && (r.slot = s), this._editingView = { ...this._editingView, widgets: [...t] }, this.requestUpdate(), this._refreshPreview();
+  _swapSlots(e, t) {
+    if (e === t || !this._editingView) return;
+    const s = [...this._editingView.widgets], i = s.find((a) => a.slot === e), r = s.find((a) => a.slot === t);
+    i && (i.slot = t), r && (r.slot = e), this._editingView = { ...this._editingView, widgets: [...s] }, this.requestUpdate(), this._refreshPreview();
   }
 };
-u.styles = fe`
+X.styles = ye`
     :host {
       display: flex;
       flex-direction: column;
@@ -2036,6 +2291,43 @@ u.styles = fe`
       flex: 1;
     }
 
+    .background-section {
+      display: grid;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+
+    .background-section ha-input,
+    .background-section ha-select {
+      width: 100%;
+    }
+
+    .field-help {
+      font-size: 12px;
+      color: var(--secondary-text-color);
+      line-height: 1.4;
+      margin-top: -8px;
+    }
+
+    .slider-field {
+      margin-bottom: 16px;
+    }
+
+    .slider-field label {
+      display: block;
+      margin-bottom: 8px;
+      color: var(--primary-text-color);
+    }
+
+    .slider-field input[type="range"] {
+      display: block;
+      width: 100%;
+    }
+
+    .slider-field .field-help {
+      margin-top: 8px;
+    }
+
     .section-title {
       font-size: 14px;
       font-weight: 500;
@@ -2055,6 +2347,7 @@ u.styles = fe`
       grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
       gap: 16px;
       width: 100%;
+      margin-bottom: 24px;
     }
 
     /* Single column on mobile */
@@ -2178,6 +2471,18 @@ u.styles = fe`
       opacity: 0.6;
     }
 
+    .custom-layout-icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .custom-layout-icon svg {
+      width: 24px;
+      height: 24px;
+      color: var(--primary-text-color);
+    }
+
     /* Layout icon patterns */
     .layout-icon.full { grid-template: 1fr / 1fr; }
     .layout-icon.g-2x2 { grid-template: 1fr 1fr / 1fr 1fr; }
@@ -2220,6 +2525,16 @@ u.styles = fe`
 
     .slot-field:last-child {
       margin-bottom: 0;
+    }
+
+    .custom-coords-row {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px;
+    }
+
+    .custom-coords-row ha-input {
+      min-width: 0;
     }
 
     ha-select,
@@ -2474,66 +2789,65 @@ u.styles = fe`
       opacity: 0.5;
     }
   `;
-g([
-  T({ attribute: !1 })
-], u.prototype, "hass", 2);
-g([
-  T({ type: Boolean })
-], u.prototype, "narrow", 2);
-g([
-  T({ attribute: !1 })
-], u.prototype, "route", 2);
-g([
-  T({ attribute: !1 })
-], u.prototype, "panel", 2);
-g([
-  m()
-], u.prototype, "_page", 2);
-g([
-  m()
-], u.prototype, "_config", 2);
-g([
-  m()
-], u.prototype, "_views", 2);
-g([
-  m()
-], u.prototype, "_devices", 2);
-g([
-  m()
-], u.prototype, "_editingView", 2);
-g([
-  m()
-], u.prototype, "_previewImage", 2);
-g([
-  m()
-], u.prototype, "_previewLoading", 2);
-g([
-  m()
-], u.prototype, "_loading", 2);
-g([
-  m()
-], u.prototype, "_saving", 2);
-g([
-  m()
-], u.prototype, "_expandedItems", 2);
-g([
-  m()
-], u.prototype, "_viewPreviews", 2);
-g([
-  m()
-], u.prototype, "_createViewDialogOpen", 2);
-g([
-  m()
-], u.prototype, "_newViewName", 2);
-g([
-  m()
-], u.prototype, "_creatingView", 2);
-g([
-  m()
-], u.prototype, "_createViewError", 2);
-u = g([
-  Te("geekmagic-panel")
-], u);
+let v = X;
+m([
+  U({ attribute: !1 })
+], v.prototype, "hass");
+m([
+  U({ type: Boolean })
+], v.prototype, "narrow");
+m([
+  U({ attribute: !1 })
+], v.prototype, "route");
+m([
+  U({ attribute: !1 })
+], v.prototype, "panel");
+m([
+  _()
+], v.prototype, "_page");
+m([
+  _()
+], v.prototype, "_config");
+m([
+  _()
+], v.prototype, "_views");
+m([
+  _()
+], v.prototype, "_devices");
+m([
+  _()
+], v.prototype, "_editingView");
+m([
+  _()
+], v.prototype, "_previewImage");
+m([
+  _()
+], v.prototype, "_previewLoading");
+m([
+  _()
+], v.prototype, "_loading");
+m([
+  _()
+], v.prototype, "_saving");
+m([
+  _()
+], v.prototype, "_expandedItems");
+m([
+  _()
+], v.prototype, "_viewPreviews");
+m([
+  _()
+], v.prototype, "_createViewDialogOpen");
+m([
+  _()
+], v.prototype, "_newViewName");
+m([
+  _()
+], v.prototype, "_creatingView");
+m([
+  _()
+], v.prototype, "_createViewError");
+customElements.get("geekmagic-panel") || customElements.define("geekmagic-panel", v);
 export {
-  u as GeekMagicPanel
+  v as GeekMagicPanel
 };

--- a/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
+++ b/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
@@ -6,7 +6,7 @@
  */
 
 import { LitElement, html, css, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import type {
   HomeAssistant,
   PanelInfo,
@@ -68,7 +68,6 @@ function debounce<T extends (...args: unknown[]) => void>(
   };
 }
 
-@customElement("geekmagic-panel")
 export class GeekMagicPanel extends LitElement {
   // Props passed by Home Assistant
   @property({ attribute: false }) hass!: HomeAssistant;
@@ -388,6 +387,43 @@ export class GeekMagicPanel extends LitElement {
       flex: 1;
     }
 
+    .background-section {
+      display: grid;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+
+    .background-section ha-input,
+    .background-section ha-select {
+      width: 100%;
+    }
+
+    .field-help {
+      font-size: 12px;
+      color: var(--secondary-text-color);
+      line-height: 1.4;
+      margin-top: -8px;
+    }
+
+    .slider-field {
+      margin-bottom: 16px;
+    }
+
+    .slider-field label {
+      display: block;
+      margin-bottom: 8px;
+      color: var(--primary-text-color);
+    }
+
+    .slider-field input[type="range"] {
+      display: block;
+      width: 100%;
+    }
+
+    .slider-field .field-help {
+      margin-top: 8px;
+    }
+
     .section-title {
       font-size: 14px;
       font-weight: 500;
@@ -407,6 +443,7 @@ export class GeekMagicPanel extends LitElement {
       grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
       gap: 16px;
       width: 100%;
+      margin-bottom: 24px;
     }
 
     /* Single column on mobile */
@@ -530,6 +567,18 @@ export class GeekMagicPanel extends LitElement {
       opacity: 0.6;
     }
 
+    .custom-layout-icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .custom-layout-icon svg {
+      width: 24px;
+      height: 24px;
+      color: var(--primary-text-color);
+    }
+
     /* Layout icon patterns */
     .layout-icon.full { grid-template: 1fr / 1fr; }
     .layout-icon.g-2x2 { grid-template: 1fr 1fr / 1fr 1fr; }
@@ -572,6 +621,16 @@ export class GeekMagicPanel extends LitElement {
 
     .slot-field:last-child {
       margin-bottom: 0;
+    }
+
+    .custom-coords-row {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px;
+    }
+
+    .custom-coords-row ha-input {
+      min-width: 0;
     }
 
     ha-select,
@@ -870,6 +929,11 @@ export class GeekMagicPanel extends LitElement {
             layout: view.layout,
             theme: view.theme,
             widgets: view.widgets,
+            background_image: view.background_image || "",
+            background_mode: view.background_mode || "stretch",
+            background_entity: view.background_entity || "",
+            widget_contrast: view.widget_contrast ?? 0,
+            text_opacity: view.text_opacity ?? 1,
           },
         });
         return { id: view.id, image: result.image };
@@ -945,6 +1009,11 @@ export class GeekMagicPanel extends LitElement {
         layout: "grid_2x2",
         theme: "watchos",
         widgets: [],
+        background_image: "",
+        background_mode: "stretch",
+        background_entity: "",
+        widget_contrast: 0.5,
+        text_opacity: 1,
       });
       this._views = [...this._views, result.view];
       this._createViewDialogOpen = false;
@@ -976,6 +1045,11 @@ export class GeekMagicPanel extends LitElement {
         layout: this._editingView.layout,
         theme: this._editingView.theme,
         widgets: this._editingView.widgets,
+        background_image: this._editingView.background_image || "",
+        background_mode: this._editingView.background_mode || "stretch",
+        background_entity: this._editingView.background_entity || "",
+        widget_contrast: this._editingView.widget_contrast ?? 0,
+        text_opacity: this._editingView.text_opacity ?? 1,
       });
       this._views = this._views.map((v) =>
         v.id === this._editingView!.id ? this._editingView! : v
@@ -1018,6 +1092,11 @@ export class GeekMagicPanel extends LitElement {
           layout: this._editingView.layout,
           theme: this._editingView.theme,
           widgets: this._editingView.widgets,
+          background_image: this._editingView.background_image || "",
+          background_mode: this._editingView.background_mode || "stretch",
+          background_entity: this._editingView.background_entity || "",
+          widget_contrast: this._editingView.widget_contrast ?? 0,
+          text_opacity: this._editingView.text_opacity ?? 1,
         },
       });
       this._previewImage = result.image;
@@ -1030,8 +1109,30 @@ export class GeekMagicPanel extends LitElement {
 
   private _updateEditingView(updates: Partial<ViewConfig>): void {
     if (!this._editingView) return;
+
+    // When switching to/from custom layout, normalize widget indices and
+    // ensure custom widgets have default coordinates.
+    if (updates.layout !== undefined && updates.layout !== this._editingView.layout) {
+      const isCustom = updates.layout === "custom";
+      const widgets = this._editingView.widgets.map((w, i) => ({
+        ...w,
+        slot: isCustom ? i : w.slot ?? i,
+        x: w.x ?? 0,
+        y: w.y ?? 0,
+        width: w.width ?? 240,
+        height: w.height ?? 240,
+      }));
+      this._editingView = { ...this._editingView, ...updates, widgets };
+      this._refreshPreview();
+      return;
+    }
+
     this._editingView = { ...this._editingView, ...updates };
     this._refreshPreview();
+  }
+
+  private _isCustomLayout(): boolean {
+    return this._editingView?.layout === "custom";
   }
 
   private _updateWidget(slot: number, updates: Partial<WidgetConfig>): void {
@@ -1047,12 +1148,33 @@ export class GeekMagicPanel extends LitElement {
     }
 
     const widgets = [...this._editingView.widgets];
-    const existingIndex = widgets.findIndex((w) => w.slot === slot);
+    const isCustom = this._isCustomLayout();
 
-    if (existingIndex >= 0) {
-      widgets[existingIndex] = { ...widgets[existingIndex], ...updates };
+    if (isCustom) {
+      // For custom layouts, slot is the list index.
+      if (slot >= 0 && slot < widgets.length) {
+        widgets[slot] = { ...widgets[slot], ...updates };
+      } else {
+        const newIndex = widgets.length;
+        const col = newIndex % 4;
+        const row = Math.floor(newIndex / 4);
+        widgets.push({
+          x: 10 + col * 60,
+          y: 10 + row * 60,
+          width: 50,
+          height: 50,
+          slot: newIndex,
+          type: "",
+          ...updates,
+        });
+      }
     } else {
-      widgets.push({ slot, type: "", ...updates });
+      const existingIndex = widgets.findIndex((w) => w.slot === slot);
+      if (existingIndex >= 0) {
+        widgets[existingIndex] = { ...widgets[existingIndex], ...updates };
+      } else {
+        widgets.push({ slot, type: "", ...updates });
+      }
     }
 
     // Create new object to ensure Lit detects the change
@@ -1282,8 +1404,10 @@ export class GeekMagicPanel extends LitElement {
   private _renderEditor() {
     if (!this._editingView || !this._config) return nothing;
 
-    const slotCount =
-      this._config.layout_types[this._editingView.layout]?.slots || 4;
+    const isCustom = this._isCustomLayout();
+    const slotCount = isCustom
+      ? Math.max(1, this._editingView.widgets.length + 1)
+      : this._config.layout_types[this._editingView.layout]?.slots || 4;
 
     return html`
       <div class="editor-header">
@@ -1351,6 +1475,14 @@ export class GeekMagicPanel extends LitElement {
           </div>
         </div>
 
+        <!-- Widget slots -->
+        <div class="section-title">Widgets</div>
+        <div class="slots-grid">
+          ${Array.from({ length: slotCount }, (_, i) =>
+            this._renderSlotEditor(i, slotCount)
+          )}
+        </div>
+
         <!-- Theme selector -->
         <div class="form-row">
           <ha-select
@@ -1374,12 +1506,103 @@ export class GeekMagicPanel extends LitElement {
           </ha-select>
         </div>
 
-        <!-- Widget slots -->
-        <div class="section-title">Widgets</div>
-        <div class="slots-grid">
-          ${Array.from({ length: slotCount }, (_, i) =>
-            this._renderSlotEditor(i, slotCount)
-          )}
+        <!-- Background settings -->
+        <div class="section-title">Background</div>
+        <div class="background-section">
+          <ha-input
+            label="Background image path (optional)"
+            .value=${this._editingView.background_image || ""}
+            @input=${(e: Event) =>
+              this._updateEditingView({
+                background_image: (e.target as HTMLInputElement).value,
+              })}
+            placeholder="/config/www/geekmagic/background.png"
+          ></ha-input>
+          <ha-select
+            label="Background fit"
+            .value=${this._editingView.background_mode || "stretch"}
+            .options=${[
+              { value: "stretch", label: "Stretch" },
+              { value: "contain", label: "Contain" },
+              { value: "cover", label: "Cover" },
+            ]}
+            @selected=${(e: CustomEvent) => {
+              const value = resolveSelectedValue(
+                e.detail,
+                ["stretch", "contain", "cover"]
+              );
+              if (value)
+                this._updateEditingView({ background_mode: value });
+            }}
+            @closed=${(e: Event) => e.stopPropagation()}
+          >
+            <mwc-list-item value="stretch">Stretch</mwc-list-item>
+            <mwc-list-item value="contain">Contain</mwc-list-item>
+            <mwc-list-item value="cover">Cover</mwc-list-item>
+          </ha-select>
+          <ha-entity-picker
+            label="Background entity (optional)"
+            .hass=${this.hass}
+            .value=${this._editingView.background_entity || ""}
+            allow-custom-entity
+            @value-changed=${(e: CustomEvent) =>
+              this._updateEditingView({
+                background_entity: e.detail.value,
+              })}
+          ></ha-entity-picker>
+          <div class="field-help">
+            Pick a sensor whose state is an image file path. It overrides the
+            static path above when the state is valid.
+          </div>
+        </div>
+
+        <!-- Display options -->
+        <div class="section-title">Display options</div>
+        <div class="display-options-section">
+          <div class="slider-field">
+            <label>Widget contrast: ${Math.round(
+              (this._editingView.widget_contrast ?? 0.5) * 100
+            )}%</label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              .value=${String(this._editingView.widget_contrast ?? 0.5)}
+              @input=${(e: Event) =>
+                this._updateEditingView({
+                  widget_contrast: parseFloat(
+                    (e.target as HTMLInputElement).value
+                  ),
+                })}
+            />
+            <div class="field-help">
+              Darken the area behind each widget to make text readable over
+              busy backgrounds. 0% = fully transparent, 100% = fully opaque.
+            </div>
+          </div>
+          <div class="slider-field">
+            <label>Text opacity: ${Math.round(
+              (this._editingView.text_opacity ?? 1) * 100
+            )}%</label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              .value=${String(this._editingView.text_opacity ?? 1)}
+              @input=${(e: Event) =>
+                this._updateEditingView({
+                  text_opacity: parseFloat(
+                    (e.target as HTMLInputElement).value
+                  ),
+                })}
+            />
+            <div class="field-help">
+              How solid the text and icons appear. Lower values let the
+              background photo shine through the letters. 100% = fully opaque.
+            </div>
+          </div>
         </div>
       </div>
     `;
@@ -1388,17 +1611,75 @@ export class GeekMagicPanel extends LitElement {
   private _renderSlotEditor(slot: number, slotCount: number) {
     if (!this._config || !this._editingView) return nothing;
 
-    const widget = this._editingView.widgets.find((w) => w.slot === slot);
+    const isCustom = this._isCustomLayout();
+    const widgets = this._editingView.widgets;
+    const isAddSlot = isCustom && slot === widgets.length;
+
+    const widget = isCustom
+      ? widgets[slot]
+      : this._editingView.widgets.find((w) => w.slot === slot);
     const widgetType = widget?.type || "";
     const schema = this._config.widget_types[widgetType];
     const layout = this._editingView.layout;
+
+    if (isAddSlot) {
+      return html`
+        <ha-card class="slot-card">
+          <div class="card-content">
+            <div class="slot-header">
+              <span style="flex: 1;">Add Widget</span>
+            </div>
+            <div class="slot-field">
+              <ha-select
+                label="Widget Type"
+                .value=""
+                .options=${buildSelectOptionsWithEmpty(
+                  "-- Empty --",
+                  Object.fromEntries(
+                    Object.entries(this._config!.widget_types).map(
+                      ([key, info]) => [key, info.name]
+                    )
+                  )
+                )}
+                @selected=${(e: CustomEvent) => {
+                  const keys = ["", ...Object.keys(this._config!.widget_types)];
+                  const value = resolveSelectedValue(e.detail, keys) ?? "";
+                  if (!value) return;
+                  this._updateWidget(slot, { type: value });
+                }}
+                @closed=${(e: Event) => e.stopPropagation()}
+              >
+                <mwc-list-item value="">-- Empty --</mwc-list-item>
+                ${Object.entries(this._config.widget_types).map(
+                  ([key, info]) => html`
+                    <mwc-list-item value=${key}>${info.name}</mwc-list-item>
+                  `
+                )}
+              </ha-select>
+            </div>
+          </div>
+        </ha-card>
+      `;
+    }
 
     return html`
       <ha-card class="slot-card">
         <div class="card-content">
           <div class="slot-header">
-            ${this._renderPositionGrid(slot, slotCount, layout)}
-            <span style="flex: 1;">Slot ${slot + 1}</span>
+            ${isCustom
+              ? nothing
+              : this._renderPositionGrid(slot, slotCount, layout)}
+            <span style="flex: 1;">
+              ${isCustom ? `Widget ${slot + 1}` : `Slot ${slot + 1}`}
+            </span>
+            ${isCustom
+              ? html`
+                  <ha-icon-button
+                    .path=${"M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"}
+                    @click=${() => this._removeCustomWidget(slot)}
+                  ></ha-icon-button>
+                `
+              : nothing}
           </div>
 
           <div class="slot-field">
@@ -1461,6 +1742,69 @@ export class GeekMagicPanel extends LitElement {
             ></ha-input>
           </div>
 
+          <div class="slot-field">
+            <ha-input
+              label="Text scale"
+              type="number"
+              min="0.5"
+              max="3"
+              step="0.1"
+              .value=${String(widget?.text_scale ?? 1)}
+              @input=${(e: Event) =>
+                this._updateWidget(slot, {
+                  text_scale:
+                    parseFloat((e.target as HTMLInputElement).value) || 1,
+                })}
+            ></ha-input>
+          </div>
+
+          ${isCustom
+            ? html`
+                <div class="slot-field custom-coords-row">
+                  <ha-input
+                    label="X"
+                    type="number"
+                    .value=${String(widget?.x ?? 0)}
+                    @input=${(e: Event) =>
+                      this._updateWidget(slot, {
+                        x: parseInt((e.target as HTMLInputElement).value, 10) || 0,
+                      })}
+                  ></ha-input>
+                  <ha-input
+                    label="Y"
+                    type="number"
+                    .value=${String(widget?.y ?? 0)}
+                    @input=${(e: Event) =>
+                      this._updateWidget(slot, {
+                        y: parseInt((e.target as HTMLInputElement).value, 10) || 0,
+                      })}
+                  ></ha-input>
+                </div>
+                <div class="slot-field custom-coords-row">
+                  <ha-input
+                    label="W"
+                    type="number"
+                    .value=${String(widget?.width ?? 240)}
+                    @input=${(e: Event) =>
+                      this._updateWidget(slot, {
+                        width:
+                          parseInt((e.target as HTMLInputElement).value, 10) || 240,
+                      })}
+                  ></ha-input>
+                  <ha-input
+                    label="H"
+                    type="number"
+                    .value=${String(widget?.height ?? 240)}
+                    @input=${(e: Event) =>
+                      this._updateWidget(slot, {
+                        height:
+                          parseInt((e.target as HTMLInputElement).value, 10) || 240,
+                      })}
+                  ></ha-input>
+                </div>
+              `
+            : nothing}
+
           ${schema?.options?.length
             ? html`
                 <div class="widget-options">
@@ -1473,6 +1817,19 @@ export class GeekMagicPanel extends LitElement {
         </div>
       </ha-card>
     `;
+  }
+
+  private _removeCustomWidget(index: number): void {
+    if (!this._editingView) return;
+    const widgets = [...this._editingView.widgets];
+    widgets.splice(index, 1);
+    // Re-number slot indices so the UI stays consistent.
+    this._editingView = {
+      ...this._editingView,
+      widgets: widgets.map((w, i) => ({ ...w, slot: i })),
+    };
+    this.requestUpdate();
+    this._refreshPreview();
   }
 
   private _renderOptionField(
@@ -2125,6 +2482,20 @@ export class GeekMagicPanel extends LitElement {
   }
 
   private _renderLayoutIcon(key: string) {
+    // Custom layout gets a distinctive move/resize arrows icon.
+    if (key === "custom") {
+      return html`
+        <div class="layout-icon custom-layout-icon">
+          <svg viewBox="0 0 24 24" width="24" height="24">
+            <path
+              fill="currentColor"
+              d="M13,17H17V13H19V17H23V19H19V23H17V19H13V17M11,17V19H9V17H11M7,17V19H5V17H7M19,9V11H17V9H19M19,5V7H17V5H19M15,5V7H13V5H15M11,5V7H9V5H11M7,5V7H5V5H7M7,13V15H5V13H7M7,9V11H5V9H7Z"
+            />
+          </svg>
+        </div>
+      `;
+    }
+
     // Map layout key to CSS class and cell count
     const layoutConfig: Record<string, { cls: string; cells: number }> = {
       fullscreen: { cls: "full", cells: 1 },
@@ -2169,6 +2540,12 @@ export class GeekMagicPanel extends LitElement {
     this.requestUpdate();
     this._refreshPreview();
   }
+}
+
+// Define the custom element only once to avoid errors when the panel is
+// reloaded (e.g. after a cache hit or a repeated navigation).
+if (!customElements.get("geekmagic-panel")) {
+  customElements.define("geekmagic-panel", GeekMagicPanel);
 }
 
 declare global {

--- a/custom_components/geekmagic/frontend/src/types.ts
+++ b/custom_components/geekmagic/frontend/src/types.ts
@@ -60,6 +60,11 @@ export interface ViewConfig {
   layout: string;
   theme: string;
   widgets: WidgetConfig[];
+  background_image?: string;
+  background_mode?: string;
+  background_entity?: string;
+  widget_contrast?: number;
+  text_opacity?: number;
   created_at?: string;
   updated_at?: string;
 }
@@ -70,7 +75,12 @@ export interface WidgetConfig {
   entity_id?: string;
   label?: string;
   color?: [number, number, number];
+  text_scale?: number;
   options?: Record<string, unknown>;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
 }
 
 export interface DeviceConfig {

--- a/custom_components/geekmagic/layouts/base.py
+++ b/custom_components/geekmagic/layouts/base.py
@@ -27,14 +27,23 @@ class Slot:
     """Represents a widget slot in a layout."""
 
     index: int
-    rect: tuple[int, int, int, int]  # x1, y1, x2, y2
+    rect: tuple[int, int, int]  # x1, y1, x2, y2
     widget: Widget | None = None
 
 
 class Layout(ABC):
     """Base class for display layouts."""
 
-    def __init__(self, padding: int | None = None, gap: int | None = None) -> None:
+    def __init__(
+        self,
+        padding: int | None = None,
+        gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
+    ) -> None:
         """Initialize the layout.
 
         Args:
@@ -44,9 +53,21 @@ class Layout(ABC):
                 via ``layout.theme = ...`` automatically updates spacing.
                 Passing an explicit value pins it and ignores the theme.
             gap: Gap between widgets. Same semantics as ``padding``.
+            background_image: Optional path to a local background image.
+            background_mode: How to fit the image: "stretch", "contain", "cover".
+            widget_contrast: Opacity of a dark contrast panel behind each widget
+                (0.0 = transparent, 1.0 = solid). Improves readability on
+                busy background images.
+            text_scale: Extra scaling factor for text and icons.
+            text_opacity: Opacity multiplier for text/icon colors (0..1).
         """
         self._padding_override = padding
         self._gap_override = gap
+        self.background_image = background_image
+        self.background_mode = background_mode
+        self.widget_contrast = widget_contrast
+        self.text_scale = text_scale
+        self.text_opacity = text_opacity
         self._theme: Theme = DEFAULT_THEME
         self.width = DISPLAY_WIDTH
         self.height = DISPLAY_HEIGHT
@@ -151,6 +172,57 @@ class Layout(ABC):
         if 0 <= index < len(self.slots):
             self.slots[index].widget = widget
 
+    def _render_background_image(
+        self,
+        canvas_size: tuple[int, int],
+    ) -> Image.Image | None:
+        """Load and fit the configured background image into an RGBA canvas.
+
+        Returns None when no image is configured or loading fails.
+        """
+        if not self.background_image:
+            return None
+        try:
+            bg = Image.open(self.background_image).convert("RGBA")
+            canvas_width, canvas_height = canvas_size
+            src_ratio = bg.width / bg.height
+            dest_ratio = canvas_width / canvas_height
+
+            if self.background_mode == "contain":
+                if src_ratio > dest_ratio:
+                    new_width = canvas_width
+                    new_height = int(canvas_width / src_ratio)
+                else:
+                    new_height = canvas_height
+                    new_width = int(canvas_height * src_ratio)
+                bg = bg.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                paste_x = (canvas_width - new_width) // 2
+                paste_y = (canvas_height - new_height) // 2
+                target = Image.new("RGBA", (canvas_width, canvas_height), (0, 0, 0, 255))
+                target.paste(bg, (paste_x, paste_y), bg)
+                return target
+
+            if self.background_mode == "cover":
+                if src_ratio > dest_ratio:
+                    new_height = canvas_height
+                    new_width = int(canvas_height * src_ratio)
+                else:
+                    new_width = canvas_width
+                    new_height = int(canvas_width * src_ratio)
+                bg = bg.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                left = (new_width - canvas_width) // 2
+                top = (new_height - canvas_height) // 2
+                cropped = bg.crop((left, top, left + canvas_width, top + canvas_height))
+                target = Image.new("RGBA", (canvas_width, canvas_height), (0, 0, 0, 255))
+                target.paste(cropped, (0, 0), cropped)
+                return target
+
+            # stretch (default)
+            bg = bg.resize((canvas_width, canvas_height), Image.Resampling.LANCZOS)
+            return bg
+        except Exception:
+            return None
+
     def render(
         self,
         renderer: Renderer,
@@ -172,61 +244,114 @@ class Layout(ABC):
         canvas = draw._image  # noqa: SLF001
         scale = renderer.scale
 
-        # Paint the canvas with the theme background so widgets gaps and
-        # uncovered areas use the correct color (not black-by-default).
-        draw.rectangle((0, 0, canvas.width, canvas.height), fill=self.theme.background)
+        # Prepare the background. When a background image is configured and
+        # loads successfully, widgets will be composited transparently on top.
+        rgba_canvas = self._render_background_image(canvas.size)
+        use_background_image = rgba_canvas is not None
+
+        if not use_background_image:
+            draw.rectangle((0, 0, canvas.width, canvas.height), fill=self.theme.background)
 
         # Default empty states dict
         if widget_states is None:
             widget_states = {}
 
-        for slot in self.slots:
-            widget = slot.widget
-            if widget is None:
-                continue
+        if use_background_image:
+            # Use an internal transparent composition canvas. The widgets are
+            # rendered here with alpha and then flattened onto the caller's RGB
+            # canvas, so the caller still sees a normal RGB image.
+            for slot in self.slots:
+                widget = slot.widget
+                if widget is None:
+                    continue
 
-            # Calculate slot dimensions in scaled coordinates
-            x1, y1, x2, y2 = slot.rect
-            slot_width = (x2 - x1) * scale
-            slot_height = (y2 - y1) * scale
+                x1, y1, x2, y2 = slot.rect
+                slot_width = (x2 - x1) * scale
+                slot_height = (y2 - y1) * scale
 
-            # When the theme uses surface chrome, paint the slot with a
-            # rounded card on top of the canvas background. Otherwise the
-            # slot background matches the canvas — widgets float on the
-            # background (watchOS deference principle).
-            temp_img = Image.new("RGB", (slot_width, slot_height), self.theme.background)
-            temp_draw = PILImageDraw.Draw(temp_img)
-            if self.theme.surface_chrome:
-                # Draw the rounded card chrome first; widgets render on top.
-                radius = max(0, self.theme.corner_radius * scale)
-                outline = self.theme.border if self.theme.border_width > 0 else None
-                temp_draw.rounded_rectangle(
-                    (0, 0, slot_width - 1, slot_height - 1),
-                    radius=radius,
-                    fill=self.theme.surface,
-                    outline=outline,
-                    width=max(1, self.theme.border_width * scale) if outline else 1,
+                temp_img = Image.new("RGBA", (slot_width, slot_height), (0, 0, 0, 0))
+                temp_draw = PILImageDraw.Draw(temp_img)
+
+                paste_x = x1 * scale
+                paste_y = y1 * scale
+
+                # Optionally draw a semi-transparent contrast backdrop behind
+                # the widget content to keep text readable on busy photos.
+                contrast = max(0.0, min(1.0, self.widget_contrast))
+                if contrast > 0:
+                    bg_color = self.theme.background
+                    overlay = Image.new(
+                        "RGBA",
+                        (slot_width, slot_height),
+                        (bg_color[0], bg_color[1], bg_color[2], int(255 * contrast)),
+                    )
+                    temp_img = Image.alpha_composite(temp_img, overlay)
+                    temp_draw = PILImageDraw.Draw(temp_img)
+
+                local_rect = (0, 0, x2 - x1, y2 - y1)
+                widget_text_scale = getattr(slot.widget.config, "text_scale", 1.0) or 1.0
+                ctx = RenderContext(
+                    temp_draw,
+                    local_rect,
+                    renderer,
+                    theme=self.theme,
+                    transparent_background=True,
+                    text_scale=self.text_scale * widget_text_scale,
+                    text_opacity=self.text_opacity,
                 )
 
-            # Create render context with local coordinates (0, 0 to width, height)
-            # The rect is relative to the temp image, not the main canvas
-            local_rect = (0, 0, x2 - x1, y2 - y1)
-            ctx = RenderContext(temp_draw, local_rect, renderer, theme=self.theme)
+                state = widget_states.get(slot.index, WidgetState())
+                result = widget.render(ctx, state)
+                if isinstance(result, Component):
+                    result.render(ctx, 0, 0, x2 - x1, y2 - y1)
 
-            # Get widget state for this slot
-            state = widget_states.get(slot.index, WidgetState())
+                rgba_canvas.paste(temp_img, (paste_x, paste_y), temp_img)
 
-            # Call widget render - returns Component tree
-            result = widget.render(ctx, state)
+            # Flatten the composited RGBA result back onto the original RGB canvas.
+            canvas.paste(rgba_canvas.convert("RGB"), (0, 0))
+        else:
+            for slot in self.slots:
+                widget = slot.widget
+                if widget is None:
+                    continue
 
-            # Render the Component tree
-            if isinstance(result, Component):
-                result.render(ctx, 0, 0, x2 - x1, y2 - y1)
+                x1, y1, x2, y2 = slot.rect
+                slot_width = (x2 - x1) * scale
+                slot_height = (y2 - y1) * scale
 
-            # Paste the widget image onto the main canvas at the slot position
-            paste_x = x1 * scale
-            paste_y = y1 * scale
-            canvas.paste(temp_img, (paste_x, paste_y))
+                temp_img = Image.new("RGB", (slot_width, slot_height), self.theme.background)
+                temp_draw = PILImageDraw.Draw(temp_img)
+                if self.theme.surface_chrome:
+                    radius = max(0, self.theme.corner_radius * scale)
+                    outline = self.theme.border if self.theme.border_width > 0 else None
+                    temp_draw.rounded_rectangle(
+                        (0, 0, slot_width - 1, slot_height - 1),
+                        radius=radius,
+                        fill=self.theme.surface,
+                        outline=outline,
+                        width=max(1, self.theme.border_width * scale) if outline else 1,
+                    )
+
+                local_rect = (0, 0, x2 - x1, y2 - y1)
+                widget_text_scale = getattr(slot.widget.config, "text_scale", 1.0) or 1.0
+                ctx = RenderContext(
+                    temp_draw,
+                    local_rect,
+                    renderer,
+                    theme=self.theme,
+                    transparent_background=False,
+                    text_scale=self.text_scale * widget_text_scale,
+                    text_opacity=self.text_opacity,
+                )
+
+                state = widget_states.get(slot.index, WidgetState())
+                result = widget.render(ctx, state)
+                if isinstance(result, Component):
+                    result.render(ctx, 0, 0, x2 - x1, y2 - y1)
+
+                paste_x = x1 * scale
+                paste_y = y1 * scale
+                canvas.paste(temp_img, (paste_x, paste_y))
 
         # Apply theme visual effects after all widgets are rendered
         self._apply_theme_effects(canvas, scale)

--- a/custom_components/geekmagic/layouts/custom.py
+++ b/custom_components/geekmagic/layouts/custom.py
@@ -1,0 +1,78 @@
+"""Custom free-form layout for GeekMagic displays."""
+
+from __future__ import annotations
+
+from .base import Layout, Slot
+
+
+def _int_or(value: object, default: int) -> int:
+    """Coerce ``value`` to an int, returning ``default`` on failure."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+class CustomLayout(Layout):
+    """Free-form layout where each widget defines its own position and size.
+
+    Widgets are placed using absolute coordinates on the 240x240 display.
+    This allows arbitrary overlapping or non-grid layouts while keeping the
+    same rendering pipeline as the fixed slot layouts.
+    """
+
+    def __init__(
+        self,
+        widgets: list[dict] | None = None,
+        padding: int | None = None,
+        gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
+    ) -> None:
+        """Initialize the custom layout.
+
+        Args:
+            widgets: List of widget configuration dicts. Each dict should
+                contain ``x``, ``y``, ``width``, ``height`` plus the usual
+                widget config keys. Coordinates are clamped to the display.
+            padding: Ignored for custom layouts (outer padding is controlled
+                by widget coordinates), kept for API compatibility.
+            gap: Ignored for custom layouts.
+            background_image: Optional path to a local background image.
+            background_mode: How to fit the image: stretch, contain, cover.
+            widget_contrast: Opacity of dark contrast panel behind widgets.
+            text_scale: Extra scaling factor for text and icons.
+            text_opacity: Opacity multiplier for text/icon colors.
+        """
+        self._widgets_config = widgets or []
+        # padding/gap are intentionally not used for slot calculation, but we
+        # still pass them through so the base Layout constructor is happy.
+        super().__init__(
+            padding=0,
+            gap=0,
+            background_image=background_image,
+            background_mode=background_mode,
+            widget_contrast=widget_contrast,
+            text_scale=text_scale,
+            text_opacity=text_opacity,
+        )
+
+    def _calculate_slots(self) -> None:
+        """Build slots from the supplied widget coordinates."""
+        self.slots = []
+        for index, widget_config in enumerate(self._widgets_config):
+            x = _int_or(widget_config.get("x", 0), 0)
+            y = _int_or(widget_config.get("y", 0), 0)
+            width = _int_or(widget_config.get("width", self.width), self.width)
+            height = _int_or(widget_config.get("height", self.height), self.height)
+
+            # Clamp to display bounds so widgets cannot render outside the canvas.
+            x1 = max(0, min(x, self.width))
+            y1 = max(0, min(y, self.height))
+            x2 = max(x1, min(x + width, self.width))
+            y2 = max(y1, min(y + height, self.height))
+
+            self.slots.append(Slot(index=index, rect=(x1, y1, x2, y2)))

--- a/custom_components/geekmagic/layouts/fullscreen.py
+++ b/custom_components/geekmagic/layouts/fullscreen.py
@@ -18,15 +18,20 @@ class FullscreenLayout(Layout):
     +---------------------+
     """
 
-    def __init__(self, padding: int = 0, gap: int = 0) -> None:
+    def __init__(self, padding: int = 0, gap: int = 0, background_image: str | None = None, background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0) -> None:
         """Initialize fullscreen layout.
 
         Args:
             padding: Ignored, always 0 for edge-to-edge display
             gap: Ignored, only one slot
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
         """
         # Force 0 padding for true edge-to-edge display
-        super().__init__(padding=0, gap=0)
+        super().__init__(padding=0, gap=0, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
     def _calculate_slots(self) -> None:
         """Calculate single fullscreen slot."""

--- a/custom_components/geekmagic/layouts/grid.py
+++ b/custom_components/geekmagic/layouts/grid.py
@@ -14,6 +14,11 @@ class GridLayout(Layout):
         cols: int = 2,
         padding: int | None = None,
         gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
         """Initialize the grid layout.
 
@@ -22,10 +27,12 @@ class GridLayout(Layout):
             cols: Number of columns
             padding: Padding around edges
             gap: Gap between cells
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
         """
         self.rows = rows
         self.cols = cols
-        super().__init__(padding=padding, gap=gap)
+        super().__init__(padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
     def _calculate_slots(self) -> None:
         """Calculate grid cell rectangles."""
@@ -54,26 +61,38 @@ class GridLayout(Layout):
 class Grid2x2(GridLayout):
     """2x2 grid layout (4 slots)."""
 
-    def __init__(self, padding: int | None = None, gap: int | None = None) -> None:
-        super().__init__(rows=2, cols=2, padding=padding, gap=gap)
+    def __init__(self, padding: int | None = None, gap: int | None = None, background_image: str | None = None, background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0) -> None:
+        super().__init__(rows=2, cols=2, padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
 
 class Grid2x3(GridLayout):
     """2x3 grid layout (6 slots) - 2 rows, 3 columns."""
 
-    def __init__(self, padding: int | None = None, gap: int | None = None) -> None:
-        super().__init__(rows=2, cols=3, padding=padding, gap=gap)
+    def __init__(self, padding: int | None = None, gap: int | None = None, background_image: str | None = None, background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0) -> None:
+        super().__init__(rows=2, cols=3, padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
 
 class Grid3x2(GridLayout):
     """3x2 grid layout (6 slots) - 3 rows, 2 columns."""
 
-    def __init__(self, padding: int | None = None, gap: int | None = None) -> None:
-        super().__init__(rows=3, cols=2, padding=padding, gap=gap)
+    def __init__(self, padding: int | None = None, gap: int | None = None, background_image: str | None = None, background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0) -> None:
+        super().__init__(rows=3, cols=2, padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
 
 class Grid3x3(GridLayout):
     """3x3 grid layout (9 slots)."""
 
-    def __init__(self, padding: int | None = None, gap: int | None = None) -> None:
-        super().__init__(rows=3, cols=3, padding=padding, gap=gap)
+    def __init__(self, padding: int | None = None, gap: int | None = None, background_image: str | None = None, background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0) -> None:
+        super().__init__(rows=3, cols=3, padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)

--- a/custom_components/geekmagic/layouts/hero.py
+++ b/custom_components/geekmagic/layouts/hero.py
@@ -25,6 +25,11 @@ class HeroLayout(Layout):
         hero_ratio: float = 0.7,
         padding: int | None = None,
         gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
         """Initialize hero layout.
 
@@ -33,10 +38,12 @@ class HeroLayout(Layout):
             hero_ratio: Ratio of hero height to total height
             padding: Padding around edges
             gap: Gap between widgets
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
         """
         self.footer_slots = footer_slots
         self.hero_ratio = hero_ratio
-        super().__init__(padding=padding, gap=gap)
+        super().__init__(padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
     def _calculate_slots(self) -> None:
         """Calculate hero and footer rectangles."""

--- a/custom_components/geekmagic/layouts/hero_simple.py
+++ b/custom_components/geekmagic/layouts/hero_simple.py
@@ -18,5 +18,19 @@ class HeroSimpleLayout(HeroLayout):
         hero_ratio: float = 0.66,
         padding: int | None = None,
         gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
-        super().__init__(footer_slots=1, hero_ratio=hero_ratio, padding=padding, gap=gap)
+        """Initialize simple hero layout.
+
+        Args:
+            hero_ratio: Ratio of hero height to total height
+            padding: Padding around edges
+            gap: Gap between widgets
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
+        """
+        super().__init__(footer_slots=1, hero_ratio=hero_ratio, padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)

--- a/custom_components/geekmagic/layouts/sidebar.py
+++ b/custom_components/geekmagic/layouts/sidebar.py
@@ -25,6 +25,11 @@ class SidebarLeft(Layout):
         ratio: float = 0.67,
         padding: int | None = None,
         gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
         """Initialize sidebar left layout.
 
@@ -32,9 +37,11 @@ class SidebarLeft(Layout):
             ratio: Width ratio for left panel (default 2/3)
             padding: Padding around edges
             gap: Gap between widgets
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
         """
         self.ratio = ratio
-        super().__init__(padding=padding, gap=gap)
+        super().__init__(padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
     def _calculate_slots(self) -> None:
         """Calculate slot rectangles."""
@@ -97,6 +104,11 @@ class SidebarRight(Layout):
         ratio: float = 0.67,
         padding: int | None = None,
         gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
         """Initialize sidebar right layout.
 
@@ -104,9 +116,11 @@ class SidebarRight(Layout):
             ratio: Width ratio for right panel (default 2/3)
             padding: Padding around edges
             gap: Gap between widgets
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
         """
         self.ratio = ratio
-        super().__init__(padding=padding, gap=gap)
+        super().__init__(padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
     def _calculate_slots(self) -> None:
         """Calculate slot rectangles."""

--- a/custom_components/geekmagic/layouts/split.py
+++ b/custom_components/geekmagic/layouts/split.py
@@ -21,6 +21,11 @@ class SplitHorizontal(Layout):
         ratio: float = 0.5,
         padding: int | None = None,
         gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
         """Initialize horizontal split layout.
 
@@ -28,9 +33,11 @@ class SplitHorizontal(Layout):
             ratio: Ratio of left panel width (0.0-1.0)
             padding: Padding around edges
             gap: Gap between panels
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
         """
         self.ratio = max(0.2, min(0.8, ratio))
-        super().__init__(padding=padding, gap=gap)
+        super().__init__(padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
     def _calculate_slots(self) -> None:
         """Calculate left/right panel rectangles."""
@@ -84,6 +91,11 @@ class SplitVertical(Layout):
         ratio: float = 0.5,
         padding: int | None = None,
         gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
         """Initialize vertical split layout.
 
@@ -91,9 +103,11 @@ class SplitVertical(Layout):
             ratio: Ratio of top panel height (0.0-1.0)
             padding: Padding around edges
             gap: Gap between panels
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
         """
         self.ratio = max(0.2, min(0.8, ratio))
-        super().__init__(padding=padding, gap=gap)
+        super().__init__(padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
     def _calculate_slots(self) -> None:
         """Calculate top/bottom panel rectangles."""
@@ -149,6 +163,11 @@ class ThreeColumnLayout(Layout):
         ratios: tuple[float, float, float] = (0.33, 0.34, 0.33),
         padding: int | None = None,
         gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
         """Initialize three-column layout.
 
@@ -156,9 +175,11 @@ class ThreeColumnLayout(Layout):
             ratios: Width ratios for each column (should sum to ~1.0)
             padding: Padding around edges
             gap: Gap between columns
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
         """
         self.ratios = ratios
-        super().__init__(padding=padding, gap=gap)
+        super().__init__(padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
     def _calculate_slots(self) -> None:
         """Calculate column rectangles."""
@@ -206,6 +227,11 @@ class ThreeRowLayout(Layout):
         ratios: tuple[float, float, float] = (0.33, 0.34, 0.33),
         padding: int | None = None,
         gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
         """Initialize three-row layout.
 
@@ -213,9 +239,11 @@ class ThreeRowLayout(Layout):
             ratios: Height ratios for each row (should sum to ~1.0)
             padding: Padding around edges
             gap: Gap between rows
+            background_image: Optional path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
         """
         self.ratios = ratios
-        super().__init__(padding=padding, gap=gap)
+        super().__init__(padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
     def _calculate_slots(self) -> None:
         """Calculate row rectangles."""
@@ -254,9 +282,18 @@ class SplitHorizontal1To2(SplitHorizontal):
     +------+-------------+
     """
 
-    def __init__(self, padding: int | None = None, gap: int | None = None) -> None:
+    def __init__(
+        self,
+        padding: int | None = None,
+        gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
+    ) -> None:
         """Initialize 1:2 horizontal split."""
-        super().__init__(ratio=0.33, padding=padding, gap=gap)
+        super().__init__(ratio=0.33, padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)
 
 
 class SplitHorizontal2To1(SplitHorizontal):
@@ -270,6 +307,15 @@ class SplitHorizontal2To1(SplitHorizontal):
     +-------------+------+
     """
 
-    def __init__(self, padding: int | None = None, gap: int | None = None) -> None:
+    def __init__(
+        self,
+        padding: int | None = None,
+        gap: int | None = None,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+        widget_contrast: float = 0.0,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
+    ) -> None:
         """Initialize 2:1 horizontal split."""
-        super().__init__(ratio=0.67, padding=padding, gap=gap)
+        super().__init__(ratio=0.67, padding=padding, gap=gap, background_image=background_image, background_mode=background_mode, widget_contrast=widget_contrast, text_scale=text_scale, text_opacity=text_opacity)

--- a/custom_components/geekmagic/manifest.json
+++ b/custom_components/geekmagic/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/adrienbrault/geekmagic-hacs/issues",
   "requirements": ["pillow>=10.0.0", "palettable>=3.3.0"],
-  "version": "1.2.0"
+  "version": "1.0.4-custom"
 }

--- a/custom_components/geekmagic/preview.py
+++ b/custom_components/geekmagic/preview.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from .const import (
+    CONF_BACKGROUND_ENTITY,
+    CONF_BACKGROUND_IMAGE,
+    CONF_BACKGROUND_MODE,
     CONF_LAYOUT,
+    CONF_TEXT_OPACITY,
+    CONF_WIDGET_CONTRAST,
     CONF_WIDGETS,
+    LAYOUT_CUSTOM,
     LAYOUT_GRID_2X2,
     LAYOUT_GRID_2X3,
     LAYOUT_GRID_3X2,
@@ -28,6 +35,8 @@ from .const import (
     LAYOUT_THREE_ROW,
 )
 from .layouts.corner_hero import HeroCornerBL, HeroCornerBR, HeroCornerTL, HeroCornerTR
+from .layouts.custom import CustomLayout
+from .layouts.fullscreen import FullscreenLayout
 from .layouts.grid import Grid2x2, Grid2x3, Grid3x2, Grid3x3
 from .layouts.hero import HeroLayout
 from .layouts.sidebar import SidebarLeft, SidebarRight
@@ -65,6 +74,8 @@ LAYOUT_CLASSES = {
     LAYOUT_HERO_TR: HeroCornerTR,
     LAYOUT_HERO_BL: HeroCornerBL,
     LAYOUT_HERO_BR: HeroCornerBR,
+    LAYOUT_FULLSCREEN: FullscreenLayout,
+    LAYOUT_CUSTOM: CustomLayout,
 }
 
 
@@ -325,6 +336,11 @@ def render_preview(
     layout_type: str,
     widgets_config: list[dict[str, Any]],
     hass: HomeAssistant | None = None,
+    background_image: str | None = None,
+    background_mode: str = "stretch",
+    background_entity: str | None = None,
+    widget_contrast: float = 0.5,
+    text_opacity: float = 1.0,
 ) -> bytes:
     """Render a preview image for the given configuration.
 
@@ -332,10 +348,26 @@ def render_preview(
         layout_type: Layout type string (grid_2x2, grid_2x3, hero, split)
         widgets_config: List of widget configuration dictionaries
         hass: Optional Home Assistant instance (uses mock if None)
+        background_image: Optional static path to a local background image
+        background_mode: How to fit the image: stretch, contain, cover
+        background_entity: Optional HA entity whose state resolves to a path
+        widget_contrast: Opacity of the contrast backdrop behind widgets (0..1).
+        text_opacity: Opacity multiplier for text/icon colors (0..1).
 
     Returns:
         PNG image bytes
     """
+    # Resolve background entity if hass is available
+    if background_entity and hass is not None:
+        state = hass.states.get(background_entity)
+        if state and isinstance(state.state, str):
+            resolved = state.state.strip()
+            if resolved and resolved.lower() not in ("unavailable", "unknown", "none", ""):
+                if not resolved.startswith("/"):
+                    resolved = f"/config/{resolved}"
+                if os.path.isfile(resolved):
+                    background_image = resolved
+
     # Build mock states for preview
     mock = MockHass()
     for widget_config in widgets_config:
@@ -344,15 +376,34 @@ def render_preview(
     # Create renderer and layout
     renderer = Renderer()
     layout_class = LAYOUT_CLASSES.get(layout_type, Grid2x2)
-    layout = layout_class()
+
+    if isinstance(background_image, str):
+        background_image = background_image.strip() or None
+    if background_mode not in ("stretch", "contain", "cover"):
+        background_mode = "stretch"
+
+    layout_kwargs = dict(
+        background_image=background_image,
+        background_mode=background_mode,
+        widget_contrast=widget_contrast,
+        text_scale=1.0,
+        text_opacity=text_opacity,
+    )
+    if layout_type == LAYOUT_CUSTOM:
+        layout_kwargs["widgets"] = widgets_config
+
+    layout = layout_class(**layout_kwargs)
 
     # Build widget_states dict for all slots
     widget_states: dict[int, WidgetState] = {}
 
     # Create and assign widgets
-    for widget_config in widgets_config:
+    for widget_index, widget_config in enumerate(widgets_config):
         widget_type = str(widget_config.get("type", "text"))
-        slot = int(widget_config.get("slot", 0))
+        if layout_type == LAYOUT_CUSTOM:
+            slot = widget_index
+        else:
+            slot = int(widget_config.get("slot", 0))
 
         if slot >= layout.get_slot_count():
             continue
@@ -371,12 +422,20 @@ def render_preview(
         if isinstance(raw_color, list | tuple) and len(raw_color) == 3:
             parsed_color = (int(raw_color[0]), int(raw_color[1]), int(raw_color[2]))
 
+        widget_text_scale = 1.0
+        try:
+            widget_text_scale = float(widget_config.get("text_scale", 1.0))
+        except (TypeError, ValueError):
+            widget_text_scale = 1.0
+        widget_text_scale = max(0.5, min(3.0, widget_text_scale))
+
         config = WidgetConfig(
             widget_type=widget_type,
             slot=slot,
             entity_id=str(entity_id) if entity_id is not None else None,
             label=str(label) if label is not None else None,
             color=parsed_color,
+            text_scale=widget_text_scale,
             options=cast("dict[str, Any]", widget_options),
         )
 
@@ -407,5 +466,31 @@ def render_screen_preview(
     """
     layout_type = screen_config.get(CONF_LAYOUT, LAYOUT_GRID_2X2)
     widgets_config = screen_config.get(CONF_WIDGETS, [])
+    background_image = screen_config.get(CONF_BACKGROUND_IMAGE)
+    background_mode = screen_config.get(CONF_BACKGROUND_MODE, "stretch")
+    background_entity = screen_config.get(CONF_BACKGROUND_ENTITY)
 
-    return render_preview(layout_type, widgets_config, hass)
+    widget_contrast = screen_config.get(CONF_WIDGET_CONTRAST, 0.5)
+    try:
+        widget_contrast = float(widget_contrast)
+    except (TypeError, ValueError):
+        widget_contrast = 0.5
+    widget_contrast = max(0.0, min(1.0, widget_contrast))
+
+    text_opacity = screen_config.get(CONF_TEXT_OPACITY, 1.0)
+    try:
+        text_opacity = float(text_opacity)
+    except (TypeError, ValueError):
+        text_opacity = 1.0
+    text_opacity = max(0.0, min(1.0, text_opacity))
+
+    return render_preview(
+        layout_type,
+        widgets_config,
+        hass,
+        background_image=background_image,
+        background_mode=background_mode,
+        background_entity=background_entity,
+        widget_contrast=widget_contrast,
+        text_opacity=text_opacity,
+    )

--- a/custom_components/geekmagic/render_context.py
+++ b/custom_components/geekmagic/render_context.py
@@ -85,6 +85,9 @@ class RenderContext:
         rect: tuple[int, int, int, int],
         renderer: Renderer,
         theme: Theme | None = None,
+        transparent_background: bool = False,
+        text_scale: float = 1.0,
+        text_opacity: float = 1.0,
     ) -> None:
         """Initialize render context.
 
@@ -93,6 +96,10 @@ class RenderContext:
             rect: (x1, y1, x2, y2) bounding box in unscaled coordinates
             renderer: Renderer instance for drawing operations
             theme: Theme configuration for styling (optional, defaults to classic)
+            transparent_background: When True, widgets should avoid painting
+                solid backgrounds so an underlying background image stays visible.
+            text_scale: Extra scaling factor for text/icon fonts.
+            text_opacity: Opacity multiplier for text/icon colors (0..1).
         """
         self._draw = draw
         self._renderer = renderer
@@ -100,6 +107,9 @@ class RenderContext:
         self.width = x2 - self._x1
         self.height = y2 - self._y1
         self._theme = theme  # Store the theme
+        self.transparent_background = transparent_background
+        self.text_scale = text_scale
+        self.text_opacity = max(0.0, min(1.0, text_opacity))
 
         # Pre-calculate scaled height for font sizing
         self._scaled_height = self.height * renderer.scale
@@ -193,6 +203,12 @@ class RenderContext:
 
         return resolve_theme_color(color, self.theme)
 
+    def _text_color(self, color: tuple[int, int, int]) -> tuple[int, int, int, int]:
+        """Resolve a color and apply the global text opacity."""
+        resolved = self._resolve_color(color)
+        alpha = int(255 * self.text_opacity)
+        return (resolved[0], resolved[1], resolved[2], alpha)
+
     def _abs_point(self, x: int, y: int) -> tuple[int, int]:
         """Convert local point to absolute canvas coordinates."""
         return (self._x1 + x, self._y1 + y)
@@ -229,7 +245,7 @@ class RenderContext:
         """
         return self._renderer.get_scaled_font(
             size_name,
-            self._scaled_height,
+            int(self._scaled_height * self.text_scale),
             bold=bold,
             adjust=adjust,
             rounded=self.theme.rounded_font,
@@ -263,9 +279,9 @@ class RenderContext:
         if max_height is None:
             max_height = int(self.height * 0.90)
 
-        # Scale dimensions for supersampling
-        scaled_width = max_width * self._renderer.scale
-        scaled_height = max_height * self._renderer.scale
+        # Scale dimensions for supersampling and the per-view text scale.
+        scaled_width = int(max_width * self._renderer.scale * self.text_scale)
+        scaled_height = int(max_height * self._renderer.scale * self.text_scale)
 
         return self._renderer.fit_text_font(
             text,
@@ -342,7 +358,7 @@ class RenderContext:
         if font is None:
             font = self.get_font("regular")
         abs_pos = self._abs_point(*position)
-        resolved_color = self._resolve_color(color)
+        resolved_color = self._text_color(color)
         self._renderer.draw_text(
             self._draw, text, abs_pos, font=font, color=resolved_color, anchor=anchor
         )
@@ -610,7 +626,7 @@ class RenderContext:
             color: Icon color (supports theme sentinel values)
         """
         abs_pos = self._abs_point(*position)
-        resolved_color = self._resolve_color(color)
+        resolved_color = self._text_color(color)
         self._renderer.draw_icon(self._draw, name, abs_pos, size=size, color=resolved_color)
 
     def draw_line(

--- a/custom_components/geekmagic/renderer.py
+++ b/custom_components/geekmagic/renderer.py
@@ -313,6 +313,60 @@ class Renderer:
         draw = ImageDraw.Draw(img)
         return img, draw
 
+    def create_canvas_with_background(
+        self,
+        background_color: tuple[int, int, int] = COLOR_BLACK,
+        background_image: str | None = None,
+        background_mode: str = "stretch",
+    ) -> tuple[Image.Image, ImageDraw.ImageDraw]:
+        """Create a canvas, optionally painting a background image.
+
+        Args:
+            background_color: Fallback RGB color if no image or image fails.
+            background_image: Path to a local image file (PNG/JPG/etc).
+            background_mode: How to fit the image: "stretch", "contain", "cover".
+
+        Returns:
+            Tuple of (Image, ImageDraw)
+        """
+        img = Image.new("RGB", (self._scaled_width, self._scaled_height), background_color)
+        if background_image:
+            try:
+                bg = Image.open(background_image).convert("RGB")
+                src_ratio = bg.width / bg.height
+                dest_ratio = self._scaled_width / self._scaled_height
+                if background_mode == "contain":
+                    if src_ratio > dest_ratio:
+                        new_width = self._scaled_width
+                        new_height = int(self._scaled_width / src_ratio)
+                    else:
+                        new_height = self._scaled_height
+                        new_width = int(self._scaled_height * src_ratio)
+                    bg = bg.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                    paste_x = (self._scaled_width - new_width) // 2
+                    paste_y = (self._scaled_height - new_height) // 2
+                    img.paste(bg, (paste_x, paste_y))
+                elif background_mode == "cover":
+                    if src_ratio > dest_ratio:
+                        new_height = self._scaled_height
+                        new_width = int(self._scaled_height * src_ratio)
+                    else:
+                        new_width = self._scaled_width
+                        new_height = int(self._scaled_width / src_ratio)
+                    bg = bg.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                    left = (new_width - self._scaled_width) // 2
+                    top = (new_height - self._scaled_height) // 2
+                    img.paste(bg.crop((left, top, left + self._scaled_width, top + self._scaled_height)))
+                else:
+                    # stretch
+                    bg = bg.resize((self._scaled_width, self._scaled_height), Image.Resampling.LANCZOS)
+                    img.paste(bg)
+            except Exception:
+                # If image loading fails, keep the fallback color.
+                pass
+        draw = ImageDraw.Draw(img)
+        return img, draw
+
     def _downscale(self, img: Image.Image) -> Image.Image:
         """Downscale supersampled image to final resolution with anti-aliasing."""
         return img.resize((self.width, self.height), Image.Resampling.LANCZOS)
@@ -401,7 +455,7 @@ class Renderer:
         text: str,
         position: tuple[int, int],
         font: FreeTypeFont | ImageFont.ImageFont | None = None,
-        color: tuple[int, int, int] = COLOR_WHITE,
+        color: tuple[int, int, int] | tuple[int, int, int, int] = COLOR_WHITE,
         anchor: str | None = None,
     ) -> None:
         """Draw text on the canvas.
@@ -411,7 +465,7 @@ class Renderer:
             text: Text to draw
             position: (x, y) position (will be scaled)
             font: Font to use (default: regular)
-            color: RGB color tuple
+            color: RGB or RGBA color tuple
             anchor: Text anchor (e.g., "mm" for center)
         """
         if font is None:
@@ -827,7 +881,7 @@ class Renderer:
         icon: str,
         position: tuple[int, int],
         size: int = 16,
-        color: tuple[int, int, int] = COLOR_WHITE,
+        color: tuple[int, int, int] | tuple[int, int, int, int] = COLOR_WHITE,
     ) -> None:
         """Draw a Material Design Icon.
 
@@ -842,7 +896,7 @@ class Renderer:
                 - Bare MDI: "thermometer"
             position: (x, y) top-left corner
             size: Icon size in pixels
-            color: Icon color (RGB tuple)
+            color: Icon color (RGB or RGBA tuple)
         """
         # Get the MDI character for this icon
         mdi_char = get_mdi_char(icon)

--- a/custom_components/geekmagic/store.py
+++ b/custom_components/geekmagic/store.py
@@ -17,7 +17,17 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, LAYOUT_GRID_2X2, THEME_CLASSIC
+from .const import (
+    BACKGROUND_MODE_STRETCH,
+    CONF_BACKGROUND_ENTITY,
+    CONF_BACKGROUND_IMAGE,
+    CONF_BACKGROUND_MODE,
+    CONF_TEXT_OPACITY,
+    CONF_WIDGET_CONTRAST,
+    DOMAIN,
+    LAYOUT_GRID_2X2,
+    THEME_CLASSIC,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,6 +120,11 @@ class GeekMagicStore:
         layout: str = LAYOUT_GRID_2X2,
         theme: str = THEME_CLASSIC,
         widgets: list[dict[str, Any]] | None = None,
+        background_image: str | None = None,
+        background_mode: str = BACKGROUND_MODE_STRETCH,
+        background_entity: str | None = None,
+        widget_contrast: float = 0.5,
+        text_opacity: float = 1.0,
     ) -> str:
         """Create a new view.
 
@@ -118,6 +133,11 @@ class GeekMagicStore:
             layout: Layout type
             theme: Theme name
             widgets: List of widget configurations
+            background_image: Optional static path to a local background image
+            background_mode: How to fit the image: stretch, contain, cover
+            background_entity: Optional HA entity whose state resolves to a path
+            widget_contrast: Opacity of a dark contrast panel behind each widget.
+            text_opacity: Opacity multiplier for text/icon colors.
 
         Returns:
             ID of the created view
@@ -131,6 +151,11 @@ class GeekMagicStore:
             "layout": layout,
             "theme": theme,
             "widgets": widgets or [],
+            CONF_BACKGROUND_IMAGE: background_image,
+            CONF_BACKGROUND_MODE: background_mode,
+            CONF_BACKGROUND_ENTITY: background_entity,
+            CONF_WIDGET_CONTRAST: widget_contrast,
+            CONF_TEXT_OPACITY: text_opacity,
             "created_at": now,
             "updated_at": now,
         }
@@ -148,7 +173,8 @@ class GeekMagicStore:
 
         Args:
             view_id: View identifier
-            **updates: Fields to update (name, layout, theme, widgets)
+            **updates: Fields to update (name, layout, theme, widgets,
+                        background_image, background_mode, background_entity)
 
         Returns:
             True if view was updated, False if not found
@@ -160,7 +186,17 @@ class GeekMagicStore:
         view = self._data["views"][view_id]
 
         # Only update allowed fields
-        allowed_fields = {"name", "layout", "theme", "widgets"}
+        allowed_fields = {
+            "name",
+            "layout",
+            "theme",
+            "widgets",
+            CONF_BACKGROUND_IMAGE,
+            CONF_BACKGROUND_MODE,
+            CONF_BACKGROUND_ENTITY,
+            CONF_WIDGET_CONTRAST,
+            CONF_TEXT_OPACITY,
+        }
         for key, value in updates.items():
             if key in allowed_fields:
                 view[key] = value
@@ -210,6 +246,11 @@ class GeekMagicStore:
             layout=source["layout"],
             theme=source["theme"],
             widgets=source.get("widgets", []).copy(),
+            background_image=source.get(CONF_BACKGROUND_IMAGE),
+            background_mode=source.get(CONF_BACKGROUND_MODE, BACKGROUND_MODE_STRETCH),
+            background_entity=source.get(CONF_BACKGROUND_ENTITY),
+            widget_contrast=source.get(CONF_WIDGET_CONTRAST, 0.5),
+            text_opacity=source.get(CONF_TEXT_OPACITY, 1.0),
         )
 
     async def async_migrate_from_screens(
@@ -236,6 +277,11 @@ class GeekMagicStore:
                 layout=screen.get("layout", LAYOUT_GRID_2X2),
                 theme=screen.get("theme", THEME_CLASSIC),
                 widgets=screen.get("widgets", []),
+                background_image=screen.get(CONF_BACKGROUND_IMAGE),
+                background_mode=screen.get(CONF_BACKGROUND_MODE, BACKGROUND_MODE_STRETCH),
+                background_entity=screen.get(CONF_BACKGROUND_ENTITY),
+                widget_contrast=screen.get(CONF_WIDGET_CONTRAST, 0.5),
+                text_opacity=screen.get(CONF_TEXT_OPACITY, 1.0),
             )
             view_ids.append(view_id)
 

--- a/custom_components/geekmagic/websocket.py
+++ b/custom_components/geekmagic/websocket.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import base64
 import contextlib
 import logging
+import os
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -18,11 +19,18 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    BACKGROUND_MODE_STRETCH,
+    CONF_BACKGROUND_ENTITY,
+    CONF_BACKGROUND_IMAGE,
+    CONF_BACKGROUND_MODE,
     CONF_REFRESH_INTERVAL,
     CONF_SCREEN_CYCLE_INTERVAL,
+    CONF_TEXT_OPACITY,
+    CONF_WIDGET_CONTRAST,
     DEFAULT_REFRESH_INTERVAL,
     DEFAULT_SCREEN_CYCLE_INTERVAL,
     DOMAIN,
+    LAYOUT_CUSTOM,
     LAYOUT_GRID_2X2,
     LAYOUT_SLOT_COUNTS,
     THEME_CLASSIC,
@@ -138,6 +146,11 @@ def ws_views_get(
         vol.Optional("layout", default=LAYOUT_GRID_2X2): str,
         vol.Optional("theme", default=THEME_CLASSIC): str,
         vol.Optional("widgets", default=[]): list,
+        vol.Optional("background_image"): str,
+        vol.Optional("background_mode", default=BACKGROUND_MODE_STRETCH): str,
+        vol.Optional("background_entity"): str,
+        vol.Optional("widget_contrast", default=0.5): vol.Coerce(float),
+        vol.Optional("text_opacity", default=1.0): vol.Coerce(float),
     }
 )
 @websocket_api.async_response
@@ -153,6 +166,11 @@ async def ws_views_create(
         layout=msg["layout"],
         theme=msg["theme"],
         widgets=msg["widgets"],
+        background_image=msg.get("background_image"),
+        background_mode=msg.get("background_mode", BACKGROUND_MODE_STRETCH),
+        background_entity=msg.get("background_entity"),
+        widget_contrast=msg.get("widget_contrast", 0.5),
+        text_opacity=msg.get("text_opacity", 1.0),
     )
     connection.send_result(
         msg["id"],
@@ -171,6 +189,11 @@ async def ws_views_create(
         vol.Optional("layout"): str,
         vol.Optional("theme"): str,
         vol.Optional("widgets"): list,
+        vol.Optional("background_image"): str,
+        vol.Optional("background_mode"): str,
+        vol.Optional("background_entity"): str,
+        vol.Optional("widget_contrast"): vol.Coerce(float),
+        vol.Optional("text_opacity"): vol.Coerce(float),
     }
 )
 @websocket_api.async_response
@@ -189,7 +212,17 @@ async def ws_views_update(
 
     # Build update dict from optional fields
     updates = {}
-    for key in ("name", "layout", "theme", "widgets"):
+    for key in (
+        "name",
+        "layout",
+        "theme",
+        "widgets",
+        CONF_BACKGROUND_IMAGE,
+        CONF_BACKGROUND_MODE,
+        CONF_BACKGROUND_ENTITY,
+        CONF_WIDGET_CONTRAST,
+        CONF_TEXT_OPACITY,
+    ):
         if key in msg:
             updates[key] = msg[key]
 
@@ -579,16 +612,62 @@ async def ws_preview_render(
         layout_class = LAYOUT_CLASSES.get(layout_type)
         if not layout_class:
             layout_class = LAYOUT_CLASSES[LAYOUT_GRID_2X2]
-        layout = layout_class()
+
+        # Resolve background image, honoring an entity override.
+        background_image = view_config.get(CONF_BACKGROUND_IMAGE)
+        background_mode = view_config.get(CONF_BACKGROUND_MODE, "stretch")
+        background_entity = view_config.get(CONF_BACKGROUND_ENTITY)
+        if background_entity:
+            entity_state = hass.states.get(background_entity)
+            if entity_state and entity_state.state not in (
+                "unavailable",
+                "unknown",
+                "",
+                None,
+            ):
+                path = entity_state.state
+                if not path.startswith("/"):
+                    path = f"/config/{path}"
+                if os.path.isfile(path):
+                    background_image = path
+
+        widget_contrast = view_config.get(CONF_WIDGET_CONTRAST, 0.5)
+        try:
+            widget_contrast = float(widget_contrast)
+        except (TypeError, ValueError):
+            widget_contrast = 0.5
+        widget_contrast = max(0.0, min(1.0, widget_contrast))
+
+        text_opacity = view_config.get(CONF_TEXT_OPACITY, 1.0)
+        try:
+            text_opacity = float(text_opacity)
+        except (TypeError, ValueError):
+            text_opacity = 1.0
+        text_opacity = max(0.0, min(1.0, text_opacity))
+
+        layout_kwargs = dict(
+            background_image=background_image,
+            background_mode=background_mode,
+            widget_contrast=widget_contrast,
+            text_scale=1.0,
+            text_opacity=text_opacity,
+        )
+        if layout_type == LAYOUT_CUSTOM:
+            layout_kwargs["widgets"] = view_config.get("widgets", [])
+
+        layout = layout_class(**layout_kwargs)
 
         # Set theme
         theme_name = view_config.get("theme", THEME_CLASSIC)
         layout.theme = get_theme(theme_name)
 
         # Add widgets
-        for widget_data in view_config.get("widgets", []):
+        for widget_index, widget_data in enumerate(view_config.get("widgets", [])):
             widget_type = widget_data.get("type")
-            slot = widget_data.get("slot", 0)
+            if layout_type == LAYOUT_CUSTOM:
+                slot = widget_index
+            else:
+                slot = widget_data.get("slot", 0)
 
             if slot >= layout.get_slot_count():
                 continue
@@ -602,12 +681,20 @@ async def ws_preview_render(
             if isinstance(raw_color, list | tuple) and len(raw_color) == 3:
                 parsed_color = (int(raw_color[0]), int(raw_color[1]), int(raw_color[2]))
 
+            widget_text_scale = 1.0
+            try:
+                widget_text_scale = float(widget_data.get("text_scale", 1.0))
+            except (TypeError, ValueError):
+                widget_text_scale = 1.0
+            widget_text_scale = max(0.5, min(3.0, widget_text_scale))
+
             config = WidgetConfig(
                 widget_type=widget_type,
                 slot=slot,
                 entity_id=widget_data.get("entity_id"),
                 label=widget_data.get("label"),
                 color=parsed_color,
+                text_scale=widget_text_scale,
                 options=widget_data.get("options", {}),
             )
             widget = widget_class(config)
@@ -621,8 +708,11 @@ async def ws_preview_render(
         tz = getattr(hass.config, "time_zone_obj", None) or UTC
         now = datetime.now(tz=tz)
 
-        for widget_data in view_config.get("widgets", []):
-            slot = widget_data.get("slot", 0)
+        for widget_index, widget_data in enumerate(view_config.get("widgets", [])):
+            if layout_type == LAYOUT_CUSTOM:
+                slot = widget_index
+            else:
+                slot = widget_data.get("slot", 0)
             if slot >= layout.get_slot_count():
                 continue
 

--- a/custom_components/geekmagic/widgets/base.py
+++ b/custom_components/geekmagic/widgets/base.py
@@ -21,6 +21,7 @@ class WidgetConfig:
     entity_id: str | None = None
     label: str | None = None
     color: tuple[int, int, int] | None = None
+    text_scale: float = 1.0
     options: dict[str, Any] = field(default_factory=dict)
 
 

--- a/custom_components/geekmagic/widgets/components.py
+++ b/custom_components/geekmagic/widgets/components.py
@@ -406,6 +406,14 @@ class Panel(Component):
         return (max_width, max_height)
 
     def render(self, ctx: RenderContext, x: int, y: int, width: int, height: int) -> None:
+        # When an underlying background image is active, panels should stay
+        # completely transparent by default so the photo shows through. Explicit
+        # colors or borders are still honored.
+        if ctx.transparent_background and self.color is None and self.border_color is None:
+            if self.child:
+                self.child.render(ctx, x, y, width, height)
+            return
+
         theme = ctx.theme
         # Use theme defaults when not explicitly specified
         fill_color = self.color if self.color is not None else theme.surface

--- a/samples/19_custom_layout.yaml
+++ b/samples/19_custom_layout.yaml
@@ -1,0 +1,42 @@
+# Custom layout example — free-form widget placement on a 240x240 display.
+# Use this view when none of the predefined slot-based layouts fit your idea.
+name: Custom Layout Demo
+layout: custom
+background_image: /config/www/geekmagic/backgrounds/example.png
+background_mode: contain
+widget_contrast: 0.3
+text_scale: 1.0
+text_opacity: 1.0
+widgets:
+  # Top bar: full-width clock
+  - type: clock
+    x: 0
+    y: 0
+    width: 240
+    height: 60
+
+  # Left column: temperature + humidity stacked
+  - type: entity_plain
+    entity_id: sensor.living_room_temperature
+    label: Living Room
+    x: 0
+    y: 60
+    width: 120
+    height: 90
+
+  - type: entity_plain
+    entity_id: sensor.living_room_humidity
+    label: Humidity
+    x: 0
+    y: 150
+    width: 120
+    height: 90
+
+  # Right side: large gauge
+  - type: gauge_ring
+    entity_id: sensor.cpu_percent
+    label: CPU
+    x: 120
+    y: 60
+    width: 120
+    height: 180

--- a/tests/layouts/test_layouts.py
+++ b/tests/layouts/test_layouts.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 import pytest
 
 from custom_components.geekmagic.layouts.base import Slot
+from custom_components.geekmagic.layouts.custom import CustomLayout
 from custom_components.geekmagic.layouts.fullscreen import FullscreenLayout
 from custom_components.geekmagic.layouts.grid import Grid2x2, Grid2x3, Grid3x3, GridLayout
 from custom_components.geekmagic.layouts.hero import HeroLayout
@@ -334,6 +335,54 @@ class TestFullscreenLayout:
         widget = ClockWidget(config)
         layout.set_widget(0, widget)
 
+        layout.render(renderer, draw)
+        assert img.size == (480, 480)
+
+
+class TestCustomLayout:
+    """Tests for CustomLayout."""
+
+    def test_init_from_widgets(self):
+        """Test custom layout builds slots from widget coordinates."""
+        widgets = [
+            {"type": "clock", "x": 0, "y": 0, "width": 120, "height": 120},
+            {"type": "weather", "x": 120, "y": 0, "width": 120, "height": 240},
+        ]
+        layout = CustomLayout(widgets=widgets)
+        assert layout.get_slot_count() == 2
+        assert layout.slots[0].rect == (0, 0, 120, 120)
+        assert layout.slots[1].rect == (120, 0, 240, 240)
+
+    def test_clamps_to_display_bounds(self):
+        """Test that out-of-bounds widgets are clamped."""
+        widgets = [{"type": "text", "x": 200, "y": 200, "width": 100, "height": 100}]
+        layout = CustomLayout(widgets=widgets)
+        assert layout.slots[0].rect == (200, 200, 240, 240)
+
+    def test_zero_size_widget(self):
+        """Test that zero-size widgets still produce valid rectangles."""
+        widgets = [{"type": "text", "x": 50, "y": 50, "width": 0, "height": 0}]
+        layout = CustomLayout(widgets=widgets)
+        x1, y1, x2, y2 = layout.slots[0].rect
+        assert x2 >= x1 and y2 >= y1
+
+    def test_set_widget_by_index(self):
+        """Test assigning widgets to custom slots."""
+        widgets = [{"type": "clock", "x": 0, "y": 0, "width": 240, "height": 240}]
+        layout = CustomLayout(widgets=widgets)
+        config = WidgetConfig(widget_type="clock", slot=0)
+        widget = ClockWidget(config)
+        layout.set_widget(0, widget)
+        assert layout.slots[0].widget is widget
+
+    def test_render(self, renderer, canvas):
+        """Test rendering custom layout."""
+        img, draw = canvas
+        widgets = [
+            {"type": "clock", "x": 0, "y": 0, "width": 120, "height": 120},
+            {"type": "clock", "x": 120, "y": 120, "width": 120, "height": 120},
+        ]
+        layout = CustomLayout(widgets=widgets)
         layout.render(renderer, draw)
         assert img.size == (480, 480)
 


### PR DESCRIPTION
This PR adds a **Custom Layout** option that allows widgets to be freely positioned on the 240×240 display using `x`, `y`, `width` and `height` instead of being constrained to predefined slots.

It also adds support for configurable **background images and entities**, **text opacity**, removes the global view-level `text_scale` setting and replaces it with a per-widget `text_scale` option, and updates the widget contrast default/range.

### What's new
- New layout: `custom`
- Widgets can be placed freely with `x`, `y`, `width`, `height`
- Configurable background image, background entity and background mode
- Configurable text opacity
- Per-widget `text_scale`
- Widget contrast range: 0 % – 100 %
- New default widget contrast: 50 %
- Frontend editor updated with X/Y/W/H inputs and the `mdi:select-drag` icon
- Added `samples/19_custom_layout.yaml`

### Breaking changes
- The global `text_scale` view option is removed. Existing views that used it will fall back to per-widget `text_scale: 1.0`.



<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/0929ecd1-e677-4f7d-921c-f928d171ae2a" />