### PR TITLE
feat: let a moved device be pointed at its new address

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,13 @@ The default `watchOS` theme is inspired by Apple's watchOS Human Interface Guide
 3. Search for "GeekMagic"
 4. Enter your device's IP address
 
+### Changing a Device's Address
+
+If DHCP moves your device to a new IP, use **Reconfigure** on the integration
+entry (the three-dot menu next to the device) and enter the new address. The
+entry keeps its views, options and entity IDs, so automations referencing the
+device keep working.
+
 ### Using the GeekMagic Panel
 
 After installation, a **GeekMagic** item appears in your sidebar.

--- a/custom_components/geekmagic/config_flow.py
+++ b/custom_components/geekmagic/config_flow.py
@@ -108,6 +108,64 @@ class GeekMagicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Point an existing entry at a new address.
+
+        DHCP hands these devices a new lease sooner or later, and the host lives
+        in entry data where nothing in the UI could reach it -- the options flow
+        only covers screens and the Pro album. Without this step the only way to
+        follow a moved device was to delete the entry and add it again, which
+        drops the assigned views and renumbers every entity.
+        """
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            _LOGGER.debug("Reconfigure: moving %s to %s", entry.title, host)
+
+            session = async_get_clientsession(self.hass)
+            device = GeekMagicDevice(host, session=session)
+
+            # The unique ID *is* the host, so moving the device has to move the
+            # unique ID with it. That rules out _abort_if_unique_id_mismatch,
+            # which would reject the very change being made here; collisions
+            # with other entries have to be checked directly instead.
+            if any(
+                other.entry_id != entry.entry_id and other.unique_id == device.host
+                for other in self._async_current_entries()
+            ):
+                return self.async_abort(reason="already_configured")
+
+            result = await device.test_connection()
+
+            if result.success:
+                await device.detect_model()
+                _LOGGER.info("Reconfigure: %s now at %s", entry.title, device.host)
+                # Redetecting also refreshes the stored model and firmware, which
+                # go stale when a device is upgraded between setup and reconfigure.
+                return self.async_update_reload_and_abort(
+                    entry,
+                    unique_id=device.host,
+                    data_updates=self._entry_data_with_profile(user_input, device),
+                )
+            _LOGGER.warning("Reconfigure: failed to connect to %s: %s", host, result.message)
+            errors["base"] = result.error
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA,
+                {
+                    CONF_HOST: entry.data.get(CONF_HOST),
+                    CONF_NAME: entry.data.get(CONF_NAME, entry.title),
+                },
+            ),
+            errors=errors,
+        )
+
     async def async_step_pro_managed_album(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/custom_components/geekmagic/strings.json
+++ b/custom_components/geekmagic/strings.json
@@ -89,6 +89,14 @@
         "data": {
           "manage_pro_album": "I understand GeekMagic will delete existing Pro album pictures and keep one managed dashboard image"
         }
+      },
+      "reconfigure": {
+        "title": "Move GeekMagic Display",
+        "description": "Enter the new IP address, hostname, or URL of your GeekMagic device. Screens, widgets and entity IDs are preserved.",
+        "data": {
+          "host": "Host (IP, hostname, or URL)",
+          "name": "Display name"
+        }
       }
     },
     "error": {
@@ -100,7 +108,8 @@
       "unknown": "An unexpected error occurred while connecting."
     },
     "abort": {
-      "already_configured": "This device is already configured."
+      "already_configured": "This device is already configured.",
+      "reconfigure_successful": "The display is now configured at its new address."
     }
   },
   "options": {

--- a/custom_components/geekmagic/translations/en.json
+++ b/custom_components/geekmagic/translations/en.json
@@ -8,6 +8,14 @@
           "host": "Host (IP address)",
           "name": "Display name"
         }
+      },
+      "reconfigure": {
+        "title": "Move GeekMagic Display",
+        "description": "Enter the new IP address, hostname, or URL of your GeekMagic device. Screens, widgets and entity IDs are preserved.",
+        "data": {
+          "host": "Host (IP, hostname, or URL)",
+          "name": "Display name"
+        }
       }
     },
     "error": {
@@ -15,7 +23,8 @@
       "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "This device is already configured."
+      "already_configured": "This device is already configured.",
+      "reconfigure_successful": "The display is now configured at its new address."
     }
   },
   "options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -66,6 +66,7 @@ class TestConfigFlowImports:
         """Test GeekMagicConfigFlow has required attributes."""
         assert hasattr(GeekMagicConfigFlow, "VERSION")
         assert hasattr(GeekMagicConfigFlow, "async_step_user")
+        assert hasattr(GeekMagicConfigFlow, "async_step_reconfigure")
         assert hasattr(GeekMagicConfigFlow, "async_get_options_flow")
 
     def test_pro_album_warning_strings_are_available_for_config_and_options(self):
@@ -85,6 +86,21 @@ class TestConfigFlowImports:
             assert "keep one managed dashboard image" in step["data"][CONF_MANAGE_PRO_ALBUM]
 
         assert "confirm_required" in strings["options"]["error"]
+
+    def test_reconfigure_strings_are_available_in_both_string_files(self):
+        """Test the reconfigure step is labelled in strings and translations.
+
+        Home Assistant reads translations/en.json at runtime and strings.json at
+        build time, so a step added to only one shows up as a raw key in the UI.
+        """
+        base = Path(__file__).resolve().parents[1] / "custom_components" / "geekmagic"
+
+        for name in ("strings.json", "translations/en.json"):
+            data = json.loads((base / name).read_text())
+            step = data["config"]["step"]["reconfigure"]
+            assert "host" in step["data"]
+            assert "reconfigure_successful" in data["config"]["abort"]
+            assert "already_configured" in data["config"]["abort"]
 
 
 class TestConfigFlowUser:
@@ -230,6 +246,135 @@ class TestConfigFlowUser:
         state = hass.states.get("sensor.test_display_status")
         assert state is not None
         assert state.state == "Connected"
+
+
+NEW_HOST = "192.168.1.201"
+
+
+class TestConfigFlowReconfigure:
+    """Test following a device that changed address."""
+
+    @staticmethod
+    def _entry(hass: HomeAssistant) -> MockConfigEntry:
+        """An entry that looks like a real one: unique_id is the host."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Display",
+            unique_id=DEVICE_HOST,
+            data={
+                "host": DEVICE_HOST,
+                "name": "Test Display",
+                CONF_PROFILE_ID: "ultra",
+                CONF_MODEL_NAME: "SmallTV Ultra",
+            },
+            options={
+                CONF_REFRESH_INTERVAL: DEFAULT_REFRESH_INTERVAL,
+                "assigned_views": ["view_abc"],
+            },
+        )
+        entry.add_to_hass(hass)
+        return entry
+
+    async def test_reconfigure_form_is_prefilled_with_current_host(self, hass: HomeAssistant):
+        """Test the form suggests the address the entry currently uses."""
+        entry = self._entry(hass)
+
+        result = await entry.start_reconfigure_flow(hass)
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+        suggested = {
+            key.schema: key.description["suggested_value"]
+            for key in result["data_schema"].schema
+            if key.description
+        }
+        assert suggested["host"] == DEVICE_HOST
+
+    async def test_reconfigure_moves_host_and_keeps_options(
+        self, hass: HomeAssistant, aioclient_mock
+    ):
+        """Test a successful move rewrites host without disturbing the entry."""
+        _mock_device_success(aioclient_mock, host=NEW_HOST)
+        entry = self._entry(hass)
+        entry_id = entry.entry_id
+
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"host": NEW_HOST, "name": "Test Display"},
+        )
+        await hass.async_block_till_done()
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+
+        # Same entry, so entities and their IDs survive.
+        assert entry.entry_id == entry_id
+        assert entry.data["host"] == NEW_HOST
+        # The unique ID is the host and has to travel with it, or the next setup
+        # attempt collides with the stale one.
+        assert entry.unique_id == NEW_HOST
+        assert entry.options["assigned_views"] == ["view_abc"]
+
+    async def test_reconfigure_connection_failure_leaves_host_alone(
+        self, hass: HomeAssistant, aioclient_mock
+    ):
+        """Test an unreachable new address is reported, not stored."""
+        aioclient_mock.get(
+            f"http://{NEW_HOST}/space.json",
+            exc=TimeoutError("Connection timed out"),
+        )
+        entry = self._entry(hass)
+
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"host": NEW_HOST, "name": "Test Display"},
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"] == {"base": "timeout"}
+        assert entry.data["host"] == DEVICE_HOST
+
+    async def test_reconfigure_rejects_address_owned_by_another_entry(
+        self, hass: HomeAssistant, aioclient_mock
+    ):
+        """Test two entries cannot be pointed at the same device."""
+        _mock_device_success(aioclient_mock, host=NEW_HOST)
+        entry = self._entry(hass)
+        other = MockConfigEntry(
+            domain=DOMAIN,
+            title="Other Display",
+            unique_id=NEW_HOST,
+            data={"host": NEW_HOST, "name": "Other Display"},
+        )
+        other.add_to_hass(hass)
+
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"host": NEW_HOST, "name": "Test Display"},
+        )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+        assert entry.data["host"] == DEVICE_HOST
+
+    async def test_reconfigure_to_same_host_is_allowed(self, hass: HomeAssistant, aioclient_mock):
+        """Test re-confirming the current address is not a self-collision."""
+        _mock_device_success(aioclient_mock)
+        entry = self._entry(hass)
+
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"host": DEVICE_HOST, "name": "Test Display"},
+        )
+        await hass.async_block_till_done()
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        assert entry.data["host"] == DEVICE_HOST
 
 
 class TestOptionsFlowInit:


### PR DESCRIPTION
The host is stored in the config entry and can't be changed from the UI. When DHCP moves a device, the only fix is to delete the entry and add it back, which loses the assigned views and options and renumbers the entities.

This adds Reconfigure to the entry's menu. It's prefilled with the current address, tests the connection before saving, and leaves everything else alone.

Two notes for review:

- The unique ID is the host, so it has to move too. That rules out `_abort_if_unique_id_mismatch()`, which would reject the edit being made. Clashes with other entries are checked directly instead.
- It re-detects model and firmware while connected, so those don't stay stale after a device upgrade.

Tests cover the prefill, a successful move, a failed connection, a clash with another entry, and re-entering the same address. One checks the step is in both `strings.json` and `translations/en.json`, since a step in only one shows up as a raw key.