### PR TITLE
fix: normalize brightness readings to prevent impossible percentages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,13 @@ GET  /set?brt={0-100}        # Set brightness
 GET  /app.json               # Get device state
 ```
 
+Brightness is a percentage on the way in but not always on the way out:
+`/set?brt=` takes 0-100, while some Pro firmware writes the level back to
+`/.sys/brt.json` as an inverted 8-bit value (the device's own settings page
+renders `255 - brt`). `FirmwareProfile.normalize_brightness` maps readings
+back to a percentage and discards anything that is neither — never surface a
+raw reading as a level (issue #172).
+
 ## Display Constraints
 
 - Resolution: 240x240 pixels

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,13 @@ GET  /set?brt={0-100}        # Set brightness
 GET  /app.json               # Get device state
 ```
 
+Brightness is a percentage on the way in but not always on the way out:
+`/set?brt=` takes 0-100, while some Pro firmware writes the level back to
+`/.sys/brt.json` as an inverted 8-bit value (the device's own settings page
+renders `255 - brt`). `FirmwareProfile.normalize_brightness` maps readings
+back to a percentage and discards anything that is neither — never surface a
+raw reading as a level (issue #172).
+
 ## Display Constraints
 
 - Resolution: 240x240 pixels

--- a/custom_components/geekmagic/coordinator.py
+++ b/custom_components/geekmagic/coordinator.py
@@ -994,6 +994,35 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
 
         return layout
 
+    async def _async_poll_brightness(self) -> None:
+        """Refresh the cached device brightness on first update and every 10 min."""
+        now = time.time()
+        if (
+            self._last_brightness_poll != 0
+            and now - self._last_brightness_poll < self._brightness_poll_interval
+        ):
+            return
+
+        try:
+            brightness = await self.device.get_brightness()
+        except Exception as e:
+            _LOGGER.debug("Failed to poll device brightness: %s", e)
+            return
+
+        self._last_brightness_poll = now
+        if brightness is None:
+            # The firmware reported a level that is not a percentage (some Pro
+            # builds write back a raw 0-255 value). Keep the last known
+            # brightness instead of publishing an impossible one.
+            _LOGGER.debug(
+                "Unusable device brightness reading; keeping %s",
+                self._device_brightness,
+            )
+            return
+
+        self._device_brightness = brightness
+        _LOGGER.debug("Polled device brightness: %d", brightness)
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data and update display.
 
@@ -1059,18 +1088,7 @@ class GeekMagicCoordinator(DataUpdateCoordinator):
                         self._current_screen,
                     )
 
-            # Poll device brightness on first update and every 10 minutes
-            now = time.time()
-            if (
-                self._device_brightness is None
-                or now - self._last_brightness_poll >= self._brightness_poll_interval
-            ):
-                try:
-                    self._device_brightness = await self.device.get_brightness()
-                    self._last_brightness_poll = now
-                    _LOGGER.debug("Polled device brightness: %d", self._device_brightness)
-                except Exception as e:
-                    _LOGGER.debug("Failed to poll device brightness: %s", e)
+            await self._async_poll_brightness()
 
             # Fetch device state and storage info
             try:

--- a/custom_components/geekmagic/device.py
+++ b/custom_components/geekmagic/device.py
@@ -223,8 +223,8 @@ class GeekMagicDevice:
         """Get storage information."""
         return await self.profile.get_space()
 
-    async def get_brightness(self) -> int:
-        """Get current brightness."""
+    async def get_brightness(self) -> int | None:
+        """Get current brightness, or None when the device reading is unusable."""
         return await self.profile.get_brightness()
 
     async def set_brightness(self, value: int) -> None:

