### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/custom_components/geekmagic/manifest.json
+++ b/custom_components/geekmagic/manifest.json
@@ -21,5 +21,5 @@
     "palettable>=3.3.0",
     "blitz-py>=0.5.0"
   ],
-  "version": "1.3.3"
+  "version": "1.4.0"
 }


### PR DESCRIPTION
Bumps `custom_components/geekmagic/manifest.json` from `1.3.3` to `1.4.0`.

## Why minor

56 commits since the `1.3.3` release, all backward-compatible, including new features:

- **StandBy and Night themes** — the watchOS system on translucent cards, plus StandBy's monochrome bedside mode
- **Legacy Smart Weather Clock firmware profile** — new device support, with Photo-mode cache readback and a real `get_space()` probe
- **Glanceable card anatomy** — header row, sibling hero harmony, edge-to-edge cells, larger header glyphs, state-tinted icons
- **Brand icons** (from @guybw)
- Assorted fixes: media title truncation, round gauge caption anchoring, deprecated device-registry lookups, malformed upload responses

No breaking changes, so patch would understate it and major would overstate it.

## Checks

`uv run pre-commit run --all`: `uv lock`, ruff, ruff format, pytest, frontend dist check, and entity translations all pass. The `ty`, frontend typecheck, and frontend test hooks fail on this container for pre-existing reasons unrelated to this diff (missing `bs4`/`playwright` for a skill script, a TypeScript `moduleResolution` deprecation warning, and `vitest` not installed).

## Next step (manual)

After merge, create the release in the GitHub UI: Releases → "Draft a new release" → tag `1.4.0` (matching `manifest.json`, no leading `v` — that is this repo's existing tag convention) targeting the bump commit on `main` → "Generate release notes" → Publish.

Note: `CLAUDE.md` documents the tag format as `vX.Y.Z`, but every published release (`1.3.3`, `1.3.2`, `1.3.1`, …) uses the bare form. Worth fixing the doc in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eqA5oJooB36wJKTDevvAf

---
_Generated by [Claude Code](https://claude.ai/code/session_017eqA5oJooB36wJKTDevvAf)_