### PR TITLE
fix: fall back to estimated glyph widths on degenerate measurements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,34 +133,36 @@ browser). Pillow only composites passes and encodes JPEG/PNG.
 
 1. Coordinator triggers update on interval
 2. Layout calculates widget rectangles (slots) — pure geometry
-3. **One `render_layers` call** (blitz-py >= 0.4.0) composites the
-   whole screen engine-side: the theme backdrop layer
-   (`theme.backdrop_css`), one layer per widget cell (each widget's
-   `render_html` fragment wrapped by `htmldoc.build_cell_document` —
-   theme CSS variables + fluid kit + `theme.chrome_css`), and the
-   optional `theme.overlay_css` layer (scanlines, vignettes) on top.
-   Each cell layer keeps its own CSS viewport (`vmin`/`vw` and
-   `@media` respond to the CELL size) and is CLIPPED to its rect by
-   the engine — the containment per-cell rasterization used to
-   provide. Themes with `glow_effect` (neon) paint each cell once
-   blurred beneath its sharp pass (per-layer `blur`/`opacity`).
-   On older blitz-py the pipeline falls back to per-document renders
-   + Pillow premultiplied compositing (`_render_legacy`).
+3. **One `render_layers` call** composites the whole screen
+   engine-side: the theme backdrop layer (`theme.backdrop_css`), one
+   layer per widget cell (each widget's `render_html` fragment wrapped
+   by `htmldoc.build_cell_document` — theme CSS variables + fluid kit +
+   `theme.chrome_css`), and the optional `theme.overlay_css` layer
+   (scanlines, vignettes) on top. Each cell layer keeps its own CSS
+   viewport (`vmin`/`vw` and `@media` respond to the CELL size) and is
+   CLIPPED to its rect by the engine. Themes with `glow_effect` (neon)
+   paint each cell once blurred beneath its sharp pass (per-layer
+   `blur`/`opacity`).
 4. Image converted to JPEG and uploaded to device. Fonts are
-   registered process-wide once (`register_fonts`, htmldoc's
-   `font_param()`) — no per-call font bytes.
+   registered process-wide once, under a lock (`register_fonts`,
+   htmldoc's `font_param()`) — no per-call font bytes. If
+   registration ever fails, the same embedded font bytes ride every
+   measurement call AND every render layer, so measurement and
+   rendering can never resolve different fonts (that divergence is how
+   fitted text overflows the panel).
+
+blitz-py >= 0.4.2 is the hard floor (`manifest.json`); an older or
+missing engine paints the install-hint screen. The pre-0.4.2 fallback
+paths (per-document renders + Pillow premultiplied compositing) were
+removed — do not reintroduce version-gated pipelines.
 
 **Animated path (opt-in):** when the device's Animations switch is on
 and a placed widget returns ``is_animated() == True``, the coordinator
 calls ``layout.render_animation`` instead: each frame is ONE
 ``render_layers`` call with the frame's clock on animated layers (and
-their glow underlays) — needs blitz-py >= 0.4.1
-(``htmldoc.HAS_LAYER_CLOCK``; 0.4.0 documented per-layer ``time`` but
-ignored it). Frames are encoded with ``Renderer.to_gif`` (1.6s @
-10fps, palette quantized without dithering) and ``dashboard.gif`` is
-uploaded in place of the JPEG. Older engines fall back to
-``render_frames`` per animated cell + Pillow compositing
-(``_render_animation_legacy``).
+their glow underlays). Frames are encoded with ``Renderer.to_gif``
+(1.6s @ 10fps, palette quantized without dithering) and
+``dashboard.gif`` is uploaded in place of the JPEG.
 
 blitz-py capabilities adopted so far: ``measure_text`` (0.3.0) and
 ``ellipsize`` (0.4.0) drive ``widgets/_textfit.py`` — engine-native
@@ -186,9 +188,20 @@ an install-hint error screen.
 Blitz engine gotchas (verified, keep in mind):
 - `var(--x)` does NOT resolve inside SVG paint attributes — pass
   concrete colors (`css_rgb(theme.x)`) to the SVG helpers.
