### PR TITLE
feat: add Show Name option to Status, Chart, Candlestick, Progress and Climate widgets

### DIFF
--- a/custom_components/geekmagic/widgets/candlestick.py
+++ b/custom_components/geekmagic/widgets/candlestick.py
@@ -254,6 +254,12 @@ class CandlestickWidget(Widget):
                 "default": 20,
             },
             {
+                "key": "show_name",
+                "type": "boolean",
+                "label": "Show Name",
+                "default": True,
+            },
+            {
                 "key": "show_value",
                 "type": "boolean",
                 "label": "Show Current Value",
@@ -273,6 +279,7 @@ class CandlestickWidget(Widget):
         super().__init__(config)
         self.candle_interval: str = config.options.get("candle_interval", "4 hours")
         self.candle_count: int = int(config.options.get("candle_count", 20))
+        self.show_name: bool = config.options.get("show_name", True)
         self.show_value: bool = config.options.get("show_value", True)
 
     @property
@@ -317,10 +324,12 @@ class CandlestickWidget(Widget):
             value_color = "var(--success)" if bullish else "var(--error)"
             caret = "menu-up" if bullish else "menu-down"
 
+        # A hidden name leaves the header to the tinted price alone.
+        caption = self.label_for(entity) if self.show_name else ""
         header, header_h = "", 0.0
         if not m.compact:
             header, header_h = self._header(
-                self.label_for(entity),
+                caption,
                 m,
                 tm,
                 current_value=current_value,
@@ -336,7 +345,7 @@ class CandlestickWidget(Widget):
             if current_value is not None:
                 value_text = f"{current_value:.1f}{unit}"
             header, header_h = compact_header(
-                self.label_for(entity),
+                caption,
                 ctx,
                 m,
                 tm,

--- a/custom_components/geekmagic/widgets/chart.py
+++ b/custom_components/geekmagic/widgets/chart.py
@@ -223,6 +223,12 @@ class ChartWidget(Widget):
                 "default": "24 hours",
             },
             {
+                "key": "show_name",
+                "type": "boolean",
+                "label": "Show Name",
+                "default": True,
+            },
+            {
                 "key": "show_value",
                 "type": "boolean",
                 "label": "Show Current Value",
@@ -262,6 +268,7 @@ class ChartWidget(Widget):
             self.hours = period / 60
         else:
             self.hours = config.options.get("hours", 24)
+        self.show_name = config.options.get("show_name", True)
         self.show_value = config.options.get("show_value", True)
         self.show_range = config.options.get("show_range", True)
         self.fill = config.options.get("fill", True)  # Default to filled area
@@ -286,11 +293,14 @@ class ChartWidget(Widget):
         has_data = state.has_history()
         binary = _is_binary_data(data)
 
+        # A hidden name leaves the header to the value alone; with both
+        # off, the whole header band goes and the plot takes its room.
+        caption = self.label_for(entity) if self.show_name else ""
         header, header_h = "", 0.0
         footer, footer_h = "", 0.0
         if not m.compact:
             header, header_h = self._header(
-                self.label_for(entity), m, tm, current_value=current_value, unit=unit, color=color
+                caption, m, tm, current_value=current_value, unit=unit, color=color
             )
             footer, footer_h = self._footer(
                 data, self.show_range and has_data and not binary, m, tm
@@ -304,7 +314,7 @@ class ChartWidget(Widget):
             if self.show_value and current_value is not None:
                 value_text = f"{current_value:.1f}{unit}"
             header, header_h = compact_header(
-                self.label_for(entity),
+                caption,
                 ctx,
                 m,
                 tm,

--- a/custom_components/geekmagic/widgets/climate.py
+++ b/custom_components/geekmagic/widgets/climate.py
@@ -239,6 +239,7 @@ class ClimateWidget(Widget):
         "needs_entity": True,
         "entity_domains": ["climate"],
         "options": [
+            {"key": "show_name", "type": "boolean", "label": "Show Name", "default": True},
             {"key": "show_target", "type": "boolean", "label": "Show Target Temp", "default": True},
             {"key": "show_humidity", "type": "boolean", "label": "Show Humidity", "default": True},
             {"key": "show_mode", "type": "boolean", "label": "Show HVAC Mode", "default": True},
@@ -248,6 +249,7 @@ class ClimateWidget(Widget):
     def __init__(self, config: WidgetConfig) -> None:
         """Initialize the climate widget."""
         super().__init__(config)
+        self.show_name = config.options.get("show_name", True)
         self.show_target = config.options.get("show_target", True)
         self.show_humidity = config.options.get("show_humidity", True)
         self.show_mode = config.options.get("show_mode", True)
@@ -432,8 +434,6 @@ class ClimateWidget(Widget):
         # anonymous temperature (same compact-identity rule as entity).
         compact_identity = not bands_kept and avail_h >= 40.0
         show_caption = bands_kept or compact_identity
-        if show_caption:
-            spent += label_px(ctx)
 
         # Width decides how the pills pack; height decides how many rows
         # the cell can afford. A 2x2 tile keeps only the running state, a
@@ -451,6 +451,13 @@ class ClimateWidget(Widget):
             # enough to afford both.
             mode_in_chips = bool(rows) and self.show_mode
             with_icon = ctx.width >= 150 or not mode_in_chips
+            # A hidden name leaves the band to the state icon alone —
+            # and when the chips already carry the mode, drops it
+            # entirely so the hero gets the height.
+            name = self.label_for(entity) if self.show_name else ""
+            show_caption = bool(name) or with_icon
+        if show_caption:
+            spent += label_px(ctx)
             if with_icon and ctx.width < 150:
                 # The stacked state icon takes its own band (i-md clamp
                 # mirror) — budget it or the hero eats its room.
@@ -458,7 +465,7 @@ class ClimateWidget(Widget):
             bands.append(
                 self._caption_html(
                     ctx,
-                    self.label_for(entity),
+                    name,
                     icon_name,
                     icon_color,
                     with_icon=with_icon,

--- a/custom_components/geekmagic/widgets/progress.py
+++ b/custom_components/geekmagic/widgets/progress.py
@@ -61,6 +61,7 @@ class ProgressWidget(Widget):
         "options": [
             {"key": "target", "type": "number", "label": "Target Value", "default": 100},
             {"key": "unit", "type": "text", "label": "Unit"},
+            {"key": "show_name", "type": "boolean", "label": "Show Name", "default": True},
             {"key": "show_target", "type": "boolean", "label": "Show Target", "default": True},
             {"key": "icon", "type": "icon", "label": "Icon"},
             {
@@ -78,6 +79,7 @@ class ProgressWidget(Widget):
         super().__init__(config)
         self.target = config.options.get("target", 100)
         self.unit = config.options.get("unit", "")
+        self.show_name = config.options.get("show_name", True)
         self.show_target = config.options.get("show_target", True)
         self.icon = config.options.get("icon") or None
         self.bar_height_style = config.options.get("bar_height", "normal")
@@ -91,7 +93,9 @@ class ProgressWidget(Widget):
         if not unit and entity:
             unit = entity.unit or ""
 
-        label = self.label_for(entity, fallback="Progress")
+        # An empty label drops the whole caption band (icon included),
+        # matching the gauge family's show_name behavior.
+        label = self.label_for(entity, fallback="Progress") if self.show_name else ""
 
         target = self.target or 100
         percent = min(100, (value / target) * 100) if target > 0 else 0

--- a/custom_components/geekmagic/widgets/status.py
+++ b/custom_components/geekmagic/widgets/status.py
@@ -256,6 +256,12 @@ class StatusWidget(Widget):
                 "label": "Show Status Text",
                 "default": True,
             },
+            {
+                "key": "show_name",
+                "type": "boolean",
+                "label": "Show Name",
+                "default": True,
+            },
         ],
     }
 
@@ -270,6 +276,7 @@ class StatusWidget(Widget):
         self.off_text = config.options.get("off_text", "OFF")
         self.icon = config.options.get("icon")
         self.show_status_text = config.options.get("show_status_text", True)
+        self.show_name = config.options.get("show_name", True)
 
     def render_html(self, ctx: CellContext, state: WidgetState) -> str:
         """Render the status widget."""
@@ -282,7 +289,7 @@ class StatusWidget(Widget):
             "success" if is_on else "error",
         )
         ind = _Indicator(
-            name=self.label_for(entity, fallback=PLACEHOLDER_NAME),
+            name=self.label_for(entity, fallback=PLACEHOLDER_NAME) if self.show_name else "",
             icon=self.icon or _entity_status_icon(entity) or "circle",
             color=color,
             fill=tint_css(tint, ctx.theme, _CHIP_FILL_ALPHA),
@@ -345,18 +352,21 @@ class StatusWidget(Widget):
         usable_w, usable_h = cell_box_px(ctx, pad_x, pad_y)
         caption_px = label_px(ctx)
 
+        # A hidden name frees its band for the other two: the chip and
+        # the hero split what the caption would have taken.
+        caption_h = caption_px * 1.2 if ind.name else 0.0
         chip_outer = min(max(0.36 * usable_h, 26.0), 104.0, 0.55 * usable_w)
         hero_px = tm.fit_font_size(
             ind.text,
             usable_w * 0.94,
-            0.38 * usable_h,
+            (0.38 if ind.name else 0.44) * usable_h,
             "extrabold",
             tracking=HERO_TRACKING,
             min_px=14.0,
         )
         # Short values leave the height budget unspent — give the slack
         # back to the indicator so the cell never reads half-empty.
-        slack = usable_h - (chip_outer + caption_px * 1.2 + hero_px)
+        slack = usable_h - (chip_outer + caption_h + hero_px)
         if slack > 0.22 * usable_h:
             chip_outer = min(chip_outer + slack * 0.45, 104.0, 0.55 * usable_w)
 
@@ -385,10 +395,12 @@ class StatusWidget(Widget):
         gap = max(7.0, chip_outer * 0.20)
         text_w = usable_w - chip_outer - gap
         inner_gap = max(2.0, usable_h * 0.05)
+        # No name band: the hero gets its height back.
+        caption_h = caption_px * 1.15 + inner_gap if ind.name else 0.0
         hero_px = tm.fit_font_size(
             ind.text,
             text_w,
-            usable_h - caption_px * 1.15 - inner_gap,
+            usable_h - caption_h,
             "extrabold",
             tracking=HERO_TRACKING,
             min_px=14.0,
@@ -450,8 +462,10 @@ class StatusWidget(Widget):
         caption_px = label_px(ctx)
         # An unnamed lozenge is a lamp with no label on it. The caption
         # shrinks instead of disappearing, so it survives every cell with
-        # room for a chip and a 10px word above it.
-        show_caption = usable_h >= _ICON_ONLY_CAPTION_MIN_H
+        # room for a chip and a 10px word above it — unless the user
+        # hid the name outright (issue #180), which leaves the chip the
+        # whole cell.
+        show_caption = bool(ind.name) and usable_h >= _ICON_ONLY_CAPTION_MIN_H
         chip_outer = min(
             usable_h - (caption_px * 1.9 if show_caption else 0.0),
             usable_w * 0.72,

--- a/tests/widgets/test_candlestick.py
+++ b/tests/widgets/test_candlestick.py
@@ -223,6 +223,34 @@ class TestCandlestickRendering:
         # Last candle is bullish, so the value takes the success tint
         assert "var(--success)" in fragment
 
+    def test_show_name_off_drops_caption(self, ctx):
+        """show_name=False keeps the tinted price but drops the label."""
+        config = WidgetConfig(
+            widget_type="candlestick",
+            slot=0,
+            entity_id="sensor.btc",
+            options={"show_name": False},
+        )
+        widget = CandlestickWidget(config)
+
+        state = WidgetState(
+            entity=EntityState(
+                entity_id="sensor.btc",
+                state="106.0",
+                attributes={"friendly_name": "Bitcoin", "unit_of_measurement": "$"},
+            ),
+            candlestick_data=[
+                (100.0, 110.0, 95.0, 105.0),
+                (98.0, 108.0, 90.0, 106.0),
+            ],
+            now=datetime.now(tz=UTC),
+        )
+
+        fragment = widget.render_html(ctx, state)
+        assert "BITC" not in fragment
+        assert "106.0" in fragment  # price header survives
+        assert "<svg" in fragment
+
     def test_render_no_data(self, ctx):
         """Rendering with no data shows 'No data' instead of a chart."""
         config = WidgetConfig(

--- a/tests/widgets/test_widgets.py
+++ b/tests/widgets/test_widgets.py
@@ -1443,6 +1443,20 @@ class TestProgressWidget:
         assert ">0<" in fragment
         assert ">%<" in fragment
 
+    def test_show_name_off_drops_caption(self, ctx):
+        widget = ProgressWidget(
+            WidgetConfig(
+                widget_type="progress",
+                slot=0,
+                entity_id="sensor.steps",
+                options={"target": 10000, "show_name": False},
+            )
+        )
+        entity = make_entity("sensor.steps", "5000", {"friendly_name": "Steps"})
+        fragment = widget.render_html(ctx, make_state(entity))
+        assert "STEPS" not in fragment
+        assert ">50<" in fragment  # percent hero survives
+
 
 # ============================================================================
 # MultiProgressWidget
@@ -1618,6 +1632,37 @@ class TestChartWidget:
         assert "t-value" not in fragment
         assert "hide-short" not in fragment  # visibility decided in Python
 
+    def test_show_name_off_drops_caption(self, ctx):
+        widget = ChartWidget(
+            WidgetConfig(
+                widget_type="chart",
+                slot=0,
+                entity_id="sensor.temperature",
+                options={"show_name": False},
+            )
+        )
+        entity = make_entity(
+            attributes={"friendly_name": "Temperature", "unit_of_measurement": "°C"}
+        )
+        fragment = widget.render_html(ctx, make_state(entity, history=[20.0, 21.0, 23.5]))
+        assert "TEMPERAT" not in fragment
+        assert "23.5" in fragment  # value header survives
+        assert "<svg" in fragment
+
+    def test_show_name_off_compact_keeps_value(self, compact_ctx):
+        widget = ChartWidget(
+            WidgetConfig(
+                widget_type="chart",
+                slot=0,
+                entity_id="sensor.temperature",
+                options={"show_name": False},
+            )
+        )
+        entity = make_entity(attributes={"friendly_name": "Temp"})
+        fragment = widget.render_html(compact_ctx, make_state(entity, history=[20.0, 21.0, 24.0]))
+        assert "TEMP" not in fragment
+        assert "<svg" in fragment
+
     def test_binary_history_draws_square_steps(self, ctx):
         """Bezier smoothing overshoots on binary traces, so it is off."""
         widget = ChartWidget(
@@ -1704,6 +1749,42 @@ class TestClimateWidget:
         # the name (inline, its reserve starved the caption to stubs).
         assert "card-icon" in fragment
         assert "icon i-md" in fragment
+
+    def test_show_name_off_drops_room_name(self, ctx):
+        widget = ClimateWidget(
+            WidgetConfig(
+                widget_type="climate",
+                slot=0,
+                entity_id="climate.thermostat",
+                options={"show_name": False},
+            )
+        )
+        entity = self._thermostat(
+            "heat", current_temperature=21.5, temperature=22, hvac_action="heating"
+        )
+        fragment = widget.render_html(ctx, make_state(entity))
+        assert "THERMOSTAT" not in fragment
+        assert "21.5" in fragment  # hero temperature survives
+        assert "HEATING" in fragment  # mode chip survives
+
+    def test_show_name_off_small_tile_keeps_state_icon(self):
+        """With chips shed (<100px wide) the caption icon is the only
+        carrier of the hvac state — hiding the name must not drop it."""
+        widget = ClimateWidget(
+            WidgetConfig(
+                widget_type="climate",
+                slot=0,
+                entity_id="climate.thermostat",
+                options={"show_name": False},
+            )
+        )
+        entity = self._thermostat(
+            "heat", current_temperature=21.5, temperature=22, hvac_action="heating"
+        )
+        tile = CellContext(width=69, height=108, slot_index=0, theme=DEFAULT_THEME)
+        fragment = widget.render_html(tile, make_state(entity))
+        assert "THERM" not in fragment
+        assert "card-icon" in fragment  # tinted state icon band stays
 
     def test_short_cell_keeps_caption_row(self):
         """Short non-strip cells keep a shrunk caption instead of an

--- a/tests/widgets/test_widgets.py
+++ b/tests/widgets/test_widgets.py
@@ -1105,6 +1105,7 @@ class TestStatusWidget:
         assert widget.on_text == "ON"
         assert widget.off_text == "OFF"
         assert widget.show_status_text is True
+        assert widget.show_name is True
 
     def test_init_with_options(self):
         widget = StatusWidget(
@@ -1196,6 +1197,53 @@ class TestStatusWidget:
         )
         entity = make_entity("binary_sensor.door", "on", {"friendly_name": "Door"})
         fragment = widget.render_html(ctx, make_state(entity))
+        assert ">ON<" not in fragment
+        assert "i-lg" in fragment
+
+    def test_hide_name(self, ctx):
+        """show_name=False drops the name band but keeps the state (issue #180)."""
+        widget = StatusWidget(
+            WidgetConfig(
+                widget_type="status",
+                slot=0,
+                entity_id="binary_sensor.door",
+                options={"show_name": False},
+            )
+        )
+        entity = make_entity("binary_sensor.door", "on", {"friendly_name": "Front Door"})
+        fragment = widget.render_html(ctx, make_state(entity))
+        assert "FRONT DOOR" not in fragment
+        assert ">ON<" in fragment
+
+    def test_hide_name_strip_layout(self):
+        """Wide cells also honor show_name=False (issue #180)."""
+        widget = StatusWidget(
+            WidgetConfig(
+                widget_type="status",
+                slot=0,
+                entity_id="binary_sensor.door",
+                options={"show_name": False},
+            )
+        )
+        strip_ctx = CellContext(width=228, height=74, slot_index=0, theme=DEFAULT_THEME)
+        entity = make_entity("binary_sensor.door", "on", {"friendly_name": "Front Door"})
+        fragment = widget.render_html(strip_ctx, make_state(entity))
+        assert "FRONT DOOR" not in fragment
+        assert ">ON<" in fragment
+
+    def test_hide_name_and_status_text_icon_only(self, ctx):
+        """Both hidden: only the tinted device icon remains (issue #180)."""
+        widget = StatusWidget(
+            WidgetConfig(
+                widget_type="status",
+                slot=0,
+                entity_id="binary_sensor.door",
+                options={"show_name": False, "show_status_text": False, "icon": "door"},
+            )
+        )
+        entity = make_entity("binary_sensor.door", "on", {"friendly_name": "Front Door"})
+        fragment = widget.render_html(ctx, make_state(entity))
+        assert "FRONT DOOR" not in fragment
         assert ">ON<" not in fragment
         assert "i-lg" in fragment
 


### PR DESCRIPTION
Adds a **Show Name** toggle (`show_name`, default on) to every widget that previously always painted the entity name, extending the pattern already used by the Entity and Gauge widgets. Defaults to on everywhere, so existing dashboards are unchanged.

Closes #180

## Per-widget behavior when the name is hidden

- **Status** (the #180 request): the name band is dropped in all four layout variants (stack, strip, compact, icon-only), and the freed height goes back to the indicator chip and state hero. Combined with the existing *Show Status Text* off, the cell shows only the tinted device icon.
- **Chart / Candlestick**: the header keeps the tinted current value/price alone; with the value also hidden (Chart's *Show Current Value*), the whole header goes and the plot takes the full cell. Applies to both the full and compact tile layouts.
- **Progress**: the whole caption band (icon included) is dropped, matching the Gauge family's `show_name` behavior.
- **Climate**: the room name goes, with one nuance: in small tiles where the chip strip is shed, the caption's tinted HVAC icon is the only carrier of the heating/cooling state, so that icon band survives on its own. Where the mode chip carries the state, the caption drops entirely and the temperature hero gets the height back.

## Notes

- No frontend or `strings.json` changes needed: the panel builds option controls generically from the widget schemas, and the `slot_N_show_name` config-flow labels already exist for all slots.
- Attribute List was reviewed and deliberately skipped: its title only falls back to the entity name when no attributes are configured, in which case the title *is* the widget's entire content; with attributes configured, an empty title already hides it.

## Testing

- 9 new regression tests covering defaults, each widget's hidden-name rendering (including Chart compact tiles and the Climate small-tile state-icon case), and the Status icon-only combination.
- Full suite: 950 tests pass; ruff lint/format clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5gYde2i89sdhEjskcGp1V