### PR TITLE
feat: Jinja2 templates in widget labels (#73) and chart Y-axis/period options (#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,30 @@ The HTML option is a Jinja template with access to entity data:
 - `state`, `name`, `unit`, `attributes` — the widget's configured entity
 - `states('sensor.x')`, `state_attr('sensor.x', 'attr')`, `is_state('sensor.x', 'on')` —
   any referenced entity is tracked and pre-fetched automatically
-- `now` — timezone-aware current datetime
+- `now` — timezone-aware current datetime (also callable as `now()`, HA-style)
 - Theme colors as CSS variables: `var(--text-primary)`, `var(--text-secondary)`,
   `var(--text-tertiary)`, `var(--primary)`, `var(--success)`, `var(--warning)`,
   `var(--error)`, `var(--info)`, `var(--muted)`, `var(--bg)`
 
 Limitations: no JavaScript, no network fetches (use `data:` URIs for
 images), no `background-clip: text`, no `text-shadow`.
+
+### Templates in Widget Labels
+
+Every widget's **Label** field — and the Text widget's content — accepts
+the same Jinja subset as the HTML widget, so any widget can carry a live
+caption without a separate Text widget:
+
+```
+Widget Type: Camera
+Entity: camera.birdnet_vogelbild
+Label: {{ states('sensor.birdnet_go_last_detection') }}
+```
+
+Entities referenced via `states()` / `state_attr()` / `is_state()` are
+pre-fetched automatically, and `now()` works for time-based labels
+(e.g. `{{ now().strftime('%A') }}`). A label whose template errors
+falls back to showing its raw text.
 
 ### Animated Widgets (opt-in)
 

--- a/custom_components/geekmagic/frontend/dist/geekmagic-panel.js
+++ b/custom_components/geekmagic/frontend/dist/geekmagic-panel.js
@@ -1217,7 +1217,7 @@ let u = class extends O {
 
           <div class="slot-field">
             <ha-input
-              label="Label (optional)"
+              label="Label (optional, supports templates)"
               .value=${(t == null ? void 0 : t.label) || ""}
               @input=${(l) => this._updateWidget(s, {
       label: l.target.value

--- a/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
+++ b/custom_components/geekmagic/frontend/src/geekmagic-panel.ts
@@ -1531,7 +1531,7 @@ export class GeekMagicPanel extends LitElement {
 
           <div class="slot-field">
             <ha-input
-              label="Label (optional)"
+              label="Label (optional, supports templates)"
               .value=${widget?.label || ""}
               @input=${(e: Event) =>
                 this._updateWidget(slot, {

--- a/custom_components/geekmagic/htmldoc.py
+++ b/custom_components/geekmagic/htmldoc.py
@@ -423,6 +423,8 @@ def svg_sparkline(
     aspect: float = 2.0,
     smooth: bool = True,
     show_dot: bool = True,
+    y_min: float | None = None,
+    y_max: float | None = None,
 ) -> str:
     """Build a responsive SVG sparkline (Apple-Health style).
 
@@ -431,11 +433,23 @@ def svg_sparkline(
     of the box the SVG will fill — the viewBox matches it so the dot
     stays circular under stretching. Pass concrete colors, never
     ``var()`` (SVG paint attributes don't resolve CSS variables).
+
+    ``y_min`` / ``y_max`` pin the vertical scale instead of the data's
+    own range (issue #139) — a fixed axis keeps several charts
+    comparable and stops the trace rescaling as values drift. Either
+    bound may be given alone (the other keeps following the data), and
+    values outside the fixed bounds are clamped to the plot edge.
+    Bounds that leave no spread (min >= max) are ignored.
     """
     if len(values) < 2:
         return ""
     vb_w = 100.0 * max(0.4, aspect)
-    vmin, vmax = min(values), max(values)
+    data_min, data_max = min(values), max(values)
+    vmin = y_min if y_min is not None else data_min
+    vmax = y_max if y_max is not None else data_max
+    if (y_min is not None or y_max is not None) and vmin >= vmax:
+        # Degenerate fixed bounds — fall back to the data's own range.
+        vmin, vmax = data_min, data_max
     spread = vmax - vmin
     n = len(values) - 1
     inset = 7.0  # headroom so the dot/halo and stroke stay inside
@@ -447,7 +461,7 @@ def svg_sparkline(
         pts = [
             (
                 inset + i / n * (vb_w - 2 * inset),
-                (100 - inset) - (v - vmin) / spread * (100 - 2 * inset),
+                (100 - inset) - (min(max(v, vmin), vmax) - vmin) / spread * (100 - 2 * inset),
             )
             for i, v in enumerate(values)
         ]

--- a/custom_components/geekmagic/websocket.py
+++ b/custom_components/geekmagic/websocket.py
@@ -538,14 +538,11 @@ async def ws_preview_render(
                     options = widget_data.get("options", {})
                     period = options.get("period", "24 hours")
 
-                    # Convert period to hours
-                    period_hours = {
-                        "5 min": 5 / 60,
-                        "15 min": 15 / 60,
-                        "1 hour": 1,
-                        "6 hours": 6,
-                        "24 hours": 24,
-                    }.get(period, 24)
+                    # Convert period to hours (single source of truth:
+                    # the chart widget's own period map)
+                    from .widgets.chart import ChartWidget
+
+                    period_hours = ChartWidget.PERIOD_TO_HOURS.get(period, 24)
 
                     start_time = now - timedelta(hours=period_hours)
 

--- a/custom_components/geekmagic/widgets/_template.py
+++ b/custom_components/geekmagic/widgets/_template.py
@@ -1,0 +1,121 @@
+"""Sandboxed Jinja templating shared by widget-authored strings.
+
+The HTML widget introduced widget-level Jinja rendering; widget labels
+reuse the exact same machinery so a template behaves identically
+wherever it appears. Rendering is pure — everything comes from the
+injected ``WidgetState`` snapshot, never from ``hass`` — so it works
+unchanged in the coordinator's executor render, the panel preview, and
+tests.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from jinja2.sandbox import SandboxedEnvironment
+
+if TYPE_CHECKING:
+    from .state import WidgetState
+
+# Entity references inside a Jinja template, e.g. states('sensor.temp'),
+# state_attr("climate.living", "current_temperature") or
+# is_state('light.kitchen', 'on'). Used to declare entity dependencies so
+# the coordinator pre-fetches them into WidgetState.
+_ENTITY_REF_RE = re.compile(r"""\b(?:states|state_attr|is_state)\(\s*['"]([^'"]+)['"]""")
+
+_TEMPLATE_MARKERS = ("{{", "{%")
+
+
+def is_template(text: str | None) -> bool:
+    """Whether ``text`` contains Jinja template syntax worth rendering."""
+    return bool(text) and any(marker in text for marker in _TEMPLATE_MARKERS)
+
+
+def template_entity_refs(text: str | None) -> list[str]:
+    """Entity IDs referenced via ``states()``/``state_attr()``/``is_state()``."""
+    if not text:
+        return []
+    refs: list[str] = []
+    for entity_id in _ENTITY_REF_RE.findall(text):
+        if entity_id not in refs:
+            refs.append(entity_id)
+    return refs
+
+
+class _CallableNow(datetime):
+    """A datetime that can also be *called*.
+
+    Home Assistant templates write ``now()`` (a function) while the HTML
+    widget documented ``now`` (a variable). Supporting both means a
+    template pasted from an HA automation works unchanged.
+    """
+
+    __slots__ = ()
+
+    def __call__(self) -> _CallableNow:
+        return self
+
+    @classmethod
+    def from_datetime(cls, dt: datetime) -> _CallableNow:
+        return cls(
+            dt.year,
+            dt.month,
+            dt.day,
+            dt.hour,
+            dt.minute,
+            dt.second,
+            dt.microsecond,
+            dt.tzinfo,
+            fold=dt.fold,
+        )
+
+
+def _build_template_context(
+    state: WidgetState, primary_entity_id: str | None = None
+) -> dict[str, Any]:
+    """Build the Jinja context exposed to widget-authored templates.
+
+    The convenience variables (``state``/``name``/``unit``/...) come from
+    ``primary_entity_id`` when given (the widget's "Entity (template
+    data)" selector, delivered by the coordinator in
+    ``WidgetState.entities``), falling back to ``state.entity``.
+    """
+
+    def states(entity_id: str) -> str:
+        entity = state.get_entity(entity_id)
+        return entity.state if entity else "unknown"
+
+    def state_attr(entity_id: str, attribute: str) -> Any:
+        entity = state.get_entity(entity_id)
+        return entity.get(attribute) if entity else None
+
+    def is_state(entity_id: str, value: str) -> bool:
+        return states(entity_id) == value
+
+    entity = state.get_entity(primary_entity_id) if primary_entity_id else None
+    if entity is None:
+        entity = state.entity
+    return {
+        "entity": entity,
+        "state": entity.state if entity else "",
+        "name": entity.friendly_name if entity else "",
+        "unit": entity.unit if entity else "",
+        "attributes": entity.attributes if entity else {},
+        "now": _CallableNow.from_datetime(state.now) if state.now else None,
+        "states": states,
+        "state_attr": state_attr,
+        "is_state": is_state,
+    }
+
+
+def _render_template(source: str, state: WidgetState, primary_entity_id: str | None = None) -> str:
+    """Render a widget-authored Jinja template against widget state.
+
+    Uses a sandboxed environment: templates come from the user's own HA
+    config, but sandboxing is cheap insurance against accidental access
+    to Python internals.
+    """
+    env = SandboxedEnvironment(autoescape=False)
+    return env.from_string(source).render(**_build_template_context(state, primary_entity_id))

--- a/custom_components/geekmagic/widgets/base.py
+++ b/custom_components/geekmagic/widgets/base.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from ._template import _render_template, is_template
+
 if TYPE_CHECKING:
     from ..htmldoc import CellContext
     from .state import EntityState, WidgetState
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -79,7 +84,46 @@ class Widget(ABC):
         """
         return None
 
-    def label_for(self, entity: EntityState | None, *, fallback: str = "") -> str:
+    def resolved_label(self, state: WidgetState | None) -> str | None:
+        """``config.label`` with Jinja templates evaluated (issue #73).
+
+        Labels support the same sandboxed template subset as the HTML
+        widget — ``states()`` / ``state_attr()`` / ``is_state()`` /
+        ``now()`` plus the primary-entity convenience variables — so
+        ``{{ states('sensor.birdnet_go_last_detection') }}`` captions a
+        Camera widget with live data. Referenced entities are
+        pre-fetched automatically (see ``build_entity_states``).
+
+        A broken template falls back to the raw label text: showing the
+        literal source is the legacy behavior and makes the mistake
+        visible on the panel. Returns None when no label is configured
+        or the template evaluates to whitespace (so caption bands hide
+        exactly like an unset label).
+        """
+        label = self.config.label
+        if not label:
+            return None
+        if state is None or not is_template(label):
+            return label
+        try:
+            rendered = _render_template(label, state, self.config.entity_id).strip()
+        except Exception:
+            _LOGGER.warning(
+                "Invalid Jinja template in %s widget label: %s",
+                self.config.widget_type,
+                label,
+                exc_info=True,
+            )
+            return label
+        return rendered or None
+
+    def label_for(
+        self,
+        entity: EntityState | None,
+        *,
+        state: WidgetState | None = None,
+        fallback: str = "",
+    ) -> str:
         """Resolve display label: ``config.label`` > ``entity.friendly_name`` > ``fallback``.
 
         Pretty much every widget that renders a name needs this chain.
@@ -87,9 +131,13 @@ class Widget(ABC):
         when no friendly name attribute is set, so widgets that previously
         wrote ``entity.friendly_name or entity.entity_id`` collapse to
         a single ``self.label_for(entity, fallback=...)``.
+
+        Pass ``state`` so a label containing a Jinja template is
+        evaluated (``resolved_label``); render paths always have it.
         """
-        if self.config.label:
-            return self.config.label
+        label = self.resolved_label(state)
+        if label:
+            return label
         if entity is not None:
             return entity.friendly_name
         return fallback

--- a/custom_components/geekmagic/widgets/camera.py
+++ b/custom_components/geekmagic/widgets/camera.py
@@ -99,7 +99,7 @@ class CameraWidget(Widget):
         cells at a shrunk size instead of hiding — a bare grey camera
         glyph says nothing.
         """
-        name = self.label_for(state.entity, fallback="No Image")
+        name = self.label_for(state.entity, state=state, fallback="No Image")
         label, font_px = fit_caption_sized(name, ctx, ctx.width * 0.88 - _CHROME_PX)
         caption = ""
         if label and ctx.height >= 44:
@@ -128,7 +128,7 @@ class CameraWidget(Widget):
         # 1px borders and the theme chrome before fitting glyphs.
         usable = ctx.width - 2 * inset_px - 1.44 * font_px - 2 - _CHROME_PX
         label = _caps_metrics(ctx).truncate(
-            self.label_for(state.entity, fallback="Camera"),
+            self.label_for(state.entity, state=state, fallback="Camera"),
             font_px,
             max(12.0, usable),
             _LABEL_WEIGHT,

--- a/custom_components/geekmagic/widgets/candlestick.py
+++ b/custom_components/geekmagic/widgets/candlestick.py
@@ -325,7 +325,7 @@ class CandlestickWidget(Widget):
             caret = "menu-up" if bullish else "menu-down"
 
         # A hidden name leaves the header to the tinted price alone.
-        caption = self.label_for(entity) if self.show_name else ""
+        caption = self.label_for(entity, state=state) if self.show_name else ""
         header, header_h = "", 0.0
         if not m.compact:
             header, header_h = self._header(

--- a/custom_components/geekmagic/widgets/chart.py
+++ b/custom_components/geekmagic/widgets/chart.py
@@ -31,6 +31,16 @@ def _format_period(hours: float) -> str:
     return f"{round(hours)}h"
 
 
+def _float_or_none(value: Any) -> float | None:
+    """Coerce an optional option value to float; blanks/garbage become None."""
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None
+
+
 def _is_binary_data(data: list[float]) -> bool:
     """Check if data is binary (all 0.0 or 1.0)."""
     if not data:
@@ -219,8 +229,26 @@ class ChartWidget(Widget):
                 "key": "period",
                 "type": "select",
                 "label": "Period",
-                "options": ["5 min", "15 min", "1 hour", "6 hours", "24 hours"],
+                "options": [
+                    "5 min",
+                    "15 min",
+                    "1 hour",
+                    "3 hours",
+                    "6 hours",
+                    "12 hours",
+                    "24 hours",
+                ],
                 "default": "24 hours",
+            },
+            {
+                "key": "y_min",
+                "type": "number",
+                "label": "Y-Axis Min (optional)",
+            },
+            {
+                "key": "y_max",
+                "type": "number",
+                "label": "Y-Axis Max (optional)",
             },
             {
                 "key": "show_name",
@@ -254,7 +282,9 @@ class ChartWidget(Widget):
         "5 min": 5 / 60,
         "15 min": 15 / 60,
         "1 hour": 1,
+        "3 hours": 3,
         "6 hours": 6,
+        "12 hours": 12,
         "24 hours": 24,
     }
 
@@ -273,6 +303,9 @@ class ChartWidget(Widget):
         self.show_range = config.options.get("show_range", True)
         self.fill = config.options.get("fill", True)  # Default to filled area
         self.color_gradient = config.options.get("color_gradient", False)
+        # Fixed Y-axis bounds (issue #139) — either may be set alone.
+        self.y_min = _float_or_none(config.options.get("y_min"))
+        self.y_max = _float_or_none(config.options.get("y_max"))
 
     def render_html(self, ctx: CellContext, state: WidgetState) -> str:
         """Render the chart: value header, sparkline, low/high range strip."""
@@ -343,6 +376,8 @@ class ChartWidget(Widget):
                 # Bezier smoothing overshoots on square binary traces.
                 smooth=not binary,
                 show_dot=True,
+                y_min=self.y_min,
+                y_max=self.y_max,
             )
             plot = f'<div style="width: 100%">{spark}</div>'
         else:

--- a/custom_components/geekmagic/widgets/chart.py
+++ b/custom_components/geekmagic/widgets/chart.py
@@ -295,7 +295,7 @@ class ChartWidget(Widget):
 
         # A hidden name leaves the header to the value alone; with both
         # off, the whole header band goes and the plot takes its room.
-        caption = self.label_for(entity) if self.show_name else ""
+        caption = self.label_for(entity, state=state) if self.show_name else ""
         header, header_h = "", 0.0
         footer, footer_h = "", 0.0
         if not m.compact:

--- a/custom_components/geekmagic/widgets/climate.py
+++ b/custom_components/geekmagic/widgets/climate.py
@@ -454,7 +454,7 @@ class ClimateWidget(Widget):
             # A hidden name leaves the band to the state icon alone —
             # and when the chips already carry the mode, drops it
             # entirely so the hero gets the height.
-            name = self.label_for(entity) if self.show_name else ""
+            name = self.label_for(entity, state=state) if self.show_name else ""
             show_caption = bool(name) or with_icon
         if show_caption:
             spent += label_px(ctx)

--- a/custom_components/geekmagic/widgets/clock.py
+++ b/custom_components/geekmagic/widgets/clock.py
@@ -114,7 +114,8 @@ class ClockWidget(Widget):
         # time — a "Tokyo" and a "London" clock in one grid must not
         # render identically (same compact-identity rule as entity).
         compact_identity = not bands_kept and box_h >= _COMPACT_MIN_H
-        show_caption = bool(self.config.label) and (bands_kept or compact_identity)
+        caption_text = self.resolved_label(state)
+        show_caption = bool(caption_text) and (bands_kept or compact_identity)
         # The date is the clock's supporting band, so it follows the
         # caption breakpoint rather than the chip strip's: a tall 114px
         # column has plenty of room for it.
@@ -147,7 +148,7 @@ class ClockWidget(Widget):
 
         return card_html(
             # card_html measures, shrinks, and truncates the caption.
-            caption=self.config.label if show_caption else None,
+            caption=caption_text if show_caption else None,
             caption_hide="hide-short" if bands_kept else "",
             hero=hero_block(
                 hero,

--- a/custom_components/geekmagic/widgets/entity.py
+++ b/custom_components/geekmagic/widgets/entity.py
@@ -113,7 +113,9 @@ class EntityWidget(Widget):
         if entity is None:
             value = PLACEHOLDER_VALUE
             unit = ""
-            name = self.label_for(None, fallback=self.config.entity_id or PLACEHOLDER_NAME)
+            name = self.label_for(
+                None, state=state, fallback=self.config.entity_id or PLACEHOLDER_NAME
+            )
         else:
             # Get value from attribute or state
             if self.attribute:
@@ -150,7 +152,7 @@ class EntityWidget(Widget):
                 except (ValueError, TypeError):
                     pass  # Keep original value if not numeric
             unit = entity.unit if self.show_unit else ""
-            name = self.label_for(entity)
+            name = self.label_for(entity, state=state)
 
         # Narrow columns: long word units (km/h, kWh) cost the digits
         # their size — drop them before the value has to shrink or

--- a/custom_components/geekmagic/widgets/gauge.py
+++ b/custom_components/geekmagic/widgets/gauge.py
@@ -152,7 +152,7 @@ class GaugeWidget(Widget):
                 unit = entity.unit or ""
 
         percent = calculate_percent(value, self.min_value, self.max_value)
-        name = self.label_for(entity) if self.show_name else ""
+        name = self.label_for(entity, state=state) if self.show_name else ""
 
         if not self.show_value:
             display_value = ""

--- a/custom_components/geekmagic/widgets/html.py
+++ b/custom_components/geekmagic/widgets/html.py
@@ -10,13 +10,11 @@ theme chrome, so user templates can use ``var(--text-primary)``,
 from __future__ import annotations
 
 import logging
-import re
 from html import escape
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from jinja2.sandbox import SandboxedEnvironment
-
 from ..htmldoc import mdi_span
+from ._template import _render_template, template_entity_refs
 from .base import Widget, WidgetConfig
 
 if TYPE_CHECKING:
@@ -24,61 +22,6 @@ if TYPE_CHECKING:
     from .state import WidgetState
 
 _LOGGER = logging.getLogger(__name__)
-
-# Entity references inside the Jinja template, e.g. states('sensor.temp'),
-# state_attr("climate.living", "current_temperature") or
-# is_state('light.kitchen', 'on'). Used to declare entity dependencies so
-# the coordinator pre-fetches them into WidgetState.
-_ENTITY_REF_RE = re.compile(r"""\b(?:states|state_attr|is_state)\(\s*['"]([^'"]+)['"]""")
-
-
-def _build_template_context(
-    state: WidgetState, primary_entity_id: str | None = None
-) -> dict[str, Any]:
-    """Build the Jinja context exposed to the user's HTML template.
-
-    The convenience variables (``state``/``name``/``unit``/...) come from
-    ``primary_entity_id`` when given (the widget's "Entity (template
-    data)" selector, delivered by the coordinator in
-    ``WidgetState.entities``), falling back to ``state.entity``.
-    """
-
-    def states(entity_id: str) -> str:
-        entity = state.get_entity(entity_id)
-        return entity.state if entity else "unknown"
-
-    def state_attr(entity_id: str, attribute: str) -> Any:
-        entity = state.get_entity(entity_id)
-        return entity.get(attribute) if entity else None
-
-    def is_state(entity_id: str, value: str) -> bool:
-        return states(entity_id) == value
-
-    entity = state.get_entity(primary_entity_id) if primary_entity_id else None
-    if entity is None:
-        entity = state.entity
-    return {
-        "entity": entity,
-        "state": entity.state if entity else "",
-        "name": entity.friendly_name if entity else "",
-        "unit": entity.unit if entity else "",
-        "attributes": entity.attributes if entity else {},
-        "now": state.now,
-        "states": states,
-        "state_attr": state_attr,
-        "is_state": is_state,
-    }
-
-
-def _render_template(source: str, state: WidgetState, primary_entity_id: str | None = None) -> str:
-    """Render the user's Jinja template against widget state.
-
-    Uses a sandboxed environment: templates come from the user's own HA
-    config, but sandboxing is cheap insurance against accidental access
-    to Python internals.
-    """
-    env = SandboxedEnvironment(autoescape=False)
-    return env.from_string(source).render(**_build_template_context(state, primary_entity_id))
 
 
 def _placeholder(message: str, icon: str = "code-tags") -> str:
@@ -193,7 +136,7 @@ class HtmlWidget(Widget):
             entities.append(self.config.entity_id)
         if self.dynamic_entity_id and self.dynamic_entity_id not in entities:
             entities.append(self.dynamic_entity_id)
-        for entity_id in _ENTITY_REF_RE.findall(self.html):
+        for entity_id in template_entity_refs(self.html):
             if entity_id not in entities:
                 entities.append(entity_id)
         return entities

--- a/custom_components/geekmagic/widgets/icon.py
+++ b/custom_components/geekmagic/widgets/icon.py
@@ -49,8 +49,9 @@ class IconWidget(Widget):
         # every widget, and silently discarding it leaves a naked glyph.
         box_w, box_h = cell_box(ctx)
         caption = ""
-        if self.config.label and box_h >= 44:
-            text, px = fit_caption_sized(self.config.label, ctx, box_w)
+        caption_text = self.resolved_label(state)
+        if caption_text and box_h >= 44:
+            text, px = fit_caption_sized(caption_text, ctx, box_w)
             if text:
                 caption = f'<div class="t-label" style="font-size: {px:.1f}px">{escape(text)}</div>'
                 box_h -= label_px(ctx) * 1.6

--- a/custom_components/geekmagic/widgets/media.py
+++ b/custom_components/geekmagic/widgets/media.py
@@ -316,7 +316,7 @@ class MediaWidget(Widget):
             or entity.state in ("off", "unavailable", "unknown", "idle")
             or (paused and not has_track)
         ):
-            return self._render_idle(ctx, entity)
+            return self._render_idle(ctx, entity, state)
 
         # Calculate current position (accounts for elapsed playback time)
         position = _calculate_media_position(entity, state.now)
@@ -332,7 +332,7 @@ class MediaWidget(Widget):
 
         return self._render_now_playing(ctx, entity, position, duration, accent)
 
-    def _render_idle(self, ctx: CellContext, entity: EntityState | None) -> str:
+    def _render_idle(self, ctx: CellContext, entity: EntityState | None, state: WidgetState) -> str:
         """Idle / paused / off placeholder — quiet, centered, never loud.
 
         Still an identity-bearing cell: the player's NAME captions the
@@ -353,7 +353,7 @@ class MediaWidget(Widget):
 
         avail_w, avail_h = cell_box(ctx)
         bands: list[str] = []
-        name = self.label_for(entity, fallback="") if entity is not None else ""
+        name = self.label_for(entity, state=state, fallback="") if entity is not None else ""
         if name and avail_h >= 60:
             text, px = fit_caption_sized(name, ctx, avail_w)
             if text:

--- a/custom_components/geekmagic/widgets/progress.py
+++ b/custom_components/geekmagic/widgets/progress.py
@@ -95,7 +95,7 @@ class ProgressWidget(Widget):
 
         # An empty label drops the whole caption band (icon included),
         # matching the gauge family's show_name behavior.
-        label = self.label_for(entity, fallback="Progress") if self.show_name else ""
+        label = self.label_for(entity, state=state, fallback="Progress") if self.show_name else ""
 
         target = self.target or 100
         percent = min(100, (value / target) * 100) if target > 0 else 0

--- a/custom_components/geekmagic/widgets/state.py
+++ b/custom_components/geekmagic/widgets/state.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from ._template import template_entity_refs
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from datetime import datetime
@@ -127,6 +129,11 @@ def build_entity_states(
 
     Shared by the coordinator's production render and the websocket
     preview so both resolve the same dependencies for a widget.
+
+    Besides ``widget.get_entities()``, entities referenced from a Jinja
+    label template (``states('sensor.x')`` etc.) are snapshotted too, so
+    label templates resolve without every widget subclass having to
+    declare them.
     """
 
     def snapshot(entity_id: str) -> EntityState | None:
@@ -142,7 +149,7 @@ def build_entity_states(
     primary_id = widget.config.entity_id
     primary = snapshot(primary_id) if primary_id else None
     additional: dict[str, EntityState] = {}
-    for eid in widget.get_entities():
+    for eid in (*widget.get_entities(), *template_entity_refs(widget.config.label)):
         if eid == primary_id or eid in additional:
             continue
         entity = snapshot(eid)

--- a/custom_components/geekmagic/widgets/status.py
+++ b/custom_components/geekmagic/widgets/status.py
@@ -289,7 +289,9 @@ class StatusWidget(Widget):
             "success" if is_on else "error",
         )
         ind = _Indicator(
-            name=self.label_for(entity, fallback=PLACEHOLDER_NAME) if self.show_name else "",
+            name=self.label_for(entity, state=state, fallback=PLACEHOLDER_NAME)
+            if self.show_name
+            else "",
             icon=self.icon or _entity_status_icon(entity) or "circle",
             color=color,
             fill=tint_css(tint, ctx.theme, _CHIP_FILL_ALPHA),

--- a/custom_components/geekmagic/widgets/text.py
+++ b/custom_components/geekmagic/widgets/text.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from ..const import PLACEHOLDER_VALUE
@@ -16,11 +17,14 @@ from ._cardfit import (
     hero_block,
     label_px,
 )
+from ._template import _render_template, is_template, template_entity_refs
 from .base import Widget, WidgetConfig
 
 if TYPE_CHECKING:
     from ..htmldoc import CellContext
     from .state import WidgetState
+
+_LOGGER = logging.getLogger(__name__)
 
 _MAX_HERO_PX = 124.0
 _MIN_HERO_PX = 12.0
@@ -70,7 +74,8 @@ class TextWidget(Widget):
         # Short cells (hero-layout footers) keep a shrunk caption row
         # instead of dropping the label — an unlabeled "247" is noise.
         compact_identity = not bands_kept and box_h >= _COMPACT_MIN_H
-        show_caption = bool(self.config.label) and (bands_kept or compact_identity)
+        caption_text = self.resolved_label(state)
+        show_caption = bool(caption_text) and (bands_kept or compact_identity)
         caption_band = label_px(ctx) * 1.25 if show_caption else 0.0
         share = HERO_SHARE_STACKED if show_caption else HERO_SHARE_SOLO
 
@@ -96,7 +101,7 @@ class TextWidget(Widget):
         hero_color = css_rgb(self.config.color) if self.config.color else None
         return card_html(
             # card_html measures, shrinks, and truncates the caption.
-            caption=self.config.label if show_caption else None,
+            caption=caption_text if show_caption else None,
             caption_hide="hide-short" if bands_kept else "",
             hero=hero_block(hero),
             hero_is_html=True,
@@ -110,7 +115,11 @@ class TextWidget(Widget):
         If entity_id is set (from options or widget config), returns the
         entity state — with absence states mapped to a dimmed "--" like
         entity.py, so a dead sensor never headlines the literal word
-        "unavailable". Otherwise returns the configured static text.
+        "unavailable". Otherwise returns the configured static text,
+        with Jinja templates evaluated (same sandboxed subset as widget
+        labels and the HTML widget — issue #73). A broken template shows
+        its raw source, which is the legacy behavior and makes the
+        mistake visible.
         """
 
         def entity_text(value: str) -> str:
@@ -122,13 +131,29 @@ class TextWidget(Widget):
             entity = state.get_entity(self.dynamic_entity_id)
             if entity:
                 return entity_text(entity.state)
+        if is_template(self.text):
+            try:
+                return _render_template(self.text, state, self.config.entity_id).strip()
+            except Exception:
+                _LOGGER.warning(
+                    "Invalid Jinja template in text widget content: %s",
+                    self.text,
+                    exc_info=True,
+                )
         return self.text
 
     def get_entities(self) -> list[str]:
-        """Return entity IDs this widget depends on."""
+        """Return entity IDs this widget depends on.
+
+        Includes entities referenced via ``states()`` etc. in a templated
+        text content, so the coordinator pre-fetches them.
+        """
         entities = []
         if self.config.entity_id:
             entities.append(self.config.entity_id)
         if self.dynamic_entity_id and self.dynamic_entity_id != self.config.entity_id:
             entities.append(self.dynamic_entity_id)
+        for entity_id in template_entity_refs(self.text):
+            if entity_id not in entities:
+                entities.append(entity_id)
         return entities

--- a/tests/widgets/test_label_templates.py
+++ b/tests/widgets/test_label_templates.py
@@ -1,0 +1,228 @@
+"""Tests for Jinja template support in widget labels and text content.
+
+Regression tests for issue #73: widget labels evaluate the same
+sandboxed Jinja subset as the HTML widget, with referenced entities
+pre-fetched automatically by ``build_entity_states``.
+"""
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import pytest
+
+from custom_components.geekmagic.htmldoc import CellContext
+from custom_components.geekmagic.widgets.base import WidgetConfig
+from custom_components.geekmagic.widgets.camera import CameraWidget
+from custom_components.geekmagic.widgets.entity import EntityWidget
+from custom_components.geekmagic.widgets.icon import IconWidget
+from custom_components.geekmagic.widgets.state import (
+    EntityState,
+    WidgetState,
+    build_entity_states,
+)
+from custom_components.geekmagic.widgets.text import TextWidget
+from custom_components.geekmagic.widgets.theme import DEFAULT_THEME
+
+BIRD_SENSOR = "sensor.birdnet_go_last_detection"
+
+
+@pytest.fixture
+def widget_state():
+    """State with a primary camera entity and the bird sensor (issue #73)."""
+    return WidgetState(
+        entity=EntityState(
+            entity_id="camera.birdnet_vogelbild",
+            state="idle",
+            attributes={"friendly_name": "Bird Cam"},
+        ),
+        entities={
+            BIRD_SENSOR: EntityState(entity_id=BIRD_SENSOR, state="Great Tit", attributes={}),
+        },
+        # A Wednesday, for the weekday template test.
+        now=datetime(2026, 8, 26, 10, 0, tzinfo=UTC),
+    )
+
+
+@pytest.fixture
+def ctx():
+    """Standard cell context."""
+    return CellContext(width=240, height=240, slot_index=0, theme=DEFAULT_THEME)
+
+
+def make_camera(label: str | None) -> CameraWidget:
+    return CameraWidget(
+        WidgetConfig(
+            widget_type="camera",
+            slot=0,
+            entity_id="camera.birdnet_vogelbild",
+            label=label,
+        )
+    )
+
+
+class TestResolvedLabel:
+    """Widget.resolved_label — the template-aware label accessor."""
+
+    def test_static_label_passthrough(self, widget_state):
+        widget = make_camera("Birds")
+        assert widget.resolved_label(widget_state) == "Birds"
+
+    def test_no_label_returns_none(self, widget_state):
+        widget = make_camera(None)
+        assert widget.resolved_label(widget_state) is None
+
+    def test_issue_73_states_template(self, widget_state):
+        """The exact example from the issue: camera label showing a sensor."""
+        widget = make_camera("{{ states('" + BIRD_SENSOR + "') }}")
+        assert widget.resolved_label(widget_state) == "Great Tit"
+
+    def test_weekday_set_block_template(self, widget_state):
+        """The abbreviated-weekday template from the issue thread —
+        ``{% set %}`` blocks and a callable ``now()`` both work."""
+        widget = make_camera(
+            "{% set days = ['ПН','ВТ','СР','ЧТ','ПТ','СБ','ВС'] %}"  # noqa: RUF001
+            "{{ days[now().weekday()] }}"
+        )
+        assert widget.resolved_label(widget_state) == "СР"  # noqa: RUF001
+
+    def test_primary_entity_variables(self, widget_state):
+        widget = make_camera("{{ name }} ({{ state }})")
+        assert widget.resolved_label(widget_state) == "Bird Cam (idle)"
+
+    def test_broken_template_falls_back_to_raw_source(self, widget_state):
+        """A syntax error shows the literal label (legacy behavior) so
+        the mistake is visible on the panel instead of a blank."""
+        widget = make_camera("{{ nope(")
+        assert widget.resolved_label(widget_state) == "{{ nope("
+
+    def test_whitespace_result_hides_label(self, widget_state):
+        """A template evaluating to whitespace behaves like no label."""
+        widget = make_camera("{% if false %}x{% endif %}")
+        assert widget.resolved_label(widget_state) is None
+
+    def test_without_state_returns_raw(self):
+        """No state to render against — the raw label is preserved."""
+        widget = make_camera("{{ states('sensor.x') }}")
+        assert widget.resolved_label(None) == "{{ states('sensor.x') }}"
+
+
+class TestLabelForChain:
+    """label_for keeps its fallback chain with templates in the mix."""
+
+    def test_template_label_wins(self, widget_state):
+        widget = make_camera("{{ states('" + BIRD_SENSOR + "') }}")
+        assert widget.label_for(widget_state.entity, state=widget_state) == "Great Tit"
+
+    def test_empty_template_falls_back_to_friendly_name(self, widget_state):
+        widget = make_camera("{% if false %}x{% endif %}")
+        assert widget.label_for(widget_state.entity, state=widget_state) == "Bird Cam"
+
+    def test_fallback_when_nothing_resolves(self, widget_state):
+        widget = make_camera("{% if false %}x{% endif %}")
+        assert widget.label_for(None, state=widget_state, fallback="Camera") == "Camera"
+
+
+class TestEntityPrefetch:
+    """build_entity_states snapshots entities referenced in label templates."""
+
+    def test_label_refs_prefetched(self):
+        widget = make_camera("{{ states('" + BIRD_SENSOR + "') }}")
+
+        def get_state(entity_id):
+            if entity_id != BIRD_SENSOR:
+                return None
+            return SimpleNamespace(entity_id=entity_id, state="Great Tit", attributes={})
+
+        _primary, additional = build_entity_states(get_state, widget)
+        assert BIRD_SENSOR in additional
+        assert additional[BIRD_SENSOR].state == "Great Tit"
+
+    def test_static_label_adds_nothing(self):
+        widget = make_camera("Birds")
+        _primary, additional = build_entity_states(lambda _eid: None, widget)
+        assert additional == {}
+
+
+class TestRenderedFragments:
+    """Templates resolve end-to-end inside rendered widget fragments."""
+
+    def test_entity_widget_label_template(self, ctx, widget_state):
+        widget = EntityWidget(
+            WidgetConfig(
+                widget_type="entity",
+                slot=0,
+                entity_id="camera.birdnet_vogelbild",
+                label="{{ states('" + BIRD_SENSOR + "') }}",
+            )
+        )
+        html = widget.render_html(ctx, widget_state)
+        assert "great tit" in html.lower()
+        assert "states(" not in html
+
+    def test_icon_widget_caption_template(self, ctx, widget_state):
+        widget = IconWidget(
+            WidgetConfig(
+                widget_type="icon",
+                slot=0,
+                label="{{ states('" + BIRD_SENSOR + "') }}",
+                options={"icon": "mdi:bird"},
+            )
+        )
+        html = widget.render_html(ctx, widget_state)
+        assert "great tit" in html.lower()
+
+
+class TestTextWidgetTemplates:
+    """Text widget content evaluates templates like labels do."""
+
+    def test_templated_text_content(self, ctx, widget_state):
+        widget = TextWidget(
+            WidgetConfig(
+                widget_type="text",
+                slot=0,
+                options={"text": "{{ states('" + BIRD_SENSOR + "') }}"},
+            )
+        )
+        state = WidgetState(entities=dict(widget_state.entities), now=widget_state.now)
+        html = widget.render_html(ctx, state)
+        # The hero fitter may wrap the two words onto separate lines.
+        assert "great" in html.lower()
+        assert "tit" in html.lower()
+        assert "states(" not in html
+
+    def test_static_text_unchanged(self, ctx):
+        widget = TextWidget(WidgetConfig(widget_type="text", slot=0, options={"text": "Hello"}))
+        assert "Hello" in widget.render_html(ctx, WidgetState(now=datetime.now(tz=UTC)))
+
+    def test_broken_text_template_shows_source(self, ctx):
+        widget = TextWidget(WidgetConfig(widget_type="text", slot=0, options={"text": "{{ bad("}))
+        html = widget.render_html(ctx, WidgetState(now=datetime.now(tz=UTC)))
+        assert "bad(" in html
+
+    def test_text_template_refs_declared(self):
+        widget = TextWidget(
+            WidgetConfig(
+                widget_type="text",
+                slot=0,
+                options={"text": "{{ states('sensor.a') }} {{ is_state('sensor.b', 'on') }}"},
+            )
+        )
+        assert widget.get_entities() == ["sensor.a", "sensor.b"]
+
+    def test_entity_state_beats_text_template(self, ctx, widget_state):
+        """An entity-driven text widget keeps showing the entity state."""
+        widget = TextWidget(
+            WidgetConfig(
+                widget_type="text",
+                slot=0,
+                entity_id="camera.birdnet_vogelbild",
+                options={"text": "{{ states('" + BIRD_SENSOR + "') }}"},
+            )
+        )
+        html = widget.render_html(ctx, widget_state)
+        assert "idle" in html
+        assert "great tit" not in html.lower()

--- a/tests/widgets/test_widgets.py
+++ b/tests/widgets/test_widgets.py
@@ -19,7 +19,7 @@ import pytest
 from PIL import Image
 
 from custom_components.geekmagic.const import COLOR_CYAN
-from custom_components.geekmagic.htmldoc import CellContext
+from custom_components.geekmagic.htmldoc import CellContext, svg_sparkline
 from custom_components.geekmagic.widgets.attribute_list import AttributeListWidget
 from custom_components.geekmagic.widgets.base import WidgetConfig
 from custom_components.geekmagic.widgets.camera import CameraWidget
@@ -1602,6 +1602,101 @@ class TestChartWidget:
         fragment = widget.render_html(ctx, make_state(entity, history=history))
         assert "<svg" in fragment  # still charts
         assert "24h" not in fragment  # no range footer for binary data
+
+    @pytest.mark.parametrize(
+        ("period", "hours"),
+        [("3 hours", 3), ("12 hours", 12)],
+    )
+    def test_intermediate_periods(self, period, hours):
+        """3h / 12h periods from issue #139 map and appear in the schema."""
+        widget = ChartWidget(
+            WidgetConfig(
+                widget_type="chart",
+                slot=0,
+                entity_id="sensor.temperature",
+                options={"period": period},
+            )
+        )
+        assert widget.hours == hours
+        period_option = next(o for o in ChartWidget.SCHEMA["options"] if o["key"] == "period")
+        assert period in period_option["options"]
+
+    def test_y_bounds_parsed(self):
+        """Fixed Y-axis options coerce to floats; blanks/garbage are None."""
+        widget = ChartWidget(
+            WidgetConfig(
+                widget_type="chart",
+                slot=0,
+                entity_id="sensor.temperature",
+                options={"y_min": 0, "y_max": "40"},
+            )
+        )
+        assert widget.y_min == 0.0
+        assert widget.y_max == 40.0
+
+        widget = ChartWidget(
+            WidgetConfig(
+                widget_type="chart",
+                slot=0,
+                entity_id="sensor.temperature",
+                options={"y_min": "", "y_max": "abc"},
+            )
+        )
+        assert widget.y_min is None
+        assert widget.y_max is None
+
+    def test_fixed_y_bounds_reach_the_sparkline(self, ctx):
+        """A fixed axis changes where the trace lands (issue #139).
+
+        With auto-scale, the series maximum pins to the top of the plot
+        (endpoint dot at y=7, the inset). With y 0..20 the same maximum
+        of 10 sits mid-plot instead.
+        """
+        history = [0.0, 5.0, 10.0]
+        entity = make_entity(attributes={"friendly_name": "Temp"})
+
+        auto = ChartWidget(
+            WidgetConfig(widget_type="chart", slot=0, entity_id="sensor.temperature")
+        )
+        fragment = auto.render_html(ctx, make_state(entity, history=history))
+        assert 'cy="7.0"' in fragment
+
+        fixed = ChartWidget(
+            WidgetConfig(
+                widget_type="chart",
+                slot=0,
+                entity_id="sensor.temperature",
+                options={"y_min": 0, "y_max": 20},
+            )
+        )
+        fragment = fixed.render_html(ctx, make_state(entity, history=history))
+        assert 'cy="50.0"' in fragment  # 10 of 0..20 → vertical midpoint
+
+
+class TestSparklineFixedBounds:
+    """svg_sparkline fixed Y-axis behavior (issue #139)."""
+
+    def test_values_outside_bounds_clamp_to_plot_edge(self):
+        svg = svg_sparkline([0.0, 5.0, 30.0], y_min=0, y_max=10, aspect=1.0)
+        # 30 clamps to the y_max edge — the top inset, not off-plot.
+        assert 'cy="7.0"' in svg
+
+    def test_single_bound_keeps_other_side_on_data(self):
+        # y_min pinned to 0; max follows the data (20 → top of plot).
+        svg = svg_sparkline([10.0, 20.0], y_min=0, aspect=1.0)
+        assert 'cy="7.0"' in svg
+        assert "M 0 50.0" in svg  # 10 of 0..20 → midpoint
+
+    def test_degenerate_bounds_fall_back_to_data_range(self):
+        auto = svg_sparkline([1.0, 2.0, 3.0], aspect=1.0)
+        degenerate = svg_sparkline([1.0, 2.0, 3.0], y_min=5, y_max=5, aspect=1.0)
+        assert degenerate == auto
+
+    def test_flat_data_with_fixed_bounds_draws_at_level(self):
+        # A steady 2 on a 0..10 axis sits low, not on the flat midline.
+        svg = svg_sparkline([2.0, 2.0, 2.0], y_min=0, y_max=10, aspect=1.0)
+        assert 'cy="50.0"' not in svg
+        assert 'cy="75.8"' in svg  # 93 - 2/10 * 86
 
     def test_fill_off_zeroes_area_opacity(self, ctx):
         widget = ChartWidget(


### PR DESCRIPTION
Closes #73
Closes #139

Two widget features, each in its own commits.

## 1. Jinja2 templates in widget labels and text content (#73)

Widget **Label** fields — and the Text widget's content — now evaluate Jinja2 templates, so any widget can carry a live caption without a separate Text widget. The example from the issue works as-is:

```
Widget Type: Camera
Entity: camera.birdnet_vogelbild
Label: {{ states('sensor.birdnet_go_last_detection') }}
```

### How it works

Rather than HA's `Template` helper (which needs the event loop, while rendering happens in an executor thread), labels reuse the **sandboxed Jinja engine the HTML widget already ships** (`widgets/html.py`). It renders purely from the `WidgetState` snapshot, so templates behave identically in device renders, the panel preview, and tests.

- `refactor:` the HTML widget's template context, renderer, and entity-reference scanning move into a shared `widgets/_template.py`. `now` is additionally callable (`now()`), so templates pasted from HA automations work unchanged — including the weekday template from the issue thread: `{% set days = ['ПН','ВТ','СР','ЧТ','ПТ','СБ','ВС'] %}{{ days[now().weekday()] }}`.
- `feat:` `Widget.resolved_label()` / `label_for(..., state=...)` evaluate the label against widget state; every widget that renders a label (entity, camera, gauge, chart, candlestick, climate, clock, icon, media, progress, status, text) passes its state through. The Text widget's `text` option gets the same treatment.
- Entities referenced via `states()` / `state_attr()` / `is_state()` are **pre-fetched automatically** in `build_entity_states` — the choke point shared by the coordinator and the websocket preview.
- Available context: `states()`, `state_attr()`, `is_state()`, `now` / `now()`, and `state` / `name` / `unit` / `attributes` for the widget's own entity.

### Edge cases

- A template that **errors** logs a warning and falls back to showing its raw text (the legacy behavior — the mistake stays visible on the panel).
- A template that evaluates to **whitespace** behaves like an unset label: caption bands hide, and `label_for` falls through to `friendly_name` / fallback.
- Static labels are untouched (no template markers → no rendering).

### UI & docs

- Panel label field now reads "Label (optional, supports templates)" (`dist/` rebuilt).
- README gains a "Templates in Widget Labels" section.

Out of scope: per-item labels inside `multi_progress` / `status_list` option lists (easy follow-up on the same machinery if wanted).

## 2. Fixed Y-axis bounds and 3h/12h chart periods (#139)

- Chart widgets gain optional **Y-Axis Min** / **Y-Axis Max** number options. The sparkline scales against the fixed bounds instead of the data's own range, so several charts stay comparable and the trace stops rescaling as values drift. Either bound may be set alone (the other keeps following the data), out-of-range values clamp to the plot edge, and degenerate bounds (min ≥ max) fall back to auto-scaling. A flat series on a fixed axis draws at its true level instead of the auto-scale midline.
- The **Period** select adds **3 hours** and **12 hours**. The websocket preview now reads `ChartWidget.PERIOD_TO_HOURS` instead of keeping its own duplicate map, so preview and device renders can't drift.
- The L/H range footer keeps showing the *data's* low/high — still the most informative reading under a fixed axis.
- No frontend rebuild needed: the panel renders these from the widget schema.

## Testing

- 20 regression tests in `tests/widgets/test_label_templates.py` (both examples from issue #73's thread, the fallback chain, entity pre-fetching, end-to-end rendered fragments).
- 8 new chart tests in `tests/widgets/test_widgets.py` (period mapping, option coercion, fixed-bounds geometry down to exact SVG coordinates, clamping, single-bound and degenerate-bounds behavior).
- Full suite: **978 passed**; ruff, ruff format, frontend typecheck/tests/dist-check all green. The `ty` hook fails on `main` with 51 pre-existing diagnostics; this branch reduces that to 38, all in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpK66nvBd3yBDWPUwXyyHc