-- No `text-overflow: ellipsis` and text ignores `overflow: hidden` —
-  truncate long strings in Python (`helpers.truncate_text`, or the
-  measured `_textfit` metrics for design-critical text).
+- `text-overflow: ellipsis` paints no "…" (0.4.2 clips the text but
+  draws no mark), and `overflow: hidden` cuts glyphs mid-stroke — on
+  tight line-heights (`.t-hero`'s 0.85) it also crops
+  ascenders/descenders, and `overflow-x` clips BOTH axes. So CSS can
+  contain overflow but never resolve it nicely: keep truncating long
+  strings in Python (`helpers.truncate_text`, or the measured
+  `_textfit` metrics for design-critical text).
+- All Python-side fitting is open-loop (predict, then draw) and funnels
+  through `_textfit._ref_width`, which sanitizes degenerate engine
+  measurements (NaN/<= 0 fall back to a conservative estimate). A NaN
+  that leaks into `fit_hero` disables the width bound AND truncation
+  (every comparison is False) and paints the value at the height cap
+  across the bezel — the "massive text" field bug. Keep that choke
+  point intact.
 - Inline `style="display: flex"` beats the kit's `.hide-*` media rules —
   put hide classes on a wrapper div without inline display.
 - Inline `<svg>` is sized from its viewBox ASPECT RATIO, not from
@@ -346,8 +359,9 @@ tint.** That's where the colour lives.
 - Don't put `style="display: flex"` inline on an element that carries a
   `.hide-*` class — inline styles defeat the media-query hide. Wrap it.
 - Don't rely on `text-overflow: ellipsis` or `overflow: hidden` for
-  text — Blitz doesn't clip text. Truncate long strings in Python
-  (`helpers.truncate_text`).
+  text — the engine clips without painting "…" and crops glyph
+  ascenders/descenders on tight line-heights. Truncate long strings in
+  Python (`helpers.truncate_text`).
 - Don't use `justify-content: center` for a cell taller than its
   content — `space-evenly` (the `.cell` default) uses the space better.
 

--- a/custom_components/geekmagic/htmldoc.py
+++ b/custom_components/geekmagic/htmldoc.py
@@ -23,12 +23,13 @@ import base64
 import io
 import logging
 import math
+import threading
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from PIL import Image, ImageChops
+from PIL import Image
 
 from .icons import get_mdi_char
 
@@ -48,32 +49,29 @@ except ImportError:  # pragma: no cover - depends on environment
 # animations/transitions at given timestamps).
 HAS_FRAMES = HAS_BLITZ and hasattr(blitz_py, "render_frames")
 
-# Engine-side layered compositing and process-wide font registration
-# need blitz-py >= 0.4.0. Without them the pipeline falls back to
-# per-document rendering + Pillow compositing.
-HAS_LAYERS = HAS_BLITZ and hasattr(blitz_py, "render_layers")
-HAS_FONT_REGISTRY = HAS_BLITZ and hasattr(blitz_py, "register_fonts")
+# The pipeline requires blitz-py >= 0.4.2 (layered compositing,
+# process-wide font registration that survives font-less systems,
+# per-layer animation clocks) — that's what manifest.json installs. An
+# older engine on disk gets the install-hint screen instead of a
+# half-working fallback pipeline: the legacy per-document + Pillow
+# compositing paths were removed once 0.4.2 became the floor.
+_ENGINE_FLOOR = (0, 4, 2)
 
 
-def _has_layer_clock() -> bool:
-    """True when per-layer ``time`` actually drives animations.
-
-    0.4.0 shipped ``render_layers`` with a documented ``time`` that was
-    ignored (fixed in 0.4.1) — animated frames rendered through it would
-    silently freeze at t=0, so the animated path needs the real version.
-    """
-    if not HAS_LAYERS:
+def _engine_ok() -> bool:
+    """True when the installed blitz-py meets the pipeline's floor."""
+    if not (HAS_BLITZ and hasattr(blitz_py, "render_layers")):
         return False
     try:
         from importlib.metadata import version  # noqa: PLC0415
 
         parts = tuple(int(p) for p in version("blitz-py").split(".")[:3])
-    except Exception:  # pragma: no cover - metadata should always resolve
-        return False
-    return parts >= (0, 4, 1)
+    except Exception:  # pragma: no cover - source installs without metadata
+        return True  # API surface is there — trust it
+    return parts >= _ENGINE_FLOOR
 
 
-HAS_LAYER_CLOCK = _has_layer_clock()
+HAS_ENGINE = _engine_ok()
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -105,22 +103,49 @@ def get_font_bytes() -> tuple[bytes, ...]:
     return tuple(fonts)
 
 
-@lru_cache(maxsize=1)
-def _fonts_registered() -> bool:
-    """Register the embedded faces process-wide (blitz-py >= 0.4.0).
+class _FontRegistry:
+    """One-time process-wide font registration, serialized by a lock.
 
-    Registration happens once, before any render or measurement, so
-    every later call sees the same collection deterministically. Returns
-    False on older blitz-py, where callers pass bytes per call instead.
+    The lock matters: no thread may measure or render against a
+    half-mutated global font collection — a divergence between measured
+    widths and drawn glyphs is exactly how text ends up painted over
+    the panel edge.
     """
-    if not HAS_FONT_REGISTRY:
-        return False
-    try:
-        blitz_py.register_fonts(list(get_font_bytes()), default_family="Nunito")
-    except Exception:  # pragma: no cover - registration is best-effort
-        _LOGGER.exception("Font registration failed; falling back to per-call fonts")
-        return False
-    return True
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state: bool | None = None
+
+    def registered(self) -> bool:
+        """Register the embedded faces exactly once; report the outcome.
+
+        Returns False when the engine has no registry (ancient
+        blitz-py) or registration failed — callers then pass font bytes
+        per call instead.
+        """
+        if self._state is None:
+            with self._lock:
+                if self._state is None:
+                    self._state = self._register()
+        return self._state
+
+    def _register(self) -> bool:
+        if not (HAS_BLITZ and hasattr(blitz_py, "register_fonts")):
+            return False
+        try:
+            blitz_py.register_fonts(list(get_font_bytes()), default_family="Nunito")
+        except Exception:  # pragma: no cover - registration is best-effort
+            _LOGGER.exception("Font registration failed; falling back to per-call fonts")
+            return False
+        return True
+
+
+_FONT_REGISTRY = _FontRegistry()
+
+
+def _fonts_registered() -> bool:
+    """True once the process-wide registry holds the embedded faces."""
+    return _FONT_REGISTRY.registered()
 
 
 def font_param() -> list[bytes] | None:
@@ -313,21 +338,29 @@ def render_layers_image(
     height: int,
     background: str = "#000000",
 ) -> Image.Image | None:
-    """Composite documents into one surface engine-side (blitz-py >= 0.4).
+    """Composite documents into one surface engine-side (blitz-py >= 0.4.2).
 
     ``layers`` follow the ``blitz_py.render_layers`` contract: ``html``
     (+ ``width``/``height`` in CSS px), device-px ``x``/``y``, optional
     ``scale``, ``opacity``, ``blur``, ``tint`` and ``time``. Layers paint
-    in list order and are clipped to their rects — the same containment
-    per-cell rasterization used to provide. ``width``/``height`` here are
-    the surface size in device px. Returns an RGB image, or None when
-    layered rendering is unavailable or fails (callers fall back to the
-    per-document + Pillow path).
+    in list order and are clipped to their rects. ``width``/``height``
+    here are the surface size in device px. Returns an RGB image, or
+    None when layered rendering is unavailable or fails.
     """
-    if not HAS_LAYERS:
+    if not HAS_ENGINE:
         return None
     try:
-        _fonts_registered()
+        # When the process-wide registry is live, layers see the
+        # embedded faces automatically. When it is not (registration
+        # failed), the fonts MUST ride each layer: measurement used the
+        # embedded faces via per-call bytes, and letting the render fall
+        # back to different fonts is how fitted text overflows the cell.
+        fonts = font_param()
+        if fonts is not None:
+            layers = [
+                {**layer, "fonts": fonts} if "html" in layer and "fonts" not in layer else layer
+                for layer in layers
+            ]
         w, h, data = blitz_py.render_layers(
             layers, width=width, height=height, background=background
         )
@@ -335,30 +368,6 @@ def render_layers_image(
     except Exception:
         _LOGGER.exception("Blitz layered render failed")
         return None
-
-
-def composite_premultiplied(canvas: Image.Image, source: Image.Image, pos: tuple[int, int]) -> None:
-    """Composite a PREMULTIPLIED-alpha RGBA image onto an RGB canvas.
-
-    ``blitz_py.render_rgba`` returns premultiplied alpha. Pasting that
-    through PIL's straight-alpha mask (``paste(img, pos, img)``) applies
-    alpha twice, crushing translucent pixels (a 16% tint lands at ~3%).
-    Correct premultiplied-over is ``dst = src + dst * (1 - a)``.
-    """
-    r, g, b, a = source.split()
-    inv = a.point(lambda v: 255 - v)
-    box = (pos[0], pos[1], pos[0] + source.width, pos[1] + source.height)
-    region = canvas.crop(box)
-    dr, dg, db = region.split()[:3]
-    out = Image.merge(
-        "RGB",
-        (
-            ImageChops.add(ImageChops.multiply(dr, inv), r),
-            ImageChops.add(ImageChops.multiply(dg, inv), g),
-            ImageChops.add(ImageChops.multiply(db, inv), b),
-        ),
-    )
-    canvas.paste(out, pos)
 
 
 def image_data_uri(image: Image.Image) -> str:

--- a/custom_components/geekmagic/layouts/base.py
+++ b/custom_components/geekmagic/layouts/base.py
@@ -1,11 +1,11 @@
 """Base layout class.
 
-Layouts compute slot rectangles (pure geometry); rendering happens by
-rasterizing each widget's HTML fragment with the Blitz engine at the
-slot size and alpha-compositing the passes:
+Layouts compute slot rectangles (pure geometry); rendering happens
+engine-side in one ``render_layers`` call per screen (or per animation
+frame):
 
 1. fullscreen theme backdrop
-2. per-slot widget cells (transparent background)
+2. per-slot widget cells (transparent background, clipped to their rects)
 3. optional fullscreen theme overlay (scanlines, vignettes)
 """
 
@@ -18,16 +18,10 @@ from typing import TYPE_CHECKING
 
 from ..const import DISPLAY_HEIGHT, DISPLAY_WIDTH
 from ..htmldoc import (
-    HAS_BLITZ,
-    HAS_FRAMES,
-    HAS_LAYER_CLOCK,
-    HAS_LAYERS,
+    HAS_ENGINE,
     CellContext,
     build_cell_document,
     build_fullscreen_document,
-    composite_premultiplied,
-    render_document,
-    render_document_frames,
     render_layers_image,
 )
 from ..widgets.state import WidgetState
@@ -265,10 +259,11 @@ class Layout(ABC):
     ) -> None:
         """Render the screen through the Blitz pipeline.
 
-        On blitz-py >= 0.4.0 the whole screen — theme backdrop, widget
-        cells at their slot rects, optional overlay — is composited
-        engine-side in one ``render_layers`` call. Older engines fall
-        back to per-document rendering with Pillow compositing.
+        The whole screen — theme backdrop, widget cells at their slot
+        rects, optional overlay — is composited engine-side in one
+        ``render_layers`` call. A missing or too-old engine paints the
+        install-hint screen instead (manifest.json pins the version, so
+        this only happens on broken installs).
 
         Args:
             renderer: Renderer instance (canvas scale + encoding)
@@ -279,7 +274,7 @@ class Layout(ABC):
         scale = renderer.scale
         theme = self.theme
 
-        if not HAS_BLITZ:
+        if not HAS_ENGINE:
             self._render_missing_blitz(canvas, draw)
             return
 
@@ -287,53 +282,22 @@ class Layout(ABC):
             widget_states = {}
         cells = self._cell_documents(widget_states)
 
-        if HAS_LAYERS:
-            layers = [
-                {k: v for k, v in spec.items() if not k.startswith("_")}
-                for spec in self._layer_specs(cells, scale)
-            ]
-            surface = render_layers_image(
-                layers,
-                self.width * scale,
-                self.height * scale,
-                background=_css_hex(theme.background),
-            )
-            if surface is not None:
-                canvas.paste(surface, (0, 0))
-                return
-            # Engine-side compositing failed — fall through to legacy.
-
-        self._render_legacy(canvas, cells, scale)
-
-    def _render_legacy(
-        self, canvas: Image.Image, cells: list[tuple[Slot, str, bool]], scale: int
-    ) -> None:
-        """Per-document rendering + Pillow compositing (blitz-py < 0.4)."""
-        theme = self.theme
-        backdrop_css = theme.backdrop_css or "body { background: var(--bg); }"
-        backdrop = render_document(
-            build_fullscreen_document(theme, backdrop_css), self.width, self.height, scale=scale
+        layers = [
+            {k: v for k, v in spec.items() if not k.startswith("_")}
+            for spec in self._layer_specs(cells, scale)
+        ]
+        surface = render_layers_image(
+            layers,
+            self.width * scale,
+            self.height * scale,
+            background=_css_hex(theme.background),
         )
-        if backdrop is not None:
-            canvas.paste(backdrop.convert("RGB"), (0, 0))
-
-        for slot, document, _animated in cells:
-            x1, y1, x2, y2 = slot.rect
-            cell = render_document(document, x2 - x1, y2 - y1, scale=scale)
-            if cell is not None:
-                # Blitz returns premultiplied alpha — a plain
-                # paste-with-mask would apply alpha twice.
-                composite_premultiplied(canvas, cell, (x1 * scale, y1 * scale))
-
-        if theme.overlay_css:
-            overlay = render_document(
-                build_fullscreen_document(theme, theme.overlay_css),
-                self.width,
-                self.height,
-                scale=scale,
-            )
-            if overlay is not None:
-                composite_premultiplied(canvas, overlay, (0, 0))
+        if surface is not None:
+            canvas.paste(surface, (0, 0))
+        else:
+            # Engine failure is logged by render_layers_image; keep the
+            # canvas on the theme background rather than uploading noise.
+            draw.rectangle((0, 0, canvas.width, canvas.height), fill=theme.background)
 
     def has_animated_widgets(self) -> bool:
         """True when any placed widget opted into animation."""
@@ -348,13 +312,12 @@ class Layout(ABC):
         """Render the screen at several animation timestamps.
 
         Static passes (backdrop, non-animated cells) render once and are
-        shared across frames; each animated cell renders all its frames
-        in a single ``render_frames`` call. Returns one supersampled RGB
+        shared across frames engine-side. Returns one supersampled RGB
         canvas per timestamp (encode with :meth:`Renderer.to_gif`), or
-        None when frame rendering is unavailable — callers fall back to
-        the still pipeline.
+        None when the engine is unavailable or a frame fails — callers
+        fall back to the still pipeline.
         """
-        if not (HAS_BLITZ and HAS_FRAMES) or not times:
+        if not HAS_ENGINE or not times:
             return None
         if widget_states is None:
             widget_states = {}
@@ -365,93 +328,31 @@ class Layout(ABC):
         # One layered call per frame: animated layers (and their glow
         # underlays) get the frame's clock, static layers render
         # identically each time, and the overlay composites in the same
-        # call. Needs the per-layer time fix from blitz-py 0.4.1 —
-        # 0.4.0 documented ``time`` but ignored it.
-        if HAS_LAYERS and HAS_LAYER_CLOCK:
-            specs = self._layer_specs(cells, scale)
-            canvases: list[Image.Image] = []
-            for t in times:
-                layers = []
-                for spec in specs:
-                    layer = {k: v for k, v in spec.items() if not k.startswith("_")}
-                    if spec.get("_animated"):
-                        layer["time"] = t
-                    layers.append(layer)
-                surface = render_layers_image(
-                    layers,
-                    self.width * scale,
-                    self.height * scale,
-                    background=_css_hex(theme.background),
-                )
-                if surface is None:
-                    canvases = []
-                    break
-                canvases.append(surface)
-            if canvases:
-                return canvases
-            # Engine-side compositing failed — fall through to legacy.
-
-        return self._render_animation_legacy(renderer, cells, times, scale)
-
-    def _render_animation_legacy(
-        self,
-        renderer: Renderer,
-        cells: list[tuple[Slot, str, bool]],
-        times: list[float],
-        scale: int,
-    ) -> list[Image.Image] | None:
-        """Frame rendering with Pillow compositing (blitz-py < 0.4)."""
-        theme = self.theme
-
-        # Static base: backdrop + every non-animated cell, rendered once.
-        base, _ = renderer.create_canvas(background=theme.background)
-        animated: list[tuple[tuple[int, int], list[Image.Image]]] = []
-
-        backdrop_css = theme.backdrop_css or "body { background: var(--bg); }"
-        backdrop = render_document(
-            build_fullscreen_document(theme, backdrop_css), self.width, self.height, scale=scale
-        )
-        if backdrop is not None:
-            base.paste(backdrop.convert("RGB"), (0, 0))
-
-        for slot, document, is_animated in cells:
-            x1, y1, x2, y2 = slot.rect
-            cell_w, cell_h = x2 - x1, y2 - y1
-            pos = (x1 * scale, y1 * scale)
-            if is_animated:
-                frames = render_document_frames(document, cell_w, cell_h, times, scale=scale)
-                if frames:
-                    animated.append((pos, frames))
-                    continue
-                # Frame render failed — fall through to a still cell.
-            cell = render_document(document, cell_w, cell_h, scale=scale)
-            if cell is not None:
-                composite_premultiplied(base, cell, pos)
-
-        overlay = None
-        if theme.overlay_css:
-            overlay = render_document(
-                build_fullscreen_document(theme, theme.overlay_css),
-                self.width,
-                self.height,
-                scale=scale,
-            )
-
+        # call.
+        specs = self._layer_specs(cells, scale)
         canvases: list[Image.Image] = []
-        for i in range(len(times)):
-            frame = base.copy()
-            for pos, frames in animated:
-                cell_frame = frames[min(i, len(frames) - 1)]
-                composite_premultiplied(frame, cell_frame, pos)
-            if overlay is not None:
-                composite_premultiplied(frame, overlay, (0, 0))
-            canvases.append(frame)
+        for t in times:
+            layers = []
+            for spec in specs:
+                layer = {k: v for k, v in spec.items() if not k.startswith("_")}
+                if spec.get("_animated"):
+                    layer["time"] = t
+                layers.append(layer)
+            surface = render_layers_image(
+                layers,
+                self.width * scale,
+                self.height * scale,
+                background=_css_hex(theme.background),
+            )
+            if surface is None:
+                return None
+            canvases.append(surface)
         return canvases
 
     def _render_missing_blitz(self, canvas: Image.Image, draw: ImageDraw.ImageDraw) -> None:
-        """Paint an instructive error screen when blitz-py is missing."""
+        """Paint an instructive error screen when blitz-py is missing/old."""
         draw.rectangle((0, 0, canvas.width, canvas.height), fill=(0, 0, 0))
-        message = "blitz-py required\npip install blitz-py"
+        message = "blitz-py >= 0.4.2 required\npip install -U blitz-py"
         draw.text(
             (canvas.width // 2, canvas.height // 2),
             message,

--- a/custom_components/geekmagic/widgets/_textfit.py
+++ b/custom_components/geekmagic/widgets/_textfit.py
@@ -25,11 +25,15 @@ tracked upstream in the blitz-py repo (docs/UPSTREAM.md there).
 
 from __future__ import annotations
 
+import logging
+import math
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from .helpers import truncate_text
+
+_LOGGER = logging.getLogger(__name__)
 
 try:
     import blitz_py as _blitz
@@ -56,7 +60,8 @@ _WEIGHT_NUM = {"regular": 400.0, "semibold": 600.0, "bold": 700.0, "extrabold": 
 _REF_PX = 200
 
 # Fallback average glyph width (em) when blitz-py is unavailable (the
-# integration then only ever draws the install-hint screen anyway).
+# integration then only ever draws the install-hint screen anyway) or a
+# measurement comes back degenerate.
 _FALLBACK_EM = 0.60
 
 
@@ -85,6 +90,17 @@ def _ref_width(text: str, family: str, weight: str) -> float:
     Shaped by the engine itself (Parley over the embedded collection,
     with the same system fallback the renderer uses), so the number IS
     what lands on the panel.
+
+    The whole fitting system is open-loop: Python predicts, the engine
+    draws, and Blitz paints any overflow straight over the panel edge.
+    Every prediction funnels through here, so a degenerate measurement
+    (NaN or <= 0 for non-empty text — seen in the field when an
+    engine's font state goes wrong) must not pass through: comparisons
+    against NaN are all False, which makes ``fit_hero`` skip both the
+    width bound and truncation and paint the value at the height cap,
+    massively overflowing the cell. Fall back to a conservative
+    per-character estimate instead — slightly small text beats text
+    clipped at the bezel.
     """
     if _measure_text is None:  # pragma: no cover - install-hint path only
         return len(text) * _REF_PX * _FALLBACK_EM
@@ -95,7 +111,21 @@ def _ref_width(text: str, family: str, weight: str) -> float:
         font_weight=_WEIGHT_NUM.get(weight, 600.0),
         fonts=_fonts(),
     )
