### PR TITLE
chore: bump version to 1.3.3

### DIFF
--- a/custom_components/geekmagic/manifest.json
+++ b/custom_components/geekmagic/manifest.json
@@ -21,5 +21,5 @@
     "palettable>=3.3.0",
     "blitz-py>=0.5.0"
   ],
-  "version": "1.3.2"
+  "version": "1.3.3"
 }


### PR DESCRIPTION
Bumps `custom_components/geekmagic/manifest.json` version from 1.3.2 to 1.3.3 for the next release.

Changes since 1.3.2:
- feat: add Show Name option to Status widget (#181)
- feat: add Show Name option to chart, candlestick, progress and climate widgets (#181)
- fix: recover display brightness after HA restart clears pause state (#178)
- fix: gate resume brightness fallback on restart-restored pause state (#178)
- chore: require blitz-py >= 0.5.0, gate animated path on the engine floor, regenerate samples (#176)

After merging, create the release in the GitHub UI: Releases → "Draft a new release" → tag `1.3.3` targeting the bump commit on `main` → "Generate release notes" → Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kx69hwD9aq7bBDrTU97Rm

---
_Generated by [Claude Code](https://claude.ai/code/session_013kx69hwD9aq7bBDrTU97Rm)_