--- a/custom_components/geekmagic/entities/number.py
+++ b/custom_components/geekmagic/entities/number.py
@@ -60,9 +60,11 @@ class GeekMagicBrightnessNumber(GeekMagicEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set brightness."""
-        brightness = int(value)
+        low, high = self.coordinator.device.capabilities.brightness_range
+        brightness = max(low, min(high, int(value)))
         await self.coordinator.device.set_brightness(brightness)
-        # Update local cache immediately so UI reflects change
+        # Update local cache immediately so UI reflects change. The device
+        # clamps to its own range, so cache the clamped value.
         self.coordinator.device_brightness = brightness
         self.async_write_ha_state()
 

--- a/custom_components/geekmagic/profiles.py
+++ b/custom_components/geekmagic/profiles.py
@@ -133,6 +133,8 @@ class FirmwareProfile:
         self._last_theme: int | None = None
         self._last_image: str | None = None
         self._image_select_rejected = False
+        self._brightness_domain_logged = False
+        self._brightness_inversion_logged = False
 
     @property
     def capabilities(self) -> FirmwareCapabilities:
@@ -183,7 +185,21 @@ class FirmwareProfile:
             return None
         if 0 <= raw <= BRIGHTNESS_PERCENT_MAX:
             return raw
-        _LOGGER.debug("Ignoring out-of-range brightness reading: %s", raw)
+        if self._brightness_domain_logged:
+            _LOGGER.debug("Ignoring out-of-range brightness reading: %s", raw)
+        else:
+            # Warn once per session: the scale this firmware reports in is
+            # unknown, and the raw value is what a bug report needs.
+            self._brightness_domain_logged = True
+            _LOGGER.warning(
+                "Device %s (%s) reported brightness %s, which is not a 0-100 "
+                "percentage; keeping the last known level. Please report this "
+                "raw value and your firmware version to the integration issue "
+                "tracker so the scale can be mapped",
+                self.transport.host,
+                self.firmware_version or "unknown firmware",
+                raw,
+            )
         return None
 
     async def get_state(self) -> DeviceState:
@@ -520,7 +536,19 @@ class StockProProfile(FirmwareProfile):
         if raw is not None and raw > BRIGHTNESS_PERCENT_MAX:
             inverted = BRIGHTNESS_INTERNAL_MAX - raw
             if 0 <= inverted <= BRIGHTNESS_PERCENT_MAX:
-                _LOGGER.debug("Inverted Pro brightness reading %d -> %d", raw, inverted)
+                if self._brightness_inversion_logged:
+                    _LOGGER.debug("Inverted Pro brightness reading %d -> %d", raw, inverted)
+                else:
+                    # Say it once at info level: the mapping is read off the
+                    # firmware's own settings page, so a user who sees a level
+                    # that disagrees with the display can report it.
+                    self._brightness_inversion_logged = True
+                    _LOGGER.info(
+                        "Device reported brightness %d on the firmware's internal "
+                        "scale; reading it as %d%%",
+                        raw,
+                        inverted,
+                    )
                 return inverted
         return super().normalize_brightness(raw)
 

--- a/custom_components/geekmagic/profiles.py
+++ b/custom_components/geekmagic/profiles.py
@@ -63,6 +63,16 @@ PRO_PICTURE_WARNING = (
     "on the device; the integration will not press menu buttons automatically."
 )
 
+# Brightness is a percentage everywhere in the integration; `brightness_range`
+# only narrows what a profile is allowed to WRITE.
+BRIGHTNESS_PERCENT_MAX = 100
+
+# Pro firmware stores the backlight level as an inverted 8-bit value; the
+# device's own settings page renders it as `255 - brt` (see
+# docs/devices/new-pro/report.md). A reading above 100 is therefore a raw
+# internal value, not a percentage.
+BRIGHTNESS_INTERNAL_MAX = 255
+
 
 def optional_int(value: object) -> int | None:
     """Parse an optional integer value returned by device JSON."""
@@ -163,10 +173,24 @@ class FirmwareProfile:
         """Return built-in display modes."""
         return self.capabilities.builtin_modes
 
+    def normalize_brightness(self, raw: int | None) -> int | None:
+        """Return a device brightness reading as a percentage, or None.
+
+        Readings outside 0-100 cannot be percentages, so they are discarded
+        rather than surfaced as an impossible level.
+        """
+        if raw is None:
+            return None
+        if 0 <= raw <= BRIGHTNESS_PERCENT_MAX:
+            return raw
+        _LOGGER.debug("Ignoring out-of-range brightness reading: %s", raw)
+        return None
+
     async def get_state(self) -> DeviceState:
         """Get current device state."""
         data = await self.transport.get_json("/app.json")
         state = state_from_stock_data(data)
+        state.brightness = self.normalize_brightness(state.brightness)
         _LOGGER.debug(
             "Device state: theme=%s, brightness=%s, image=%s",
             state.theme,
@@ -190,11 +214,11 @@ class FirmwareProfile:
         )
         return space
 
-    async def get_brightness(self) -> int:
+    async def get_brightness(self) -> int | None:
         """Get current brightness from device."""
         data = await self.transport.get_json("/brt.json")
-        brightness = optional_int(data.get("brt")) or 0
-        _LOGGER.debug("Device brightness: %d", brightness)
+        brightness = self.normalize_brightness(optional_int(data.get("brt")))
+        _LOGGER.debug("Device brightness: %s", brightness)
         return brightness
 
     async def set_brightness(self, value: int) -> None:
@@ -465,6 +489,7 @@ class StockProProfile(FirmwareProfile):
                 raise
             else:
                 state = state_from_stock_data(data)
+                state.brightness = self.normalize_brightness(state.brightness)
                 _LOGGER.debug(
                     "Device state: theme=%s, brightness=%s, image=%s",
                     state.theme,
@@ -483,11 +508,27 @@ class StockProProfile(FirmwareProfile):
 
         raise RuntimeError("Device state was not read")
 
-    async def get_brightness(self) -> int:
+    def normalize_brightness(self, raw: int | None) -> int | None:
+        """Map a Pro reading to a percentage, undoing the firmware inversion.
+
+        `/set?brt=` takes 0-100, but the firmware also writes the backlight
+        level back on its own (after a reboot or a night-mode transition) as
+        an inverted 8-bit value — which is why the device's settings page
+        renders `255 - brt`. A reading above 100 is therefore an internal
+        value: invert it back before falling through to the range check.
+        """
+        if raw is not None and raw > BRIGHTNESS_PERCENT_MAX:
+            inverted = BRIGHTNESS_INTERNAL_MAX - raw
+            if 0 <= inverted <= BRIGHTNESS_PERCENT_MAX:
+                _LOGGER.debug("Inverted Pro brightness reading %d -> %d", raw, inverted)
+                return inverted
+        return super().normalize_brightness(raw)
+
+    async def get_brightness(self) -> int | None:
         """Get Pro brightness from /.sys."""
         data = await self.transport.get_json("/.sys/brt.json")
-        brightness = optional_int(data.get("brt")) or 0
-        _LOGGER.debug("Device brightness: %d", brightness)
+        brightness = self.normalize_brightness(optional_int(data.get("brt")))
+        _LOGGER.debug("Device brightness: %s", brightness)
         return brightness
 
     async def get_album_settings(self) -> AlbumSettings:
@@ -555,7 +596,7 @@ class SdProProfile(FirmwareProfile):
         data = await self.transport.get_json("/config")
         return DeviceState(
             theme=optional_int(data.get("theme")),
-            brightness=optional_int(data.get("brightness")),
+            brightness=self.normalize_brightness(optional_int(data.get("brightness"))),
             current_image=None,
         )
 
@@ -564,11 +605,10 @@ class SdProProfile(FirmwareProfile):
         photos = await self.get_sdpro_photo_settings()
         return SpaceInfo(total=photos.total, free=max(0, photos.total - photos.used))
 
-    async def get_brightness(self) -> int:
+    async def get_brightness(self) -> int | None:
         """Get SD_PRO brightness from /config."""
         data = await self.transport.get_json("/config")
-        brightness = optional_int(data.get("brightness"))
-        return brightness or 0
+        return self.normalize_brightness(optional_int(data.get("brightness")))
 
     async def set_brightness(self, value: int) -> None:
         """Set SD_PRO brightness."""

--- a/tests/entities/test_entities.py
+++ b/tests/entities/test_entities.py
@@ -424,3 +424,55 @@ class TestActiveSwitchAttributes:
         switch = GeekMagicActiveSwitch(mock_coordinator)
 
         assert switch._attr_unique_id == "test_entry_123_active"
+
+
+class TestBrightnessNumber:
+    """Tests for the brightness number entity.
+
+    Issue #172: the entity is a 0-100 percentage, so what it reports must
+    always be a percentage — never a raw firmware level.
+    """
+
+    @pytest.fixture
+    def brightness_coordinator(self, mock_coordinator):
+        """Mock coordinator with a brightness-capable device."""
+        mock_coordinator.device.capabilities.brightness_range = (0, 100)
+        mock_coordinator.device.set_brightness = AsyncMock()
+        mock_coordinator.device_brightness = None
+        return mock_coordinator
+
+    def test_native_value_follows_coordinator_cache(self, brightness_coordinator):
+        """The reported value is the coordinator's cached device brightness."""
+        from custom_components.geekmagic.entities.number import GeekMagicBrightnessNumber
+
+        brightness_coordinator.device_brightness = 66
+        entity = GeekMagicBrightnessNumber(brightness_coordinator)
+
+        assert entity.native_value == 66
+
+    @pytest.mark.asyncio
+    async def test_set_caches_written_value(self, brightness_coordinator):
+        """Setting brightness writes to the device and caches the same value."""
+        from custom_components.geekmagic.entities.number import GeekMagicBrightnessNumber
+
+        entity = GeekMagicBrightnessNumber(brightness_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_set_native_value(66)
+
+        brightness_coordinator.device.set_brightness.assert_awaited_once_with(66)
+        assert brightness_coordinator.device_brightness == 66
+
+    @pytest.mark.asyncio
+    async def test_set_caches_value_clamped_to_device_range(self, brightness_coordinator):
+        """Firmware with a narrower range caches what the device actually stores."""
+        from custom_components.geekmagic.entities.number import GeekMagicBrightnessNumber
+
+        brightness_coordinator.device.capabilities.brightness_range = (2, 99)
+        entity = GeekMagicBrightnessNumber(brightness_coordinator)
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_set_native_value(100)
+
+        brightness_coordinator.device.set_brightness.assert_awaited_once_with(99)
+        assert brightness_coordinator.device_brightness == 99

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1315,3 +1315,78 @@ class TestAnimationUploadBudget:
         assert filename == "dashboard.jpg"
         assert payload[:3] == b"\xff\xd8\xff"
         mock_gif.assert_not_called()
+
+
+class TestCoordinatorBrightnessPoll:
+    """Tests for the cached device brightness poll.
+
+    Issue #172: some Pro firmware reports the backlight level on a raw 0-255
+    scale, which surfaced as an impossible "155%" on the brightness number.
+    """
+
+    @pytest.fixture
+    def brightness_device(self):
+        """Create a mock device exposing only the brightness calls."""
+        device = MagicMock()
+        device.host = "192.168.1.100"
+        device.model = "unknown"
+        device.get_brightness = AsyncMock(return_value=66)
+        return device
+
+    @pytest.fixture
+    def simple_options(self):
+        """Create simple single-screen options."""
+        return {
+            CONF_REFRESH_INTERVAL: 10,
+            CONF_SCREENS: [
+                {
+                    "name": "Test",
+                    CONF_LAYOUT: LAYOUT_GRID_2X2,
+                    CONF_WIDGETS: [{"type": "clock", "slot": 0}],
+                }
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_poll_caches_device_value(self, hass, brightness_device, simple_options):
+        """A usable reading replaces the cached brightness."""
+        coordinator = GeekMagicCoordinator(hass, brightness_device, simple_options)
+
+        await coordinator._async_poll_brightness()
+
+        assert coordinator.device_brightness == 66
+
+    @pytest.mark.asyncio
+    async def test_unusable_reading_keeps_last_value(self, hass, brightness_device, simple_options):
+        """An unreadable level never overwrites the last known brightness."""
+        coordinator = GeekMagicCoordinator(hass, brightness_device, simple_options)
+        coordinator.device_brightness = 66
+        brightness_device.get_brightness = AsyncMock(return_value=None)
+
+        await coordinator._async_poll_brightness()
+
+        assert coordinator.device_brightness == 66
+
+    @pytest.mark.asyncio
+    async def test_unusable_reading_does_not_poll_every_cycle(
+        self, hass, brightness_device, simple_options
+    ):
+        """A poll that returns None still counts as a poll for scheduling."""
+        coordinator = GeekMagicCoordinator(hass, brightness_device, simple_options)
+        brightness_device.get_brightness = AsyncMock(return_value=None)
+
+        await coordinator._async_poll_brightness()
+        await coordinator._async_poll_brightness()
+
+        assert brightness_device.get_brightness.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_poll_retries_next_cycle(self, hass, brightness_device, simple_options):
+        """A poll that raises is retried on the next update."""
+        coordinator = GeekMagicCoordinator(hass, brightness_device, simple_options)
+        brightness_device.get_brightness = AsyncMock(side_effect=OSError("boom"))
+
+        await coordinator._async_poll_brightness()
+        await coordinator._async_poll_brightness()
+
+        assert brightness_device.get_brightness.await_count == 2

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -241,3 +242,18 @@ async def test_stock_profile_drops_out_of_range_brightness() -> None:
 
     assert await profile.get_brightness() is None
     assert (await profile.get_state()).brightness is None
+
+
+@pytest.mark.asyncio
+async def test_unreadable_brightness_is_logged_once(caplog) -> None:
+    """The first uninterpretable reading warns with the raw value; later ones don't."""
+    transport = FakeTransport({"/brt.json": {"brt": "168"}})
+    profile = StockUltraProfile(transport)
+
+    with caplog.at_level(logging.WARNING):
+        assert await profile.get_brightness() is None
+        assert await profile.get_brightness() is None
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "168" in warnings[0].getMessage()

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -207,3 +207,37 @@ async def test_detects_sdpro_profile_from_theme_list() -> None:
     profile = await detect_firmware_profile(transport)
 
     assert profile.capabilities.profile_id == MODEL_SD_PRO
+
+
+@pytest.mark.asyncio
+async def test_pro_profile_inverts_internal_brightness_readings() -> None:
+    """Pro readings above 100 are the firmware's inverted 0-255 value."""
+    transport = FakeTransport({"/.sys/brt.json": {"brt": "155"}})
+    profile = StockProProfile(transport)
+
+    # The device's own settings page renders `255 - brt`, so 155 means 100%.
+    assert await profile.get_brightness() == 100
+
+
+@pytest.mark.asyncio
+async def test_pro_profile_drops_unreadable_brightness() -> None:
+    """A Pro reading that is a percentage in neither domain is discarded."""
+    transport = FakeTransport({"/.sys/brt.json": {"brt": "130"}})
+    profile = StockProProfile(transport)
+
+    assert await profile.get_brightness() is None
+
+
+@pytest.mark.asyncio
+async def test_stock_profile_drops_out_of_range_brightness() -> None:
+    """Stock readings outside 0-100 are never reported as a percentage."""
+    transport = FakeTransport(
+        {
+            "/brt.json": {"brt": "168"},
+            "/app.json": {"theme": "3", "brt": "168", "img": "/image/old.jpg"},
+        }
+    )
+    profile = StockUltraProfile(transport)
+
+    assert await profile.get_brightness() is None
+    assert (await profile.get_state()).brightness is None


### PR DESCRIPTION
## Summary

Fixes issue #172 where some Pro firmware models report the backlight level as a raw 0-255 inverted value instead of a 0-100 percentage, causing the brightness entity to display impossible values like "155%".

## Changes

- **Brightness normalization**: Added `normalize_brightness()` method to `FirmwareProfile` that validates readings are in the 0-100 range and discards out-of-range values
- **Pro firmware inversion handling**: `StockProProfile.normalize_brightness()` detects readings above 100, inverts them (255 - value), and validates the result — matching how the device's own settings page renders brightness
- **Return type updates**: Changed `get_brightness()` return type from `int` to `int | None` across all profiles to indicate when a reading is unusable
- **Coordinator polling refactor**: Extracted brightness polling logic into `_async_poll_brightness()` method that respects the 10-minute poll interval and preserves the last known brightness when a reading is unusable
- **Entity caching**: Updated `GeekMagicBrightnessNumber` to clamp written values to the device's actual brightness range before caching
- **State normalization**: Applied brightness normalization in `get_state()` methods for all profiles to ensure state readings are also validated

## Implementation Details

- Readings outside 0-100 are logged at debug level and discarded rather than surfaced as impossible percentages
- The polling interval is respected even when a reading returns `None`, preventing excessive device queries
- Device-specific brightness ranges (e.g., 2-99) are applied when writing values, with the clamped value cached to match what the device actually stores
- All brightness readings (from `/brt.json`, `/.sys/brt.json`, `/config`, and `/app.json`) flow through the same normalization pipeline

## Tests

- Added comprehensive test suite for brightness polling behavior (caching, interval respect, error handling)
- Added tests for brightness entity value caching and range clamping
- Added profile tests for Pro inversion logic and out-of-range rejection

https://claude.ai/code/session_018eSbo4fE7Scbp5ANoaSTSU