-    return float(width)
+    width = float(width)
+    if not math.isfinite(width) or width <= 0.0:
+        _warn_measurement_broken()
+        _LOGGER.debug("measure_text returned %r for %r; using the estimate", width, text)
+        return len(text) * _REF_PX * _FALLBACK_EM
+    return width
+
+
+@lru_cache(maxsize=1)
+def _warn_measurement_broken() -> None:
+    """One loud warning per process; per-string details go to debug."""
+    _LOGGER.warning(
+        "blitz-py text measurement returned degenerate widths; falling back to "
+        "estimated glyph widths (text may render slightly smaller than optimal)"
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/test_htmldoc_fonts.py
+++ b/tests/test_htmldoc_fonts.py
@@ -1,0 +1,71 @@
+"""Font-state guarantees of the layered render path.
+
+Measurement (``_textfit``) and rendering must always see the same font
+collection: measuring with the embedded faces while the render falls
+back to different fonts is how Python-fitted text overflows its cell.
+When the process-wide registry is live, layers inherit it; when
+registration failed, the embedded font bytes must ride every html layer
+instead.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from custom_components.geekmagic import htmldoc
+
+
+class TestLayerFonts:
+    """render_layers_image keeps measure and render on the same fonts."""
+
+    def _captured_layers(self, layers):
+        captured = {}
+
+        def fake_render_layers(layers, *, width, height, background):
+            captured["layers"] = layers
+            return (width, height, bytes(width * height * 4))
+
+        with (
+            patch.object(htmldoc.blitz_py, "render_layers", fake_render_layers),
+            patch.object(htmldoc, "HAS_ENGINE", True),
+        ):
+            assert htmldoc.render_layers_image(layers, 10, 10) is not None
+        return captured["layers"]
+
+    def test_registry_live_layers_untouched(self):
+        with patch.object(htmldoc, "font_param", return_value=None):
+            layers = self._captured_layers([{"html": "<body>x</body>", "width": 5, "height": 5}])
+        assert "fonts" not in layers[0]
+
+    def test_registry_down_fonts_ride_each_layer(self):
+        font_bytes = [b"fake-font"]
+        with patch.object(htmldoc, "font_param", return_value=font_bytes):
+            layers = self._captured_layers(
+                [
+                    {"html": "<body>x</body>", "width": 5, "height": 5},
+                    {"html": "<body>y</body>", "width": 5, "height": 5, "fonts": [b"own"]},
+                ]
+            )
+        assert layers[0]["fonts"] == font_bytes
+        # A layer that already carries fonts keeps them.
+        assert layers[1]["fonts"] == [b"own"]
+
+    def test_fonts_registered_is_thread_safe_and_sticky(self):
+        """Concurrent first calls register exactly once."""
+        import threading
+
+        calls = []
+
+        def fake_register(fonts, *, default_family=None):
+            calls.append(default_family)
+            return ["Nunito"]
+
+        registry = htmldoc._FontRegistry()
+        with patch.object(htmldoc.blitz_py, "register_fonts", fake_register):
+            threads = [threading.Thread(target=registry.registered) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        assert calls == ["Nunito"]
+        assert registry.registered() is True

--- a/tests/widgets/test_textfit_degenerate.py
+++ b/tests/widgets/test_textfit_degenerate.py
@@ -1,0 +1,98 @@
+"""Degenerate-measurement regression tests (the "massive text" bug).
+
+Field report: on some installs the engine's text measurement came back
+degenerate (NaN / zero) while rendering still drew real glyphs. Every
+comparison against NaN is False, so ``fit_hero`` skipped both its width
+bound and its truncation pass and sized the hero to the HEIGHT budget
+alone — values painted at ~45px across the full panel and clipped at
+the bezel. These tests pin the choke-point fallback in
+``_textfit._ref_width``: a broken measurement must degrade to the
+conservative per-character estimate, never to an overflow.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from custom_components.geekmagic.htmldoc import CellContext
+from custom_components.geekmagic.widgets import _textfit
+from custom_components.geekmagic.widgets._cardfit import cell_box, fit_hero
+from custom_components.geekmagic.widgets._textfit import TextMetrics
+from custom_components.geekmagic.widgets.base import WidgetConfig
+from custom_components.geekmagic.widgets.entity import EntityWidget
+from custom_components.geekmagic.widgets.state import EntityState, WidgetState
+from custom_components.geekmagic.widgets.theme import DEFAULT_THEME
+
+
+@pytest.fixture(params=[float("nan"), 0.0, -1.0], ids=["nan", "zero", "negative"])
+def broken_measurer(request, monkeypatch):
+    """measure_text returning a degenerate width, as seen in the field."""
+
+    def _measure(text, **kwargs):
+        return (request.param, 40.0)
+
+    monkeypatch.setattr(_textfit, "_measure_text", _measure)
+    _textfit._ref_width.cache_clear()
+    _textfit._warn_measurement_broken.cache_clear()
+    yield request.param
+    _textfit._ref_width.cache_clear()
+    _textfit._warn_measurement_broken.cache_clear()
+
+
+class TestDegenerateMeasurementFallback:
+    """_ref_width must never propagate NaN/non-positive widths."""
+
+    def test_width_falls_back_to_estimate(self, broken_measurer):
+        metrics = TextMetrics()
+        width = metrics.width("1am Wet tray", 33.2, "extrabold")
+        estimate = len("1am Wet tray") * 0.60 * 33.2
+        assert math.isfinite(width)
+        assert width == pytest.approx(estimate)
+
+    def test_fit_hero_stays_width_bound(self, broken_measurer):
+        """The photo scenario: 228x111 split cell, 12-char value.
+
+        With a sane measurement the hero is width-bound around 30-36px.
+        With a degenerate one it must NOT jump to the ~45px height cap —
+        the fallback estimate keeps the width bound in force.
+        """
+        ctx = CellContext(width=228, height=111, slot_index=0, theme=DEFAULT_THEME)
+        box_w, _box_h = cell_box(ctx)
+        fit = fit_hero("1am Wet tray", ctx, box_w, 38.0, max_px=124.0, min_px=12.0)
+        assert math.isfinite(fit.px)
+        # Fallback estimate: 12 chars * 0.6em -> box_w / 7.2em ~= 29px.
+        assert fit.px <= box_w / (len("1am Wet tray") * 0.60) + 0.1
+
+    def test_entity_widget_emits_bounded_hero(self, broken_measurer):
+        """End to end: the rendered fragment carries a width-safe size."""
+        widget = EntityWidget(
+            WidgetConfig(
+                widget_type="entity",
+                entity_id="sensor.feed",
+                label="Steve's next feed",
+                options={"icon": "cat"},
+            )
+        )
+        ctx = CellContext(width=228, height=111, slot_index=0, theme=DEFAULT_THEME)
+        state = WidgetState(entity=EntityState(entity_id="sensor.feed", state="1am Wet tray"))
+        fragment = widget.render_html(ctx, state)
+        sizes = [
+            float(chunk.split("px")[0])
+            for chunk in fragment.split("font-size: ")[1:]
+            if chunk.split("px")[0].replace(".", "").isdigit()
+        ]
+        hero_px = max(sizes)
+        # box_w ~= 212; the fallback estimate allows at most ~29px for a
+        # 12-char value. The broken-measurement failure mode was ~45px
+        # (the height cap); anything close to it means the width bound
+        # was skipped again.
+        assert hero_px < 32.0
+
+    def test_warns_once(self, broken_measurer, caplog):
+        with caplog.at_level("DEBUG", logger=_textfit.__name__):
+            TextMetrics().width("first string", 20.0)
+            TextMetrics().width("second string", 20.0)
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1


### PR DESCRIPTION
Field report ("massive text" after 1.3.x): on some installs the
engine's measure_text returns 0 (or NaN) while rendering still draws
real glyphs. Every fitting decision funnels through _ref_width and
trusted that number blindly: a zero/NaN width disables fit_hero's
width bound AND its truncation pass (every comparison is False), so
heroes get sized to the height budget alone and paint across the
panel, clipped at the bezel — reproduced pixel-for-pixel against the
reported photo.

Degenerate measurements now degrade to the conservative 0.6em/char
estimate (one loud warning per process): slightly small text instead
of text over the bezel.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Xqjq2SCvD3JJv5MUTgz5b